### PR TITLE
refactor(schema_parser): fix O(n²) string building in split_top_level_commas

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -221,40 +221,70 @@ fn parse_column(
 }
 
 fn split_top_level_commas(input: String) -> List(String) {
-  split_top_level_commas_loop(input, 0, "", [])
+  split_top_level_commas_loop(input, 0, [], [])
 }
 
 fn split_top_level_commas_loop(
   remaining: String,
   depth: Int,
-  current: String,
+  current_rev: List(String),
   acc: List(String),
 ) -> List(String) {
   case string.pop_grapheme(remaining) {
-    Error(_) ->
-      case string.trim(current) == "" {
+    Error(_) -> {
+      let current = flush_current(current_rev)
+      case current == "" {
         True -> list.reverse(acc)
-        False -> list.reverse([string.trim(current), ..acc])
+        False -> list.reverse([current, ..acc])
       }
+    }
     Ok(#(grapheme, rest)) ->
       case grapheme {
         "(" ->
-          split_top_level_commas_loop(rest, depth + 1, current <> grapheme, acc)
+          split_top_level_commas_loop(
+            rest,
+            depth + 1,
+            [grapheme, ..current_rev],
+            acc,
+          )
         ")" ->
-          split_top_level_commas_loop(rest, depth - 1, current <> grapheme, acc)
+          split_top_level_commas_loop(
+            rest,
+            depth - 1,
+            [grapheme, ..current_rev],
+            acc,
+          )
         "," ->
           case depth == 0 {
             True ->
-              split_top_level_commas_loop(rest, depth, "", [
-                string.trim(current),
+              split_top_level_commas_loop(rest, depth, [], [
+                flush_current(current_rev),
                 ..acc
               ])
             False ->
-              split_top_level_commas_loop(rest, depth, current <> grapheme, acc)
+              split_top_level_commas_loop(
+                rest,
+                depth,
+                [grapheme, ..current_rev],
+                acc,
+              )
           }
-        _ -> split_top_level_commas_loop(rest, depth, current <> grapheme, acc)
+        _ ->
+          split_top_level_commas_loop(
+            rest,
+            depth,
+            [grapheme, ..current_rev],
+            acc,
+          )
       }
   }
+}
+
+fn flush_current(current_rev: List(String)) -> String {
+  current_rev
+  |> list.reverse
+  |> string.concat
+  |> string.trim
 }
 
 fn take_type_tokens(tokens: List(String), acc: List(String)) -> List(String) {


### PR DESCRIPTION
## Summary

- Fix O(n²) per-grapheme string concatenation in `split_top_level_commas_loop` by accumulating graphemes in a reversed list and joining once at emit time

## Changes

- **schema_parser.gleam**: Changed `current: String` parameter to `current_rev: List(String)`, accumulating graphemes via cons (`[grapheme, ..current_rev]`) instead of `current <> grapheme`
- Added `flush_current` helper that reverses, concatenates, and trims the accumulated graphemes

## Design Decisions

- `codegen.gleam` was not converted to `string_builder` because it already uses list-based construction via `string.join(lines, "\n")`, which is equivalent in efficiency to `string_builder` for the patterns used there. The `<>` usage in codegen is limited to building short individual lines (type names, function signatures), not assembling the full output.

Closes #4