### PR TITLE
fix(codegen): remove duplicate runtime import in generated params module

### DIFF
--- a/src/sqlode/codegen.gleam
+++ b/src/sqlode/codegen.gleam
@@ -57,13 +57,9 @@ pub fn render_params_module(queries: List(model.AnalyzedQuery)) -> String {
   let imports = case needs_option_import(queries) {
     True -> [
       "import gleam/option.{type Option, None, Some}",
-      "import sqlode/runtime",
       "import sqlode/runtime.{type Value}",
     ]
-    False -> [
-      "import sqlode/runtime",
-      "import sqlode/runtime.{type Value}",
-    ]
+    False -> ["import sqlode/runtime.{type Value}"]
   }
 
   let declarations =


### PR DESCRIPTION
## Summary

- Remove redundant `import sqlode/runtime` from generated params module, keeping only `import sqlode/runtime.{type Value}` which already brings the module into scope

## Changes

- `src/sqlode/codegen.gleam`: Merged duplicate imports in both branches of `render_params_module` (lines 58-66) into a single `import sqlode/runtime.{type Value}`

## Design Decisions

- In Gleam, `import module.{type Foo}` already makes the module available as a qualified name, so a separate `import module` is redundant and may trigger compiler warnings

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified generated import statements in modules for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->