### PR TITLE
refactor(naming): deduplicate normalize_identifier into shared module

### DIFF
--- a/src/sqlode/naming.gleam
+++ b/src/sqlode/naming.gleam
@@ -1,5 +1,6 @@
 import gleam/list
 import gleam/regexp
+import gleam/result
 import gleam/string
 
 pub type NamingContext {
@@ -67,6 +68,47 @@ fn split_camel_case(input: String, ctx: NamingContext) -> List(String) {
 
 fn insert_underscores_before_caps(input: String, ctx: NamingContext) -> String {
   regexp.replace(ctx.underscore_before_caps, input, "\\1_\\2")
+}
+
+pub fn normalize_identifier(identifier: String) -> String {
+  identifier
+  |> string.trim
+  |> strip_identifier_quotes
+  |> last_dot_segment
+  |> string.lowercase
+}
+
+fn strip_identifier_quotes(identifier: String) -> String {
+  let length = string.length(identifier)
+
+  case length >= 2 {
+    False -> identifier
+    True -> {
+      let first = string.slice(identifier, 0, 1)
+      let last = string.slice(identifier, length - 1, 1)
+
+      let is_quoted =
+        { first == "\"" && last == "\"" }
+        || { first == "`" && last == "`" }
+        || { first == "[" && last == "]" }
+
+      case is_quoted {
+        True -> string.slice(identifier, 1, length - 2)
+        False -> identifier
+      }
+    }
+  }
+}
+
+fn last_dot_segment(identifier: String) -> String {
+  case string.contains(identifier, ".") {
+    True ->
+      identifier
+      |> string.split(".")
+      |> list.last
+      |> result.unwrap(identifier)
+    False -> identifier
+  }
 }
 
 fn escape_keyword(name: String) -> String {

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -2,7 +2,6 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/regexp
-import gleam/result
 import gleam/string
 import sqlode/model
 import sqlode/naming
@@ -236,7 +235,7 @@ fn infer_insert_params(
         [Some(table_name), Some(columns_text), Some(values_text)] -> {
           let columns =
             split_csv(columns_text)
-            |> list.map(normalize_identifier)
+            |> list.map(naming.normalize_identifier)
 
           let values =
             split_csv(values_text)
@@ -343,7 +342,7 @@ fn scan_equality_matches(
                 find_column(
                   catalog,
                   table_name,
-                  normalize_identifier(column_name),
+                  naming.normalize_identifier(column_name),
                 )
               {
                 Some(column) -> [#(index, column), ..acc]
@@ -527,12 +526,14 @@ fn find_column(
 ) -> Option(model.Column) {
   case
     catalog.tables
-    |> list.find(fn(table) { table.name == normalize_identifier(table_name) })
+    |> list.find(fn(table) {
+      table.name == naming.normalize_identifier(table_name)
+    })
   {
     Ok(table) ->
       table.columns
       |> list.find(fn(column) {
-        column.name == normalize_identifier(column_name)
+        column.name == naming.normalize_identifier(column_name)
       })
       |> column_result_to_option
     Error(_) -> None
@@ -544,40 +545,6 @@ fn split_csv(text: String) -> List(String) {
   |> string.split(",")
   |> list.map(string.trim)
   |> list.filter(fn(entry) { entry != "" })
-}
-
-fn normalize_identifier(identifier: String) -> String {
-  identifier
-  |> string.trim
-  |> fn(value) {
-    case string.contains(value, ".") {
-      True ->
-        value
-        |> string.split(".")
-        |> list.last
-        |> result.unwrap(value)
-      False -> value
-    }
-  }
-  |> fn(value) {
-    let length = string.length(value)
-    case length >= 2 {
-      True -> {
-        let first = string.slice(value, 0, 1)
-        let last = string.slice(value, length - 1, 1)
-        case first == "\"" && last == "\"" {
-          True -> string.slice(value, 1, length - 2)
-          False ->
-            case first == "`" && last == "`" {
-              True -> string.slice(value, 1, length - 2)
-              False -> value
-            }
-        }
-      }
-      False -> value
-    }
-  }
-  |> string.lowercase
 }
 
 fn sequential_placeholder(engine: model.Engine) -> Bool {

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -3,6 +3,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import sqlode/model
+import sqlode/naming
 
 pub type ParseError {
   InvalidCreateTable(detail: String)
@@ -131,7 +132,7 @@ fn parse_create_table(
   use table_name <- result.try(
     header_tokens
     |> list.last
-    |> result.map(trim_identifier)
+    |> result.map(naming.normalize_identifier)
     |> result.map_error(fn(_) {
       InvalidCreateTable(detail: "missing table name")
     }),
@@ -185,7 +186,7 @@ fn parse_column(
       case is_table_constraint(first_lower) {
         True -> Ok(None)
         False -> {
-          let name = trim_identifier(first)
+          let name = naming.normalize_identifier(first)
           let type_tokens = take_type_tokens(rest, [])
 
           case type_tokens {
@@ -332,43 +333,6 @@ fn contains_phrase(tokens: List(String), first: String, second: String) -> Bool 
         False -> contains_phrase([b, ..rest], first, second)
       }
   }
-}
-
-fn trim_identifier(identifier: String) -> String {
-  identifier
-  |> string.trim
-  |> trim_identifier_quotes
-  |> last_identifier_segment
-  |> string.lowercase
-}
-
-fn trim_identifier_quotes(identifier: String) -> String {
-  let length = string.length(identifier)
-
-  case length >= 2 {
-    False -> identifier
-    True -> {
-      let first = string.slice(identifier, 0, 1)
-      let last = string.slice(identifier, length - 1, 1)
-
-      let is_quoted =
-        { first == "\"" && last == "\"" }
-        || { first == "`" && last == "`" }
-        || { first == "[" && last == "]" }
-
-      case is_quoted {
-        True -> string.slice(identifier, 1, length - 2)
-        False -> identifier
-      }
-    }
-  }
-}
-
-fn last_identifier_segment(identifier: String) -> String {
-  identifier
-  |> string.split(".")
-  |> list.last
-  |> result.unwrap(identifier)
 }
 
 fn find_enum(type_text: String, enums: List(model.EnumDef)) -> Option(String) {


### PR DESCRIPTION
## Summary

- Extract duplicated identifier normalization logic into a single `naming.normalize_identifier` function shared by both `schema_parser` and `query_analyzer`

## Changes

- **naming.gleam**: Added `normalize_identifier` (public), `strip_identifier_quotes`, and `last_dot_segment` helper functions
- **schema_parser.gleam**: Replaced `trim_identifier`, `trim_identifier_quotes`, and `last_identifier_segment` with `naming.normalize_identifier`
- **query_analyzer.gleam**: Replaced local `normalize_identifier` with `naming.normalize_identifier`, removed unused `gleam/result` import

## Design Decisions

- The shared implementation uses the schema_parser's operation order (trim -> strip quotes -> extract last dot-segment -> lowercase) which is equivalent in behavior
- Square bracket quote support (`[name]`) from schema_parser is now available in query_analyzer too, improving consistency for SQL Server-style identifiers

Closes #6