### PR TITLE
refactor(schema_parser): replace nested case chain with data-driven type lookup

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -270,59 +270,33 @@ fn take_type_tokens(tokens: List(String), acc: List(String)) -> List(String) {
 fn infer_scalar_type(type_text: String) -> model.ScalarType {
   let lowered = string.lowercase(type_text)
 
-  case string.contains(lowered, "int") || string.contains(lowered, "serial") {
-    True -> model.IntType
-    False ->
-      case
-        string.contains(lowered, "double")
-        || string.contains(lowered, "real")
-        || string.contains(lowered, "float")
-        || string.contains(lowered, "numeric")
-        || string.contains(lowered, "decimal")
-      {
-        True -> model.FloatType
-        False ->
-          case string.contains(lowered, "bool") {
-            True -> model.BoolType
-            False ->
-              case
-                string.contains(lowered, "bytea")
-                || string.contains(lowered, "blob")
-                || string.contains(lowered, "binary")
-              {
-                True -> model.BytesType
-                False ->
-                  case string.contains(lowered, "uuid") {
-                    True -> model.UuidType
-                    False ->
-                      case
-                        string.contains(lowered, "json")
-                        || string.contains(lowered, "jsonb")
-                      {
-                        True -> model.JsonType
-                        False ->
-                          case
-                            string.contains(lowered, "timestamp")
-                            || string.contains(lowered, "datetime")
-                          {
-                            True -> model.DateTimeType
-                            False ->
-                              case string.contains(lowered, "date") {
-                                True -> model.DateType
-                                False ->
-                                  case
-                                    string.contains(lowered, "time")
-                                    || string.contains(lowered, "timetz")
-                                  {
-                                    True -> model.TimeType
-                                    False -> model.StringType
-                                  }
-                              }
-                          }
-                      }
-                  }
-              }
-          }
+  // Order matters: check more specific patterns before general ones
+  // (e.g. "timestamp"/"datetime" before "time"/"date", "jsonb" before "json")
+  let type_rules = [
+    #(["int", "serial"], model.IntType),
+    #(["double", "real", "float", "numeric", "decimal"], model.FloatType),
+    #(["bool"], model.BoolType),
+    #(["bytea", "blob", "binary"], model.BytesType),
+    #(["uuid"], model.UuidType),
+    #(["jsonb", "json"], model.JsonType),
+    #(["timestamp", "datetime"], model.DateTimeType),
+    #(["date"], model.DateType),
+    #(["timetz", "time"], model.TimeType),
+  ]
+
+  find_matching_type(lowered, type_rules)
+}
+
+fn find_matching_type(
+  lowered: String,
+  rules: List(#(List(String), model.ScalarType)),
+) -> model.ScalarType {
+  case rules {
+    [] -> model.StringType
+    [#(patterns, scalar_type), ..rest] ->
+      case list.any(patterns, fn(p) { string.contains(lowered, p) }) {
+        True -> scalar_type
+        False -> find_matching_type(lowered, rest)
       }
   }
 }


### PR DESCRIPTION
## Summary

- Replace 9 levels of nested case expressions in `infer_scalar_type` with a declarative list of pattern/type rules

## Changes

- **schema_parser.gleam**: Replaced `infer_scalar_type` with a data-driven approach using a `type_rules` list of `#(List(String), ScalarType)` pairs and a recursive `find_matching_type` helper
- Reduced from 58 lines to 32 lines while preserving identical behavior

## Design Decisions

- Pattern order in the rules list preserves the original precedence (e.g., "timestamp"/"datetime" checked before "time"/"date")
- Each rule groups related SQL type keywords together (e.g., `["double", "real", "float", "numeric", "decimal"]` all map to `FloatType`)
- The per-engine type mapping switches in `codegen.gleam` and `model.gleam` are left as-is since they map Gleam types to adapter-specific values and are already flat `case` statements

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized scalar type inference logic to improve type precedence handling and consistency in schema parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->