### PR TITLE
fix(generate): improve NoQueriesGenerated error with diagnostic context

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import gleam/list
 import gleam/result
 import gleam/string
@@ -17,7 +18,13 @@ pub type GenerateError {
   SchemaParseError(detail: String)
   QueryReadError(path: String, detail: String)
   QueryParseError(path: String, detail: String)
-  NoQueriesGenerated(output: String)
+  NoQueriesGenerated(
+    output: String,
+    parsed_query_count: Int,
+    schema_table_count: Int,
+    query_paths: List(String),
+    schema_paths: List(String),
+  )
   WriteError(writer.WriteError)
 }
 
@@ -58,7 +65,14 @@ fn generate_sql_block(
   let model.GleamOutput(out:, ..) = gleam
 
   case analyzed {
-    [] -> Error(NoQueriesGenerated(output: out))
+    [] ->
+      Error(NoQueriesGenerated(
+        output: out,
+        parsed_query_count: list.length(queries),
+        schema_table_count: list.length(catalog.tables),
+        query_paths: block.queries,
+        schema_paths: block.schema,
+      ))
     _ -> {
       let has_row_types =
         list.any(analyzed, fn(query) {
@@ -277,8 +291,36 @@ pub fn error_to_string(error: GenerateError) -> String {
     SchemaParseError(detail:) -> detail
     QueryReadError(path:, detail:) -> path <> ": " <> detail
     QueryParseError(detail:, ..) -> detail
-    NoQueriesGenerated(output:) ->
-      "No queries were generated for output directory: " <> output
+    NoQueriesGenerated(
+      output:,
+      parsed_query_count:,
+      schema_table_count:,
+      query_paths:,
+      schema_paths:,
+    ) ->
+      "No queries were generated for output directory: "
+      <> output
+      <> "\n  Parsed queries: "
+      <> int.to_string(parsed_query_count)
+      <> " (from "
+      <> string.join(query_paths, ", ")
+      <> ")"
+      <> "\n  Schema tables: "
+      <> int.to_string(schema_table_count)
+      <> " (from "
+      <> string.join(schema_paths, ", ")
+      <> ")"
+      <> case parsed_query_count {
+        0 ->
+          "\n  Hint: No queries were found. Ensure your query files contain annotations like '-- name: QueryName :one'"
+        _ ->
+          case schema_table_count {
+            0 ->
+              "\n  Hint: No tables found in schema. Ensure your schema files contain CREATE TABLE statements"
+            _ ->
+              "\n  Hint: Queries were parsed but none produced output. Check that your schema defines the tables referenced in your queries"
+          }
+      }
     WriteError(inner) -> writer.error_to_string(inner)
   }
 }


### PR DESCRIPTION
## Summary

- Enrich the `NoQueriesGenerated` error message with diagnostic context to help users identify why no queries were generated

## Changes

- **generate.gleam**: Extended `NoQueriesGenerated` variant to include `parsed_query_count`, `schema_table_count`, `query_paths`, and `schema_paths`
- Error message now shows:
  - Number of parsed queries and their source files
  - Number of schema tables and their source files
  - Actionable hint based on the specific failure scenario (no queries found, no tables in schema, or queries parsed but not producing output)

## Design Decisions

- Kept all diagnostic info in the error variant rather than using a separate warning system, since this is a terminal error that stops generation
- Hints are context-sensitive: different messages for "no queries parsed" vs "no tables in schema" vs "queries exist but produced no output"

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL generation error messages now include detailed diagnostics with query counts, schema information, and file paths for improved troubleshooting when generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->