### PR TITLE
docs: fix misleading installation and CLI instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ Supported engines: PostgreSQL, MySQL, SQLite.
 
 ### Install
 
+Add sqlode as a development dependency:
+
 ```console
-gleam add sqlode
+gleam add --dev sqlode
 ```
 
 ### Initialize config
 
 ```console
-sqlode init
+gleam run -m sqlode -- init
 ```
 
 This creates `sqlode.yaml`:
@@ -69,7 +71,7 @@ VALUES (sqlc.arg(author_name), sqlc.narg(bio));
 ### Generate
 
 ```console
-sqlode generate
+gleam run -m sqlode -- generate
 ```
 
 This produces `params.gleam`, `queries.gleam`, and `models.gleam` in the configured output directory.
@@ -277,8 +279,8 @@ sql:
 ## CLI
 
 ```
-sqlode generate [--config=./sqlode.yaml]
-sqlode init [--output=./sqlode.yaml]
+gleam run -m sqlode -- generate [--config=./sqlode.yaml]
+gleam run -m sqlode -- init [--output=./sqlode.yaml]
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Replace standalone `sqlode` commands with the correct `gleam run -m sqlode --` invocation
- Change `gleam add` to `gleam add --dev` since sqlode is a development tool

## Changes

- **README.md**: Updated Install, Initialize config, Generate, and CLI sections to use `gleam run -m sqlode --` prefix for all commands

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to add `sqlode` as a development dependency
  * Changed invocation method: use `gleam run -m sqlode -- ...` instead of direct command execution
  * Updated all CLI examples (`init`, `generate`) to reflect the new usage pattern

<!-- end of auto-generated comment: release notes by coderabbit.ai -->