### PR TITLE
refactor(model): extract shared scalar type mappings to reduce duplication

### DIFF
--- a/src/sqlode/codegen.gleam
+++ b/src/sqlode/codegen.gleam
@@ -317,8 +317,8 @@ fn pog_adapter_config() -> AdapterConfig {
     library_import: "import pog",
     connection_type: "pog.Connection",
     error_type: "pog.QueryError",
-    value_function: pog_value_function,
-    decoder_function: pog_decoder_function,
+    value_function: model.scalar_type_to_value_function(model.PostgreSQL, _),
+    decoder_function: model.scalar_type_to_decoder(model.PostgreSQL, _),
     render_params: render_pog_params,
     render_query_call: render_pog_query_call,
     render_one_result: render_pog_one_result,
@@ -332,8 +332,8 @@ fn sqlight_adapter_config() -> AdapterConfig {
     library_import: "import sqlight",
     connection_type: "sqlight.Connection",
     error_type: "sqlight.Error",
-    value_function: sqlight_value_function,
-    decoder_function: sqlight_decoder_function,
+    value_function: model.scalar_type_to_value_function(model.SQLite, _),
+    decoder_function: model.scalar_type_to_decoder(model.SQLite, _),
     render_params: render_sqlight_params,
     render_query_call: render_sqlight_query_call,
     render_one_result: render_sqlight_one_result,
@@ -643,7 +643,8 @@ fn render_pog_query_call(
 fn render_pog_params(params: List(model.QueryParam), _prefix: String) -> String {
   params
   |> list.map(fn(param) {
-    let value_fn = pog_value_function(param.scalar_type)
+    let value_fn =
+      model.scalar_type_to_value_function(model.PostgreSQL, param.scalar_type)
     case param.nullable {
       False ->
         "  |> pog.parameter(pog."
@@ -660,38 +661,6 @@ fn render_pog_params(params: List(model.QueryParam), _prefix: String) -> String 
     }
   })
   |> string.join("\n")
-}
-
-fn pog_value_function(scalar_type: model.ScalarType) -> String {
-  case scalar_type {
-    model.IntType -> "int"
-    model.FloatType -> "float"
-    model.BoolType -> "bool"
-    model.StringType -> "text"
-    model.BytesType -> "bytea"
-    model.DateTimeType
-    | model.DateType
-    | model.TimeType
-    | model.UuidType
-    | model.JsonType
-    | model.EnumType(_) -> "text"
-  }
-}
-
-fn pog_decoder_function(scalar_type: model.ScalarType) -> String {
-  case scalar_type {
-    model.IntType -> "decode.int"
-    model.FloatType -> "decode.float"
-    model.BoolType -> "decode.bool"
-    model.StringType -> "decode.string"
-    model.BytesType -> "decode.bit_array"
-    model.DateTimeType
-    | model.DateType
-    | model.TimeType
-    | model.UuidType
-    | model.JsonType
-    | model.EnumType(_) -> "decode.string"
-  }
 }
 
 fn render_pog_one_result() -> List(String) {
@@ -744,7 +713,8 @@ fn render_sqlight_params(
       <> {
         params
         |> list.map(fn(param) {
-          let value_fn = sqlight_value_function(param.scalar_type)
+          let value_fn =
+            model.scalar_type_to_value_function(model.SQLite, param.scalar_type)
           case param.nullable {
             False -> "sqlight." <> value_fn <> "(p." <> param.field_name <> ")"
             True ->
@@ -758,39 +728,6 @@ fn render_sqlight_params(
         |> string.join(", ")
       }
       <> "]"
-  }
-}
-
-fn sqlight_value_function(scalar_type: model.ScalarType) -> String {
-  case scalar_type {
-    model.IntType -> "int"
-    model.FloatType -> "float"
-    model.BoolType -> "bool"
-    model.StringType -> "text"
-    model.BytesType -> "blob"
-    model.DateTimeType
-    | model.DateType
-    | model.TimeType
-    | model.UuidType
-    | model.JsonType
-    | model.EnumType(_) -> "text"
-  }
-}
-
-fn sqlight_decoder_function(scalar_type: model.ScalarType) -> String {
-  case scalar_type {
-    model.IntType -> "decode.int"
-    model.FloatType -> "decode.float"
-    model.BoolType ->
-      "decode.then(decode.int, fn(v) { decode.success(v != 0) })"
-    model.StringType -> "decode.string"
-    model.BytesType -> "decode.bit_array"
-    model.DateTimeType
-    | model.DateType
-    | model.TimeType
-    | model.UuidType
-    | model.JsonType
-    | model.EnumType(_) -> "decode.string"
   }
 }
 

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -213,7 +213,7 @@ fn find_type_override(
   scalar_type: model.ScalarType,
   overrides: List(model.TypeOverride),
 ) -> Result(String, Nil) {
-  let type_name = scalar_type_name(scalar_type)
+  let type_name = model.scalar_type_to_db_name(scalar_type)
 
   list.find_map(overrides, fn(ovr) {
     case string.lowercase(ovr.db_type) == type_name {
@@ -221,22 +221,6 @@ fn find_type_override(
       False -> Error(Nil)
     }
   })
-}
-
-fn scalar_type_name(scalar_type: model.ScalarType) -> String {
-  case scalar_type {
-    model.IntType -> "int"
-    model.FloatType -> "float"
-    model.BoolType -> "bool"
-    model.StringType -> "string"
-    model.BytesType -> "bytes"
-    model.DateTimeType -> "datetime"
-    model.DateType -> "date"
-    model.TimeType -> "time"
-    model.UuidType -> "uuid"
-    model.JsonType -> "json"
-    model.EnumType(name) -> name
-  }
 }
 
 fn gleam_type_to_scalar(gleam_type: String) -> model.ScalarType {

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -179,6 +179,57 @@ pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
   }
 }
 
+pub fn scalar_type_to_db_name(scalar_type: ScalarType) -> String {
+  case scalar_type {
+    IntType -> "int"
+    FloatType -> "float"
+    BoolType -> "bool"
+    StringType -> "string"
+    BytesType -> "bytes"
+    DateTimeType -> "datetime"
+    DateType -> "date"
+    TimeType -> "time"
+    UuidType -> "uuid"
+    JsonType -> "json"
+    EnumType(name) -> name
+  }
+}
+
+pub fn scalar_type_to_value_function(
+  engine: Engine,
+  scalar_type: ScalarType,
+) -> String {
+  case scalar_type {
+    IntType -> "int"
+    FloatType -> "float"
+    BoolType -> "bool"
+    StringType -> "text"
+    BytesType ->
+      case engine {
+        PostgreSQL -> "bytea"
+        SQLite | MySQL -> "blob"
+      }
+    DateTimeType | DateType | TimeType | UuidType | JsonType | EnumType(_) ->
+      "text"
+  }
+}
+
+pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String {
+  case scalar_type {
+    IntType -> "decode.int"
+    FloatType -> "decode.float"
+    BoolType ->
+      case engine {
+        SQLite -> "decode.then(decode.int, fn(v) { decode.success(v != 0) })"
+        PostgreSQL | MySQL -> "decode.bool"
+      }
+    StringType -> "decode.string"
+    BytesType -> "decode.bit_array"
+    DateTimeType | DateType | TimeType | UuidType | JsonType | EnumType(_) ->
+      "decode.string"
+  }
+}
+
 pub type Column {
   Column(name: String, scalar_type: ScalarType, nullable: Bool)
 }


### PR DESCRIPTION
## Summary

Consolidate duplicated scalar type conversion logic into shared functions in `model.gleam`, eliminating ~30 lines of duplication across `codegen.gleam` and `generate.gleam`.

## Changes

- `src/sqlode/model.gleam`: Add three shared mapping functions:
  - `scalar_type_to_db_name`: Maps ScalarType to lowercase DB type name (used for config type override matching)
  - `scalar_type_to_value_function(engine, scalar_type)`: Maps ScalarType to engine-specific value function name (e.g., `"bytea"` for pog, `"blob"` for sqlight)
  - `scalar_type_to_decoder(engine, scalar_type)`: Maps ScalarType to engine-specific decoder expression (e.g., `"decode.bool"` for pog, SQLite-specific int-to-bool conversion)
- `src/sqlode/codegen.gleam`: Remove `pog_value_function`, `pog_decoder_function`, `sqlight_value_function`, `sqlight_decoder_function` (4 functions, ~60 lines). Replace with calls to `model.scalar_type_to_value_function` and `model.scalar_type_to_decoder`.
- `src/sqlode/generate.gleam`: Remove `scalar_type_name` (~15 lines). Replace with `model.scalar_type_to_db_name`.

## Design Decisions

- The shared functions take `Engine` as a parameter to handle engine-specific differences (BytesType → "bytea"/"blob", BoolType decoder). This keeps the mapping centralized while preserving correctness.
- Placed in `model.gleam` alongside existing `scalar_type_to_gleam_type` and `scalar_type_to_runtime_function` for consistency.
- Net reduction: 60 insertions, 88 deletions (-28 lines).

Closes #56