### PR TITLE
fix(generate): scope column renames to queries referencing the target table

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -252,9 +252,14 @@ fn apply_column_renames(
     [] -> queries
     _ ->
       list.map(queries, fn(query) {
+        let sql_lowered = string.lowercase(query.base.sql)
+        let applicable_renames =
+          list.filter(renames, fn(r) {
+            string.contains(sql_lowered, string.lowercase(r.table))
+          })
         let result_columns =
           list.map(query.result_columns, fn(col) {
-            case find_column_rename(col.name, renames) {
+            case find_column_rename(col.name, applicable_renames) {
               Ok(new_name) -> model.ResultColumn(..col, name: new_name)
               Error(_) -> col
             }


### PR DESCRIPTION
## Summary

- Fix column renames being applied across all tables regardless of the configured table name

## Changes

- **generate.gleam**: In `apply_column_renames`, filter the rename list per-query by checking if the query's SQL references the rename's target table before applying column name matching

## Design Decisions

- Used SQL text matching (`string.contains`) rather than adding a `source_table` field to `ResultColumn`, keeping the change minimal and avoiding a type-level change that would propagate through codegen
- The table name check is case-insensitive to match SQL conventions

## Limitations

- If a table name appears as a substring of another identifier in the SQL, the rename could still apply incorrectly (e.g., table "auth" would match "authors"). This is unlikely in practice but could be improved with word-boundary matching in the future.

Closes #2