### PR TITLE
test(compile): add pog adapter compilation verification test

### DIFF
--- a/spec/compile_spec.sh
+++ b/spec/compile_spec.sh
@@ -63,6 +63,35 @@ sql:
 YAML
   }
 
+  setup_pog_project() {
+    rm -rf "$INTEGRATION_DIR"
+    mkdir -p "$INTEGRATION_DIR/src/db"
+
+    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+pog = ">= 4.0.0 and < 5.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "native"
+YAML
+  }
+
   cleanup_project() {
     rm -rf "$INTEGRATION_DIR"
   }
@@ -77,6 +106,18 @@ YAML
     After 'cleanup_project'
 
     It 'generates and builds raw mode code'
+      When call generate_and_build
+      The status should be success
+      The output should include 'Successfully generated'
+      The output should include 'Compiled in'
+    End
+  End
+
+  Describe 'PostgreSQL native mode (with pog adapter)'
+    Before 'setup_pog_project'
+    After 'cleanup_project'
+
+    It 'generates and builds PostgreSQL native mode code'
       When call generate_and_build
       The status should be success
       The output should include 'Successfully generated'


### PR DESCRIPTION
## Summary

Add a compilation verification test for the PostgreSQL pog adapter, ensuring generated `pog_adapter.gleam` code compiles against a real Gleam project with the pog dependency.

## Changes

- `spec/compile_spec.sh`: Add `setup_pog_project()` function and a new ShellSpec `Describe` block for PostgreSQL native mode that generates adapter code and verifies it compiles with `gleam build`.

## Design Decisions

- Used pog `>= 4.0.0 and < 5.0.0` because pog v1.x is incompatible with the current gleam_stdlib (v0.71.0) — pog v1.x uses the removed `gleam/dynamic.DecodeErrors` and `gleam/dynamic.Decoder` types. pog v4.x uses the current `gleam/dynamic/decode` API.
- Reuses the existing `test/fixtures/schema.sql` and `test/fixtures/query.sql` fixtures (same as the raw mode and sqlight tests) with `engine: "postgresql"` and `runtime: "native"`.

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for PostgreSQL database support with the pog adapter, validating compilation scenarios in native mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->