### PR TITLE
test(generate): add tests for config type overrides and column renames

### DIFF
--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1,0 +1,232 @@
+import gleam/option
+import gleam/string
+import gleeunit/should
+import simplifile
+import sqlode/generate
+import sqlode/model
+
+const test_out = "test_output/generate_test"
+
+fn cleanup() {
+  let _ = simplifile.delete(test_out)
+  Nil
+}
+
+fn base_block(overrides: model.Overrides) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.PostgreSQL,
+    schema: ["test/fixtures/schema.sql"],
+    queries: ["test/fixtures/query.sql"],
+    gleam: model.GleamOutput(package: "db", out: test_out, runtime: model.Raw),
+    overrides: overrides,
+  )
+}
+
+fn run_generate(block: model.SqlBlock) -> List(String) {
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(files) = generate.generate_config(cfg)
+  files
+}
+
+fn read_generated(filename: String) -> String {
+  let assert Ok(content) = simplifile.read(test_out <> "/" <> filename)
+  content
+}
+
+// --- Type override tests ---
+
+pub fn type_override_changes_scalar_type_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.TypeOverride(db_type: "string", gleam_type: "Int"),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // "name" column is TEXT (StringType), override to Int
+  string.contains(models, "name: Int") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn type_override_case_insensitive_db_type_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.TypeOverride(db_type: "STRING", gleam_type: "Float"),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  string.contains(models, "name: Float") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn type_override_preserves_unmatched_columns_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.TypeOverride(db_type: "bool", gleam_type: "String"),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // No bool columns in schema, so types should remain unchanged
+  string.contains(models, "id: Int") |> should.be_true()
+  string.contains(models, "name: String") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn type_override_multiple_overrides_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.TypeOverride(db_type: "int", gleam_type: "String"),
+          model.TypeOverride(db_type: "string", gleam_type: "BitArray"),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // id (IntType) → String, name (StringType) → BitArray
+  string.contains(models, "id: String") |> should.be_true()
+  string.contains(models, "name: BitArray") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn no_overrides_leaves_types_unchanged_test() {
+  cleanup()
+  let block = base_block(model.empty_overrides())
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  string.contains(models, "id: Int") |> should.be_true()
+  string.contains(models, "name: String") |> should.be_true()
+
+  cleanup()
+}
+
+// --- Column rename tests ---
+
+pub fn column_rename_changes_field_name_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(type_overrides: [], column_renames: [
+        model.ColumnRename(
+          table: "authors",
+          column: "name",
+          rename_to: "author_name",
+        ),
+      ]),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  string.contains(models, "author_name: String") |> should.be_true()
+  // Original field pattern "id: Int, name: String" should be replaced
+  string.contains(models, "id: Int, name: String") |> should.be_false()
+
+  cleanup()
+}
+
+pub fn column_rename_case_insensitive_match_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(type_overrides: [], column_renames: [
+        model.ColumnRename(
+          table: "authors",
+          column: "NAME",
+          rename_to: "full_name",
+        ),
+      ]),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  string.contains(models, "full_name: String") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn column_rename_only_applies_to_matching_table_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(type_overrides: [], column_renames: [
+        model.ColumnRename(
+          table: "posts",
+          column: "name",
+          rename_to: "post_name",
+        ),
+      ]),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Rename for "posts" table should not affect "authors" queries
+  string.contains(models, "name: String") |> should.be_true()
+  string.contains(models, "post_name") |> should.be_false()
+
+  cleanup()
+}
+
+pub fn combined_type_override_and_column_rename_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.TypeOverride(db_type: "string", gleam_type: "BitArray"),
+        ],
+        column_renames: [
+          model.ColumnRename(
+            table: "authors",
+            column: "name",
+            rename_to: "display_name",
+          ),
+        ],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Both override and rename should apply
+  string.contains(models, "display_name: BitArray") |> should.be_true()
+
+  cleanup()
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -1,5 +1,6 @@
 import codegen_test
 import config_test
+import generate_test
 import gleeunit
 import query_analyzer_test
 import query_parser_test
@@ -135,4 +136,40 @@ pub fn render_pog_adapter_test() {
 
 pub fn render_sqlight_adapter_test() {
   codegen_test.render_sqlight_adapter_test()
+}
+
+pub fn type_override_changes_scalar_type_test() {
+  generate_test.type_override_changes_scalar_type_test()
+}
+
+pub fn type_override_case_insensitive_db_type_test() {
+  generate_test.type_override_case_insensitive_db_type_test()
+}
+
+pub fn type_override_preserves_unmatched_columns_test() {
+  generate_test.type_override_preserves_unmatched_columns_test()
+}
+
+pub fn type_override_multiple_overrides_test() {
+  generate_test.type_override_multiple_overrides_test()
+}
+
+pub fn no_overrides_leaves_types_unchanged_test() {
+  generate_test.no_overrides_leaves_types_unchanged_test()
+}
+
+pub fn column_rename_changes_field_name_test() {
+  generate_test.column_rename_changes_field_name_test()
+}
+
+pub fn column_rename_case_insensitive_match_test() {
+  generate_test.column_rename_case_insensitive_match_test()
+}
+
+pub fn column_rename_only_applies_to_matching_table_test() {
+  generate_test.column_rename_only_applies_to_matching_table_test()
+}
+
+pub fn combined_type_override_and_column_rename_test() {
+  generate_test.combined_type_override_and_column_rename_test()
 }


### PR DESCRIPTION
## Summary

Add E2E tests for the config type override and column rename features in `generate.gleam`, verifying that these features correctly modify the generated Gleam code.

## Changes

- `test/generate_test.gleam`: New test file with 9 test cases covering:
  - **Type overrides** (5 tests): scalar type change, case-insensitive db_type matching, unmatched columns preserved, multiple overrides, no overrides baseline
  - **Column renames** (3 tests): field name change, case-insensitive column matching, table-scoped rename (only applies to matching table)
  - **Combined** (1 test): type override and column rename applied together
- `test/sqlode_test.gleam`: Register all 9 new tests

## Design Decisions

- Tests use `generate_config` (public API) with temporary output directory rather than exposing private functions. Each test creates a config with specific overrides, runs generation, reads the output `models.gleam`, and asserts on its content.
- Tests clean up generated files before and after each run to avoid interference.

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for SQL-to-Gleam code generation, including validation of type override behavior (scalar type changes, case-insensitive matching, multiple overrides) and column rename functionality (field name changes, table-scoped application, combined operations).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->