### PR TITLE
test(integration): add compile verification tests for generated Gleam code

### DIFF
--- a/integration_test/compile_test.sh
+++ b/integration_test/compile_test.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# Integration test: verify generated Gleam code compiles
+# This test creates a temporary Gleam project, generates code into it,
+# and runs gleam build to verify the generated code is syntactically valid.
+
+set -eu
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INTEGRATION_DIR="$PROJECT_ROOT/test_integration_tmp"
+
+cleanup() {
+  rm -rf "$INTEGRATION_DIR"
+}
+trap cleanup EXIT
+
+echo "=== Integration test: generated code compilation ==="
+
+# --- Test 1: raw mode (params + queries + models) ---
+echo ""
+echo "--- Test 1: raw mode ---"
+
+cleanup
+mkdir -p "$INTEGRATION_DIR/src/db"
+
+cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "raw"
+YAML
+
+echo "Generating code..."
+cd "$PROJECT_ROOT"
+gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+
+echo "Building generated project..."
+cd "$INTEGRATION_DIR"
+gleam build
+
+echo "PASS: raw mode code compiles"
+
+# --- Test 2: raw mode with complex schema ---
+echo ""
+echo "--- Test 2: raw mode with complex schema ---"
+
+cleanup
+mkdir -p "$INTEGRATION_DIR/src/db"
+
+cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/complex_schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/complex_query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "raw"
+YAML
+
+echo "Generating code..."
+cd "$PROJECT_ROOT"
+gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+
+echo "Building generated project..."
+cd "$INTEGRATION_DIR"
+gleam build
+
+echo "PASS: complex schema raw mode code compiles"
+
+# --- Test 3: raw mode with all types ---
+echo ""
+echo "--- Test 3: raw mode with all types ---"
+
+cleanup
+mkdir -p "$INTEGRATION_DIR/src/db"
+
+cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/all_types_schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/all_types_query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "raw"
+YAML
+
+echo "Generating code..."
+cd "$PROJECT_ROOT"
+gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+
+echo "Building generated project..."
+cd "$INTEGRATION_DIR"
+gleam build
+
+echo "PASS: all types raw mode code compiles"
+
+echo ""
+echo "=== All integration tests passed ==="

--- a/spec/compile_spec.sh
+++ b/spec/compile_spec.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+Describe 'generated code compilation'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  INTEGRATION_DIR="$PROJECT_ROOT/test_integration_tmp"
+
+  setup_raw_project() {
+    rm -rf "$INTEGRATION_DIR"
+    mkdir -p "$INTEGRATION_DIR/src/db"
+
+    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "raw"
+YAML
+  }
+
+  setup_sqlight_project() {
+    rm -rf "$INTEGRATION_DIR"
+    mkdir -p "$INTEGRATION_DIR/src/db"
+
+    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+sqlight = ">= 1.0.0 and < 2.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
+    engine: "sqlite"
+    gen:
+      gleam:
+        package: "db"
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "native"
+YAML
+  }
+
+  cleanup_project() {
+    rm -rf "$INTEGRATION_DIR"
+  }
+
+  generate_code() {
+    cd "$PROJECT_ROOT" && gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml" 2>&1
+  }
+
+  build_project() {
+    cd "$INTEGRATION_DIR" && gleam build 2>&1
+  }
+
+  Describe 'raw mode (params + queries + models)'
+    Before 'setup_raw_project'
+    After 'cleanup_project'
+
+    It 'generates and compiles raw mode code'
+      When call generate_code
+      The status should be success
+      The output should include 'Successfully generated'
+    End
+
+    It 'builds without errors'
+      When call build_project
+      The status should be success
+      The output should include 'Compiled in'
+    End
+  End
+
+  Describe 'SQLite native mode (with sqlight adapter)'
+    Before 'setup_sqlight_project'
+    After 'cleanup_project'
+
+    It 'generates and compiles SQLite native mode code'
+      When call generate_code
+      The status should be success
+      The output should include 'Successfully generated'
+    End
+
+    It 'builds without errors'
+      When call build_project
+      The status should be success
+      The output should include 'Compiled in'
+    End
+  End
+End


### PR DESCRIPTION
## Summary
- Add integration test script (`integration_test/compile_test.sh`) that creates temporary Gleam projects, generates code from test fixtures (raw mode, complex schema, all types), and verifies `gleam build` succeeds
- Add ShellSpec test (`spec/compile_spec.sh`) covering raw mode (PostgreSQL) and SQLite native mode compilation verification
- Ensures generated `.gleam` files are syntactically valid and compile without errors

Closes #16

## Test plan
- [x] `integration_test/compile_test.sh` passes all 3 test cases (raw, complex schema, all types)
- [x] `shellspec spec/compile_spec.sh` passes all 4 examples (raw + SQLite native generate & build)
- [x] `just all` passes (167 gleam tests + 7 shellspec tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify generated code compiles correctly across raw mode and SQLite native mode configurations with varying schema complexity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->