### PR TITLE
fix(query_parser): replace only first occurrence of each sqlc macro

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -295,7 +295,7 @@ fn expand_sqlc_macros(
             [Some(kind), Some(name)] -> {
               let placeholder = engine_placeholder(engine, idx)
               let new_sql =
-                string.replace(current_sql, match.content, placeholder)
+                replace_first(current_sql, match.content, placeholder)
               let sqlc_macro = case kind {
                 "narg" -> model.SqlcNarg(index: idx, name:)
                 "slice" -> model.SqlcSlice(index: idx, name:)
@@ -309,6 +309,17 @@ fn expand_sqlc_macros(
 
       #(expanded, list.reverse(macros))
     }
+  }
+}
+
+fn replace_first(
+  in text: String,
+  each pattern: String,
+  with replacement: String,
+) -> String {
+  case string.split_once(text, pattern) {
+    Ok(#(before, after)) -> before <> replacement <> after
+    Error(_) -> text
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix sqlc macro expansion replacing all occurrences at once instead of one per iteration

## Changes

- **query_parser.gleam**: Added `replace_first` helper using `string.split_once` to replace only the first match, and use it in `expand_sqlc_macros` instead of `string.replace`

## Design Decisions

- `string.split_once` is the cleanest way to implement replace-first in Gleam without regex or manual index tracking

Closes #3