### PR TITLE
fix(analyzer): report query analysis failures with early errors instead of silent fallback

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -18,6 +18,7 @@ pub type GenerateError {
   SchemaParseError(detail: String)
   QueryReadError(path: String, detail: String)
   QueryParseError(path: String, detail: String)
+  QueryAnalysisError(detail: String)
   NoQueriesGenerated(
     output: String,
     parsed_query_count: Int,
@@ -57,9 +58,13 @@ fn generate_sql_block(
   let catalog =
     apply_type_overrides(raw_catalog, block.overrides.type_overrides)
   use queries <- result.try(load_queries(naming_ctx, block))
-  let analyzed =
+  use analyzed <- result.try(
     query_analyzer.analyze_queries(block.engine, catalog, naming_ctx, queries)
-    |> apply_column_renames(block.overrides.column_renames)
+    |> result.map_error(fn(error) {
+      QueryAnalysisError(detail: query_analyzer.analysis_error_to_string(error))
+    }),
+  )
+  let analyzed = apply_column_renames(analyzed, block.overrides.column_renames)
 
   let model.SqlBlock(gleam:, ..) = block
   let model.GleamOutput(out:, ..) = gleam
@@ -296,6 +301,7 @@ pub fn error_to_string(error: GenerateError) -> String {
     SchemaParseError(detail:) -> detail
     QueryReadError(path:, detail:) -> path <> ": " <> detail
     QueryParseError(detail:, ..) -> detail
+    QueryAnalysisError(detail:) -> detail
     NoQueriesGenerated(
       output:,
       parsed_query_count:,

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -3,9 +3,34 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/regexp
+import gleam/result
 import gleam/string
 import sqlode/model
 import sqlode/naming
+
+pub type AnalysisError {
+  TableNotFound(query_name: String, table_name: String)
+  ColumnNotFound(query_name: String, table_name: String, column_name: String)
+}
+
+pub fn analysis_error_to_string(error: AnalysisError) -> String {
+  case error {
+    TableNotFound(query_name:, table_name:) ->
+      "Query \""
+      <> query_name
+      <> "\": table \""
+      <> table_name
+      <> "\" not found in schema"
+    ColumnNotFound(query_name:, table_name:, column_name:) ->
+      "Query \""
+      <> query_name
+      <> "\": column \""
+      <> column_name
+      <> "\" not found in table \""
+      <> table_name
+      <> "\""
+  }
+}
 
 type PlaceholderOccurrence {
   PlaceholderOccurrence(index: Int, token: String, default_name: String)
@@ -88,9 +113,9 @@ pub fn analyze_queries(
   catalog: model.Catalog,
   naming_ctx: naming.NamingContext,
   queries: List(model.ParsedQuery),
-) -> List(model.AnalyzedQuery) {
+) -> Result(List(model.AnalyzedQuery), AnalysisError) {
   let ctx = new_analyzer_context(naming_ctx)
-  list.map(queries, analyze_query(ctx, engine, catalog, _))
+  list.try_map(queries, analyze_query(ctx, engine, catalog, _))
 }
 
 fn analyze_query(
@@ -98,12 +123,12 @@ fn analyze_query(
   engine: model.Engine,
   catalog: model.Catalog,
   query: model.ParsedQuery,
-) -> model.AnalyzedQuery {
+) -> Result(model.AnalyzedQuery, AnalysisError) {
   let occurrences = extract_placeholder_occurrences(ctx, engine, query.sql)
   let params = build_params(ctx, engine, query, catalog, occurrences)
-  let result_columns = infer_result_columns(ctx, query, catalog)
+  use result_columns <- result.try(infer_result_columns(ctx, query, catalog))
 
-  model.AnalyzedQuery(base: query, params:, result_columns:)
+  Ok(model.AnalyzedQuery(base: query, params:, result_columns:))
 }
 
 fn build_params(
@@ -594,9 +619,9 @@ fn infer_result_columns(
   ctx: AnalyzerContext,
   query: model.ParsedQuery,
   catalog: model.Catalog,
-) -> List(model.ResultColumn) {
+) -> Result(List(model.ResultColumn), AnalysisError) {
   case query.command {
-    model.Exec | model.ExecResult | model.ExecRows | model.ExecLastId -> []
+    model.Exec | model.ExecResult | model.ExecRows | model.ExecLastId -> Ok([])
     model.One | model.Many -> {
       let normalized = normalize_sql(ctx, query.sql)
 
@@ -604,15 +629,13 @@ fn infer_result_columns(
         Some(returning_cols) -> {
           let table_names = extract_table_names(ctx, normalized)
           case table_names {
-            [] -> []
-            _ ->
+            [] -> Ok([])
+            [primary, ..] ->
               resolve_select_columns(
+                query.name,
                 returning_cols,
                 catalog,
-                case table_names {
-                  [first, ..] -> first
-                  [] -> ""
-                },
+                primary,
                 table_names,
               )
           }
@@ -622,10 +645,11 @@ fn infer_result_columns(
           let table_names = extract_table_names(ctx, main_sql)
 
           case table_names {
-            [] -> []
+            [] -> Ok([])
             [primary, ..] -> {
               let select_columns = extract_select_columns(ctx, main_sql)
               resolve_select_columns(
+                query.name,
                 select_columns,
                 catalog,
                 primary,
@@ -744,11 +768,12 @@ fn extract_select_columns(ctx: AnalyzerContext, sql: String) -> List(String) {
 }
 
 fn resolve_select_columns(
+  query_name: String,
   columns: List(String),
   catalog: model.Catalog,
   primary_table: String,
   all_tables: List(String),
-) -> List(model.ResultColumn) {
+) -> Result(List(model.ResultColumn), AnalysisError) {
   case columns {
     ["*"] ->
       case
@@ -756,18 +781,19 @@ fn resolve_select_columns(
         |> list.find(fn(table) { table.name == primary_table })
       {
         Ok(table) ->
-          list.map(table.columns, fn(col) {
-            model.ResultColumn(
-              name: col.name,
-              scalar_type: col.scalar_type,
-              nullable: col.nullable,
-            )
-          })
-        Error(_) -> []
+          Ok(
+            list.map(table.columns, fn(col) {
+              model.ResultColumn(
+                name: col.name,
+                scalar_type: col.scalar_type,
+                nullable: col.nullable,
+              )
+            }),
+          )
+        Error(_) -> Error(TableNotFound(query_name:, table_name: primary_table))
       }
     _ ->
-      columns
-      |> list.flat_map(fn(col_name) {
+      list.try_map(columns, fn(col_name) {
         let trimmed = string.trim(col_name)
         case string.starts_with(trimmed, "sqlc.embed(") {
           True -> {
@@ -783,37 +809,41 @@ fn resolve_select_columns(
               |> list.find(fn(table) { table.name == embed_name })
             {
               Ok(table) ->
-                list.map(table.columns, fn(col) {
-                  model.ResultColumn(
-                    name: col.name,
-                    scalar_type: col.scalar_type,
-                    nullable: col.nullable,
-                  )
-                })
-              Error(_) -> []
+                Ok(
+                  list.map(table.columns, fn(col) {
+                    model.ResultColumn(
+                      name: col.name,
+                      scalar_type: col.scalar_type,
+                      nullable: col.nullable,
+                    )
+                  }),
+                )
+              Error(_) ->
+                Error(TableNotFound(query_name:, table_name: embed_name))
             }
           }
           False -> {
             let normalized_name = string.lowercase(trimmed)
             case find_column_in_tables(catalog, all_tables, normalized_name) {
-              Some(column) -> [
-                model.ResultColumn(
-                  name: column.name,
-                  scalar_type: column.scalar_type,
-                  nullable: column.nullable,
-                ),
-              ]
-              None -> [
-                model.ResultColumn(
-                  name: normalized_name,
-                  scalar_type: model.StringType,
-                  nullable: False,
-                ),
-              ]
+              Some(column) ->
+                Ok([
+                  model.ResultColumn(
+                    name: column.name,
+                    scalar_type: column.scalar_type,
+                    nullable: column.nullable,
+                  ),
+                ])
+              None ->
+                Error(ColumnNotFound(
+                  query_name:,
+                  table_name: primary_table,
+                  column_name: normalized_name,
+                ))
             }
           }
         }
       })
+      |> result.map(list.flatten)
   }
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -135,7 +135,7 @@ pub fn render_sqlight_adapter_test() {
       naming_ctx,
       content,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
   let rendered = codegen.render_adapter_module(naming_ctx, block, analyzed)
 
@@ -186,7 +186,14 @@ fn analyzed_queries(path: String) -> List(model.AnalyzedQuery) {
   let assert Ok(queries) =
     query_parser.parse_file(path, model.PostgreSQL, naming_ctx, content)
 
-  query_analyzer.analyze_queries(model.PostgreSQL, catalog, naming_ctx, queries)
+  let assert Ok(result) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result
 }
 
 fn analyzed_star_queries() -> List(model.AnalyzedQuery) {
@@ -199,5 +206,12 @@ fn analyzed_star_queries() -> List(model.AnalyzedQuery) {
   let assert Ok(queries) =
     query_parser.parse_file("star.sql", model.PostgreSQL, naming_ctx, sql)
 
-  query_analyzer.analyze_queries(model.PostgreSQL, catalog, naming_ctx, queries)
+  let assert Ok(result) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result
 }

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -21,7 +21,7 @@ pub fn mysql_positional_placeholder_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/mysql_query.sql", model.MySQL, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   // GetAuthor :one - single ? placeholder
@@ -38,7 +38,7 @@ pub fn mysql_insert_params_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/mysql_query.sql", model.MySQL, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   let assert Ok(create) =
@@ -58,7 +58,7 @@ pub fn mysql_update_params_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/mysql_query.sql", model.MySQL, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   let assert Ok(update) =
@@ -72,7 +72,7 @@ pub fn mysql_no_params_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/mysql_query.sql", model.MySQL, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   let assert Ok(list_q) =
@@ -86,7 +86,7 @@ pub fn mysql_result_columns_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/mysql_query.sql", model.MySQL, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   let assert Ok(get) = list.find(analyzed, fn(q) { q.base.name == "GetAuthor" })
@@ -106,7 +106,7 @@ pub fn sqlite_numbered_placeholder_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/sqlite_query.sql", model.SQLite, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
 
   let assert Ok(get_by_id) =
@@ -121,7 +121,7 @@ pub fn sqlite_colon_named_placeholder_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/sqlite_query.sql", model.SQLite, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
 
   let assert Ok(get_by_name) =
@@ -136,7 +136,7 @@ pub fn sqlite_at_named_placeholder_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/sqlite_query.sql", model.SQLite, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
 
   let assert Ok(get_by_email) =
@@ -153,7 +153,7 @@ pub fn sqlite_dollar_named_placeholder_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/sqlite_query.sql", model.SQLite, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
 
   let assert Ok(get_by_slug) =
@@ -170,7 +170,7 @@ pub fn sqlite_insert_params_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/sqlite_query.sql", model.SQLite, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
 
   let assert Ok(create) =
@@ -187,7 +187,7 @@ pub fn sqlite_result_columns_test() {
   let catalog = load_catalog("test/fixtures/schema.sql")
   let queries =
     parse_queries("test/fixtures/sqlite_query.sql", model.SQLite, naming_ctx)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
 
   let assert Ok(list_q) =
@@ -214,11 +214,11 @@ pub fn cross_engine_select_produces_same_result_columns_test() {
   let assert Ok(sl_q) =
     query_parser.parse_file("sl.sql", model.SQLite, naming_ctx, sl_sql)
 
-  let pg_analyzed =
+  let assert Ok(pg_analyzed) =
     query_analyzer.analyze_queries(model.PostgreSQL, catalog, naming_ctx, pg_q)
-  let my_analyzed =
+  let assert Ok(my_analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, my_q)
-  let sl_analyzed =
+  let assert Ok(sl_analyzed) =
     query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, sl_q)
 
   let assert [pg] = pg_analyzed
@@ -241,7 +241,7 @@ pub fn exec_result_command_test() {
     "-- name: DeleteAuthor :execresult\nDELETE FROM authors WHERE id = $1;"
   let assert Ok(queries) =
     query_parser.parse_file("er.sql", model.PostgreSQL, naming_ctx, sql)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -262,7 +262,7 @@ pub fn exec_rows_command_test() {
     "-- name: DeleteAllInactive :execrows\nDELETE FROM authors WHERE bio IS NULL;"
   let assert Ok(queries) =
     query_parser.parse_file("rows.sql", model.PostgreSQL, naming_ctx, sql)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -282,7 +282,7 @@ pub fn exec_last_id_command_test() {
     "-- name: InsertAuthor :execlastid\nINSERT INTO authors (name, bio) VALUES (?, ?);"
   let assert Ok(queries) =
     query_parser.parse_file("lid.sql", model.MySQL, naming_ctx, sql)
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   let assert [query] = analyzed

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -23,7 +23,7 @@ pub fn infer_param_type_from_where_clause_test() {
       content,
     )
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -57,7 +57,7 @@ pub fn infer_insert_param_types_from_column_order_test() {
       content,
     )
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -97,7 +97,7 @@ pub fn infer_result_columns_for_select_test() {
       content,
     )
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -139,7 +139,7 @@ pub fn infer_no_result_columns_for_exec_test() {
       content,
     )
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -158,7 +158,7 @@ pub fn infer_result_columns_with_star_test() {
   let assert Ok(queries) =
     query_parser.parse_file("star.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -191,7 +191,7 @@ pub fn infer_result_columns_with_table_prefix_test() {
   let assert Ok(queries) =
     query_parser.parse_file("prefix.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -219,7 +219,7 @@ pub fn sqlc_arg_sets_param_name_test() {
   let assert Ok(queries) =
     query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -248,7 +248,7 @@ pub fn sqlc_narg_sets_nullable_test() {
   let assert Ok(queries) =
     query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -272,7 +272,7 @@ pub fn sqlc_slice_sets_is_list_test() {
   let assert Ok(queries) =
     query_parser.parse_file("slice.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -314,7 +314,7 @@ pub fn join_result_columns_test() {
   let assert Ok(queries) =
     query_parser.parse_file("join.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -346,7 +346,7 @@ pub fn sqlc_embed_expands_table_columns_test() {
   let assert Ok(queries) =
     query_parser.parse_file("embed.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -372,7 +372,7 @@ pub fn returning_clause_result_columns_test() {
   let assert Ok(queries) =
     query_parser.parse_file("ret.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -400,7 +400,7 @@ pub fn cte_select_from_real_table_test() {
   let assert Ok(queries) =
     query_parser.parse_file("cte.sql", model.PostgreSQL, naming_ctx, sql)
 
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,

--- a/test/sqlc_compat_test.gleam
+++ b/test/sqlc_compat_test.gleam
@@ -109,7 +109,7 @@ pub fn all_types_result_columns_star_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -138,7 +138,7 @@ pub fn all_types_insert_params_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -212,7 +212,7 @@ pub fn complex_query_basic_crud_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -254,7 +254,7 @@ pub fn complex_query_single_join_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -282,7 +282,7 @@ pub fn complex_query_multi_join_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -309,7 +309,7 @@ pub fn complex_query_returning_clause_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -352,7 +352,7 @@ pub fn complex_query_update_params_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -395,7 +395,7 @@ pub fn macro_mixed_arg_narg_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -421,7 +421,7 @@ pub fn macro_slice_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,
@@ -445,7 +445,7 @@ pub fn macro_update_with_multiple_macros_test() {
       model.PostgreSQL,
       naming_ctx,
     )
-  let analyzed =
+  let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
       model.PostgreSQL,
       catalog,


### PR DESCRIPTION
## Summary

Replace silent fallback behavior in query analysis with early errors. When a `:one`/`:many` query references a table or column not found in the schema, sqlode now returns an error instead of silently generating code with default `String` types.

## Changes

- `src/sqlode/query_analyzer.gleam`:
  - Add `AnalysisError` type with `TableNotFound` and `ColumnNotFound` variants
  - Add `analysis_error_to_string` for human-readable error messages
  - Change `analyze_queries` return type from `List(AnalyzedQuery)` to `Result(List(AnalyzedQuery), AnalysisError)`
  - `resolve_select_columns` now returns `Error(TableNotFound)` when `SELECT *` references a missing table, and `Error(ColumnNotFound)` when an individual column is not found in any referenced table
- `src/sqlode/generate.gleam`:
  - Add `QueryAnalysisError` variant to `GenerateError`
  - Propagate analysis errors through the generation pipeline
- `test/codegen_test.gleam`, `test/query_analyzer_test.gleam`, `test/sqlc_compat_test.gleam`, `test/dialect_test.gleam`:
  - Update all `analyze_queries` call sites to handle `Result` type

## Design Decisions

- Early error over silent fallback: Previously, unresolved columns defaulted to `StringType` with no warning. Now the analyzer errors immediately, giving users actionable feedback (e.g., `Query "GetPost": column "id" not found in table "posts"`).
- Error, not warning: Since generating code with incorrect types leads to runtime failures, failing fast at generation time is preferable.
- `AnalysisError` is a dedicated type in `query_analyzer` rather than reusing `GenerateError`, keeping module boundaries clean.

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during query analysis. The system now explicitly detects and reports when referenced tables or columns cannot be found, providing users with clear error messages instead of silently falling back to default values and continuing execution.

* **Tests**
  * Expanded test coverage to validate proper error detection and propagation in query analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->