### PR TITLE
docs: update architecture, spec, and testing docs to match implementation

### DIFF
--- a/doc/reference/design/sqlode-architecture.md
+++ b/doc/reference/design/sqlode-architecture.md
@@ -1,0 +1,154 @@
+# sqlode Architecture
+
+## Product definition
+
+`sqlode` is a sqlc-like compiler that reads SQL schema/query files and
+generates typed Gleam code.
+
+The compatibility target is:
+
+- sqlc-like configuration and query annotation syntax
+- Gleam-native generated modules
+- PostgreSQL, MySQL (parsing only), and SQLite support
+
+## Top-level architecture
+
+The pipeline has four stages:
+
+1. config loading
+2. SQL parsing (schema + query)
+3. query analysis
+4. Gleam code generation
+
+## 1. Config loading (`config.gleam`)
+
+Responsibilities:
+
+- parse sqlc-style config v2 from YAML
+- resolve schema/query file paths (string or list)
+- validate engine and runtime values
+- parse overrides (type overrides and column renames)
+- produce precise diagnostics via `ConfigError` variants
+
+## 2. SQL parsing
+
+### Schema parsing (`schema_parser.gleam`)
+
+A single unified parser handles all SQL dialects:
+
+- parses `CREATE TABLE` statements into `Catalog` (tables + columns)
+- parses `CREATE TYPE ... AS ENUM` for PostgreSQL enums
+- infers scalar types from SQL type names via data-driven lookup
+- handles `IF NOT EXISTS`, quoted identifiers, table constraints
+- normalizes identifiers via shared `naming.normalize_identifier`
+
+### Query parsing (`query_parser.gleam`)
+
+A single unified parser handles all SQL dialects:
+
+- parses `-- name: <Name> <command>` annotations
+- counts placeholders per engine (`$N` for PostgreSQL, `?` for MySQL,
+  `?N`/`:name`/`@name`/`$name` for SQLite)
+- expands `sqlc.arg`, `sqlc.narg`, `sqlc.slice` macros into
+  engine-appropriate placeholders
+
+## 3. Query analysis (`query_analyzer.gleam`)
+
+Analyzes parsed queries against the schema catalog:
+
+- infers parameter types from INSERT column order and WHERE equality
+- infers result columns from SELECT lists, `*` expansion, table prefixes
+- resolves JOIN tables and `sqlc.embed` table expansion
+- handles RETURNING clauses and CTE (WITH) stripping
+- uses pre-compiled regexes via `AnalyzerContext` for performance
+
+## 4. Gleam code generation (`codegen.gleam`)
+
+Generates Gleam source files from analyzed queries:
+
+### Generated files
+
+- `params.gleam` — parameter record types and value conversion functions
+- `queries.gleam` — query metadata (name, SQL, command, param count)
+- `models.gleam` — result row types (only when queries return rows)
+- `<engine>_adapter.gleam` — database adapter functions (when runtime
+  is `native` or `based`)
+
+### Adapter generation
+
+Uses `AdapterConfig` record to parameterize engine-specific differences:
+
+- `pog_adapter.gleam` for PostgreSQL (pog library)
+- `sqlight_adapter.gleam` for SQLite (sqlight library)
+- MySQL adapter is a stub (no driver available)
+
+Shared `render_adapter_*` functions dispatch through config callbacks for
+library imports, connection types, parameter encoding, and query call
+patterns.
+
+## Module overview
+
+```text
+src/sqlode/
+  cli.gleam            — CLI commands (generate, init)
+  config.gleam         — YAML config parsing
+  generate.gleam       — orchestrates the pipeline
+  model.gleam          — shared types (Engine, Config, Query, ScalarType, etc.)
+  naming.gleam         — NamingContext, identifier normalization, case conversion
+  query_analyzer.gleam — query analysis with AnalyzerContext
+  query_parser.gleam   — query annotation parsing with ParserContext
+  schema_parser.gleam  — DDL schema parsing
+  codegen.gleam        — Gleam source code generation with AdapterConfig
+  runtime.gleam        — runtime types (Value, QueryCommand)
+  version.gleam        — version constant
+  writer.gleam         — file output
+```
+
+## IR types (`model.gleam`)
+
+The IR consumed by codegen:
+
+- `Config`, `SqlBlock`, `GleamOutput`, `Overrides`
+- `Catalog`, `Table`, `Column`, `EnumDef`
+- `ParsedQuery`, `QueryCommand`, `SqlcMacro`
+- `AnalyzedQuery`, `QueryParam`, `ResultColumn`
+- `ScalarType` — IntType, FloatType, BoolType, StringType, BytesType,
+  DateTimeType, DateType, TimeType, UuidType, JsonType, EnumType
+
+## Runtime strategy
+
+A single flat `runtime.gleam` module exports:
+
+- `QueryCommand` type (QueryOne, QueryMany, QueryExec, etc.)
+- `Value` type (SqlNull, SqlString, SqlInt, SqlFloat, SqlBool, SqlBytes)
+- Constructor functions (`null`, `string`, `int`, `float`, `bool`, `bytes`)
+
+### `gen.gleam.runtime` values
+
+- `raw` — generates only params, queries, models (no adapter)
+- `based` — same as native (reserved for future common abstraction)
+- `native` — generates adapter module for pog (PostgreSQL) or sqlight (SQLite)
+
+## Implementation status
+
+### Completed
+
+- Config parsing with overrides and column renames
+- All 6 query annotations (`:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`)
+- All sqlc macros (`sqlc.arg`, `sqlc.narg`, `sqlc.slice`, `sqlc.embed`)
+- Comprehensive type mapping (integers, floats, booleans, strings, bytes,
+  date/time/timestamp, UUID, JSON/JSONB, PostgreSQL enums)
+- Nullable detection and `Option(T)` wrapping
+- JOIN type inference, RETURNING clause, CTE support
+- pog and sqlight adapter generation
+- `init` command with stub file creation
+
+### Not yet implemented
+
+- `@name` shorthand for named parameters
+- `database` / `analyzer` config fields for live DB analysis
+- `emit_exact_table_names`, `emit_sql_as_comment`, `query_parameter_limit`
+- Batch annotations (`:batchexec`, `:batchmany`, `:batchone`, `:copyfrom`)
+- MySQL native adapter (no Gleam MySQL driver exists)
+- PostgreSQL arrays
+- Golden-file / snapshot testing for codegen output

--- a/doc/reference/design/testing-strategy.md
+++ b/doc/reference/design/testing-strategy.md
@@ -1,0 +1,94 @@
+# Testing Strategy
+
+## Test stack
+
+- Gleam unit tests (`gleam test`)
+- ShellSpec CLI tests (`shellspec`)
+
+## CI order (via `just all`)
+
+1. `gleam format --check src/ test/`
+2. `gleam check`
+3. `gleam build --warnings-as-errors`
+4. `gleam test`
+5. `shellspec`
+
+## 1. Gleam unit tests
+
+### Current test layout
+
+```text
+test/
+  config_test.gleam          — config loading, error cases
+  schema_parser_test.gleam   — DDL parsing, types, constraints, errors
+  query_parser_test.gleam    — annotation parsing, placeholders, macros, errors
+  query_analyzer_test.gleam  — param inference, result columns, JOINs, CTEs
+  codegen_test.gleam         — params/models/queries/adapter rendering
+  naming_test.gleam          — case conversion, identifier normalization
+  model_test.gleam           — type parsing, conversions, roundtrips
+  runtime_test.gleam         — Value constructors
+  sqlc_compat_test.gleam     — comprehensive SQL coverage (types, complex schemas, macros)
+  dialect_test.gleam         — MySQL/SQLite dialect-specific analysis
+  sqlode_test.gleam          — test runner entry point
+```
+
+### Fixture strategy
+
+Fixtures are kept in `test/fixtures/`:
+
+- One schema/query pair per behavior
+- Focused assertions per fixture
+- Separate fixtures for each test domain (basic, complex, all-types, macros, dialects)
+
+### Current fixture files
+
+```text
+test/fixtures/
+  schema.sql              — basic authors table
+  query.sql               — basic GetAuthor/ListAuthors
+  create_query.sql        — INSERT query
+  join_schema.sql         — authors + books for JOIN tests
+  extended_schema.sql     — date/time/uuid/json types
+  all_types_schema.sql    — all 23 SQL type variants
+  all_types_query.sql     — SELECT/INSERT for all types
+  complex_schema.sql      — 6-table schema (users, posts, comments, etc.)
+  complex_query.sql       — JOINs, RETURNING, UPDATE, DELETE
+  macro_edge_cases.sql    — duplicate args, mixed macros, slice
+  mysql_query.sql         — MySQL ? placeholder queries
+  sqlite_query.sql        — SQLite ?N/:name/@name/$name queries
+  sqlode.yaml             — valid config fixture
+  invalid_version.yaml    — version error fixture
+  missing_engine.yaml     — missing field error fixture
+  invalid_engine.yaml     — invalid value error fixture
+  malformed.yaml          — invalid structure fixture
+  missing_sql.yaml        — missing sql field fixture
+```
+
+## 2. ShellSpec CLI tests
+
+ShellSpec verifies the public CLI contract:
+
+```text
+spec/
+  generate_spec.sh   — CLI help, error paths, successful generation
+  spec_helper.sh     — shared helpers (project root, test output dir)
+```
+
+### Current coverage
+
+- `--help` for generate command
+- invalid config path error
+- successful generation output (file existence and content checks)
+
+## 3. Integration tests (planned)
+
+Not yet implemented. See Issues #16 and #17:
+
+- **Issue #16**: Verify generated Gleam code compiles
+- **Issue #17**: SQLite integration test with real database connection
+
+### Planned approach
+
+- SQLite: local file-backed test (no Docker needed)
+- PostgreSQL: Docker-based
+- MySQL: deferred (no native adapter)

--- a/doc/reference/specs/sqlc-compatibility.md
+++ b/doc/reference/specs/sqlc-compatibility.md
@@ -1,0 +1,147 @@
+# sqlc Compatibility Target
+
+## Goal
+
+`sqlode` should feel familiar to existing `sqlc` users:
+
+- same mental model: schema files + query files + generated typed API
+- same query naming convention
+- same primary engines: PostgreSQL, MySQL, SQLite
+- same default config shape where practical
+
+The compatibility target is sqlc configuration version 2.
+
+## Config surface
+
+The baseline config shape matches sqlc v2:
+
+```yaml
+version: "2"
+sql:
+  - schema: "db/schema.sql"
+    queries: "db/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "src/db"
+        runtime: "raw"
+    overrides:
+      types:
+        - db_type: "uuid"
+          gleam_type: "String"
+      renames:
+        - table: "authors"
+          column: "bio"
+          rename_to: "biography"
+```
+
+### Implemented `gen.gleam` options
+
+| Option | Status | Notes |
+|--------|--------|-------|
+| `package` | Implemented | Package name for imports |
+| `out` | Implemented | Output directory |
+| `runtime` | Implemented | `raw`, `based`, `native` |
+| `overrides.types` | Implemented | Map DB types to Gleam types |
+| `overrides.renames` | Implemented | Rename columns in result types |
+
+### Not yet implemented options
+
+| Option | Status |
+|--------|--------|
+| `emit_exact_table_names` | Not implemented |
+| `emit_sql_as_comment` | Not implemented |
+| `query_parameter_limit` | Not implemented |
+| `database` | Not implemented (live DB analysis) |
+| `analyzer` | Not implemented |
+
+These options are accepted in the config model but have no effect.
+
+## Query annotations
+
+The required naming format matches sqlc:
+
+```sql
+-- name: GetAuthor :one
+SELECT * FROM authors WHERE id = $1;
+```
+
+### Implemented annotations
+
+All core sqlc annotations are implemented:
+
+- `:one` — returns at most one row
+- `:many` — returns zero or more rows
+- `:exec` — returns nothing
+- `:execresult` — returns the execution result
+- `:execrows` — returns affected row count
+- `:execlastid` — returns last inserted ID
+
+### Not implemented annotations
+
+Batch annotations are not yet supported:
+
+- `:batchexec`
+- `:batchmany`
+- `:batchone`
+- `:copyfrom`
+
+## Macros and parameter naming
+
+### Implemented macros
+
+| Macro | Status | Notes |
+|-------|--------|-------|
+| `sqlc.arg(name)` | Implemented | Names a parameter |
+| `sqlc.narg(name)` | Implemented | Names a nullable parameter |
+| `sqlc.slice(name)` | Implemented | Expands to list parameter |
+| `sqlc.embed(table)` | Implemented | Flattens all table columns into result |
+
+### Compatibility notes
+
+- `sqlc.arg` and `sqlc.narg` are expanded by the query parser into
+  engine-appropriate placeholders (`$N` for PostgreSQL, `?` for MySQL,
+  `?N` for SQLite).
+- `sqlc.embed` flattens all columns from the embedded table into the
+  result type. **Note:** This differs from sqlc's Go behavior which
+  produces nested structs. Gleam does not have implicit struct embedding.
+- `sqlc.slice` generates a `List(T)` parameter type.
+- `@name` shorthand is **not yet implemented**.
+
+## Type mapping
+
+### Implemented type families
+
+| SQL Type | Gleam Type |
+|----------|-----------|
+| INT, INTEGER, BIGINT, SERIAL, BIGSERIAL, SMALLINT | Int |
+| FLOAT, DOUBLE, REAL, NUMERIC, DECIMAL | Float |
+| BOOLEAN, BOOL | Bool |
+| TEXT, VARCHAR, CHAR | String |
+| BYTEA, BLOB, BINARY | BitArray |
+| TIMESTAMP, DATETIME | String |
+| DATE | String |
+| TIME, TIMETZ | String |
+| UUID | String |
+| JSON, JSONB | String |
+| PostgreSQL ENUM | String |
+
+Nullable columns (without `NOT NULL`) are wrapped in `Option(T)`.
+
+Type overrides allow remapping DB types to different Gleam types.
+
+### Not yet implemented
+
+- PostgreSQL arrays
+- MySQL `ENUM` / `SET`
+- SQLite affinity-based typing edge cases
+
+## Sources
+
+- sqlc configuration:
+  https://docs.sqlc.dev/en/stable/reference/config.html
+- sqlc query annotations:
+  https://docs.sqlc.dev/en/stable/reference/query-annotations.html
+- sqlc macros:
+  https://docs.sqlc.dev/en/stable/reference/macros.html


### PR DESCRIPTION
## Summary

- Rewrite architecture, sqlc-compatibility, and testing-strategy docs to match the current implementation

## Changes

- **sqlode-architecture.md**: Complete rewrite describing unified parser model, actual module layout, IR types from model.gleam, AdapterConfig pattern, implementation status
- **sqlc-compatibility.md**: Added implementation status tables, corrected sqlc.embed behavior (flattens, not nests), documented type mapping table
- **testing-strategy.md**: Updated test file listing (11 files), fixture inventory (18 files), CI order via justfile

## Limitations

- These files are in doc/reference/ which is gitignored. Force-added for this PR since the issue specifically asks to update them.

Closes #13