### PR TITLE
docs: add CHANGELOG.md and fix version string duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-13
+
+### Added
+
+- Initial sqlc-style code generator for Gleam
+- PostgreSQL, MySQL, and SQLite engine support
+- Query annotations: `:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`
+- sqlc macros: `sqlc.arg`, `sqlc.narg`, `sqlc.slice`, `sqlc.embed`
+- Type mapping for INT, FLOAT, BOOL, TEXT, BYTEA, UUID, JSON, TIMESTAMP, DATE, TIME
+- PostgreSQL ENUM type support
+- Nullable column detection with `Option(T)` wrapping
+- Result record types (`models.gleam`) for `:one` and `:many` queries
+- Adapter generation for pog (PostgreSQL) and sqlight (SQLite)
+- RETURNING clause support for INSERT/UPDATE/DELETE
+- CTE (WITH clause) support
+- JOIN type inference
+- Type overrides and column renames via config
+- `init` command with stub `db/schema.sql` and `db/query.sql` creation
+- `generate` command with `--config` flag
+- Version constant in `version.gleam` as single source of truth

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -5,6 +5,7 @@ import gleam/result
 import glint
 import simplifile
 import sqlode/generate
+import sqlode/version
 
 pub fn app() -> glint.Glint(Nil) {
   glint.new()
@@ -52,7 +53,7 @@ fn init_command() -> glint.Command(Nil) {
 }
 
 fn run_generate(config_path: String) -> Nil {
-  io.println("sqlode v0.1.0")
+  io.println("sqlode v" <> version.version)
   io.println("Loading config from: " <> config_path)
 
   case generate.run(config_path) {

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,0 +1,1 @@
+pub const version = "0.1.0"


### PR DESCRIPTION
## Summary

- Add CHANGELOG.md following Keep a Changelog format
- Fix version string duplication by extracting it into a `version.gleam` constant module

## Changes

- **CHANGELOG.md**: New file documenting the initial 0.1.0 release features
- **version.gleam**: New module with `pub const version = "0.1.0"` as single source of truth
- **cli.gleam**: Replace hardcoded `"sqlode v0.1.0"` with `"sqlode v" <> version.version`

## Limitations

- `gleam.toml` version still needs to be updated manually alongside `version.gleam`. Gleam does not currently support reading `gleam.toml` at compile time.

Closes #12