### PR TITLE
test(compile): fix ShellSpec Before/After test isolation issue

### DIFF
--- a/spec/compile_spec.sh
+++ b/spec/compile_spec.sh
@@ -67,11 +67,8 @@ YAML
     rm -rf "$INTEGRATION_DIR"
   }
 
-  generate_code() {
+  generate_and_build() {
     cd "$PROJECT_ROOT" && gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml" 2>&1
-  }
-
-  build_project() {
     cd "$INTEGRATION_DIR" && gleam build 2>&1
   }
 
@@ -79,15 +76,10 @@ YAML
     Before 'setup_raw_project'
     After 'cleanup_project'
 
-    It 'generates and compiles raw mode code'
-      When call generate_code
+    It 'generates and builds raw mode code'
+      When call generate_and_build
       The status should be success
       The output should include 'Successfully generated'
-    End
-
-    It 'builds without errors'
-      When call build_project
-      The status should be success
       The output should include 'Compiled in'
     End
   End
@@ -96,15 +88,10 @@ YAML
     Before 'setup_sqlight_project'
     After 'cleanup_project'
 
-    It 'generates and compiles SQLite native mode code'
-      When call generate_code
+    It 'generates and builds SQLite native mode code'
+      When call generate_and_build
       The status should be success
       The output should include 'Successfully generated'
-    End
-
-    It 'builds without errors'
-      When call build_project
-      The status should be success
       The output should include 'Compiled in'
     End
   End


### PR DESCRIPTION
## Summary

Fix `spec/compile_spec.sh` where ShellSpec `Before`/`After` hooks caused the build test to run on an empty project instead of verifying generated code compiles.

## Changes

- `spec/compile_spec.sh`: Combine `generate_code` and `build_project` into a single `generate_and_build` function called within one `It` block per mode, ensuring generated files exist when `gleam build` runs.

## Design Decisions

- Merged the two separate `It` blocks (generate, then build) into one per mode. ShellSpec's `Before`/`After` hooks run per `It` block, so separating them caused `cleanup_project` to delete generated files before the build step. Combining them is the simplest correct fix.
- Both assertions (`Successfully generated` and `Compiled in`) are checked in the same test to verify the full pipeline.

Closes #57