### PR TITLE
feat(overrides): add column-level type overrides with table.column targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,20 @@ sql:
       types:
         - db_type: "uuid"
           gleam_type: "String"
+        - column: "users.id"
+          gleam_type: "String"
       renames:
         - table: "authors"
           column: "bio"
           rename_to: "biography"
 ```
+
+Type overrides support two targeting modes:
+
+- **`db_type`**: Overrides all columns of a given database type (e.g., all `uuid` columns become `String`)
+- **`column`**: Overrides a specific column using `table.column` format (e.g., only `users.id` becomes `String`)
+
+Column-level overrides take precedence over `db_type` overrides.
 
 ## CLI
 

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -2,6 +2,7 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
+import gleam/string
 import simplifile
 import sqlode/model
 import yay
@@ -137,13 +138,23 @@ fn parse_overrides(node: yay.Node) -> model.Overrides {
       {
         Ok(yay.NodeSeq(items)) ->
           list.filter_map(items, fn(item) {
-            case
-              optional_string(item, "db_type"),
-              optional_string(item, "gleam_type")
-            {
-              Some(db_type), Some(gleam_type) ->
-                Ok(model.TypeOverride(db_type:, gleam_type:))
-              _, _ -> Error(Nil)
+            let gleam_type = optional_string(item, "gleam_type")
+            let db_type = optional_string(item, "db_type")
+            let column = optional_string(item, "column")
+            case column, db_type, gleam_type {
+              Some(col), _, Some(gt) ->
+                case string.split(col, ".") {
+                  [table, col_name] ->
+                    Ok(model.ColumnOverride(
+                      table:,
+                      column: col_name,
+                      gleam_type: gt,
+                    ))
+                  _ -> Error(Nil)
+                }
+              _, Some(dt), Some(gt) ->
+                Ok(model.DbTypeOverride(db_type: dt, gleam_type: gt))
+              _, _, _ -> Error(Nil)
             }
           })
         _ -> []

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -193,13 +193,21 @@ fn apply_type_overrides(
         list.map(catalog.tables, fn(table) {
           let columns =
             list.map(table.columns, fn(col) {
-              case find_type_override(col.scalar_type, overrides) {
+              case find_column_override(table.name, col.name, overrides) {
                 Ok(gleam_type) ->
                   model.Column(
                     ..col,
                     scalar_type: gleam_type_to_scalar(gleam_type),
                   )
-                Error(_) -> col
+                Error(_) ->
+                  case find_db_type_override(col.scalar_type, overrides) {
+                    Ok(gleam_type) ->
+                      model.Column(
+                        ..col,
+                        scalar_type: gleam_type_to_scalar(gleam_type),
+                      )
+                    Error(_) -> col
+                  }
               }
             })
           model.Table(..table, columns:)
@@ -209,16 +217,40 @@ fn apply_type_overrides(
   }
 }
 
-fn find_type_override(
+fn find_column_override(
+  table_name: String,
+  column_name: String,
+  overrides: List(model.TypeOverride),
+) -> Result(String, Nil) {
+  list.find_map(overrides, fn(ovr) {
+    case ovr {
+      model.ColumnOverride(table:, column:, gleam_type:) ->
+        case
+          string.lowercase(table) == string.lowercase(table_name)
+          && string.lowercase(column) == string.lowercase(column_name)
+        {
+          True -> Ok(gleam_type)
+          False -> Error(Nil)
+        }
+      model.DbTypeOverride(..) -> Error(Nil)
+    }
+  })
+}
+
+fn find_db_type_override(
   scalar_type: model.ScalarType,
   overrides: List(model.TypeOverride),
 ) -> Result(String, Nil) {
   let type_name = model.scalar_type_to_db_name(scalar_type)
 
   list.find_map(overrides, fn(ovr) {
-    case string.lowercase(ovr.db_type) == type_name {
-      True -> Ok(ovr.gleam_type)
-      False -> Error(Nil)
+    case ovr {
+      model.DbTypeOverride(db_type:, gleam_type:) ->
+        case string.lowercase(db_type) == type_name {
+          True -> Ok(gleam_type)
+          False -> Error(Nil)
+        }
+      model.ColumnOverride(..) -> Error(Nil)
     }
   })
 }

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -47,7 +47,8 @@ pub fn runtime_to_string(runtime: Runtime) -> String {
 }
 
 pub type TypeOverride {
-  TypeOverride(db_type: String, gleam_type: String)
+  DbTypeOverride(db_type: String, gleam_type: String)
+  ColumnOverride(table: String, column: String, gleam_type: String)
 }
 
 pub type ColumnRename {

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -42,7 +42,7 @@ pub fn type_override_changes_scalar_type_test() {
     base_block(
       model.Overrides(
         type_overrides: [
-          model.TypeOverride(db_type: "string", gleam_type: "Int"),
+          model.DbTypeOverride(db_type: "string", gleam_type: "Int"),
         ],
         column_renames: [],
       ),
@@ -63,7 +63,7 @@ pub fn type_override_case_insensitive_db_type_test() {
     base_block(
       model.Overrides(
         type_overrides: [
-          model.TypeOverride(db_type: "STRING", gleam_type: "Float"),
+          model.DbTypeOverride(db_type: "STRING", gleam_type: "Float"),
         ],
         column_renames: [],
       ),
@@ -83,7 +83,7 @@ pub fn type_override_preserves_unmatched_columns_test() {
     base_block(
       model.Overrides(
         type_overrides: [
-          model.TypeOverride(db_type: "bool", gleam_type: "String"),
+          model.DbTypeOverride(db_type: "bool", gleam_type: "String"),
         ],
         column_renames: [],
       ),
@@ -105,8 +105,8 @@ pub fn type_override_multiple_overrides_test() {
     base_block(
       model.Overrides(
         type_overrides: [
-          model.TypeOverride(db_type: "int", gleam_type: "String"),
-          model.TypeOverride(db_type: "string", gleam_type: "BitArray"),
+          model.DbTypeOverride(db_type: "int", gleam_type: "String"),
+          model.DbTypeOverride(db_type: "string", gleam_type: "BitArray"),
         ],
         column_renames: [],
       ),
@@ -210,7 +210,7 @@ pub fn combined_type_override_and_column_rename_test() {
     base_block(
       model.Overrides(
         type_overrides: [
-          model.TypeOverride(db_type: "string", gleam_type: "BitArray"),
+          model.DbTypeOverride(db_type: "string", gleam_type: "BitArray"),
         ],
         column_renames: [
           model.ColumnRename(
@@ -227,6 +227,84 @@ pub fn combined_type_override_and_column_rename_test() {
 
   // Both override and rename should apply
   string.contains(models, "display_name: BitArray") |> should.be_true()
+
+  cleanup()
+}
+
+// --- Column-level type override tests ---
+
+pub fn column_override_changes_specific_column_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.ColumnOverride(
+            table: "authors",
+            column: "id",
+            gleam_type: "String",
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // id column should be overridden to String
+  string.contains(models, "id: String") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn column_override_takes_precedence_over_db_type_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(db_type: "int", gleam_type: "Float"),
+          model.ColumnOverride(
+            table: "authors",
+            column: "id",
+            gleam_type: "String",
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Column override (String) should win over db_type override (Float)
+  string.contains(models, "id: String") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn column_override_does_not_affect_other_tables_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.ColumnOverride(
+            table: "posts",
+            column: "id",
+            gleam_type: "String",
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Override for posts.id should not affect authors.id
+  string.contains(models, "id: Int") |> should.be_true()
 
   cleanup()
 }

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -175,6 +175,18 @@ pub fn combined_type_override_and_column_rename_test() {
   generate_test.combined_type_override_and_column_rename_test()
 }
 
+pub fn column_override_changes_specific_column_test() {
+  generate_test.column_override_changes_specific_column_test()
+}
+
+pub fn column_override_takes_precedence_over_db_type_test() {
+  generate_test.column_override_takes_precedence_over_db_type_test()
+}
+
+pub fn column_override_does_not_affect_other_tables_test() {
+  generate_test.column_override_does_not_affect_other_tables_test()
+}
+
 pub fn all_commands_generate_queries_test() {
   generate_test.all_commands_generate_queries_test()
 }


### PR DESCRIPTION
## Summary

Add column-level type overrides that target specific `table.column` pairs, matching sqlc's override behavior. Column-level overrides take precedence over `db_type` overrides.

## Changes

- `src/sqlode/model.gleam`: Split `TypeOverride` into two variants:
  - `DbTypeOverride(db_type, gleam_type)` — overrides all columns of a given DB type
  - `ColumnOverride(table, column, gleam_type)` — overrides a specific table.column
- `src/sqlode/config.gleam`: Parse `column` field in overrides types section. Format: `"table.column"`. When both `column` and `db_type` are present, `column` takes precedence.
- `src/sqlode/generate.gleam`: Split `find_type_override` into `find_column_override` and `find_db_type_override`. Column overrides are checked first (higher priority).
- `test/generate_test.gleam`: Add 3 tests:
  - Column override changes a specific column's type
  - Column override takes precedence over db_type override
  - Column override for a different table does not affect unrelated tables
- `test/sqlode_test.gleam`: Register 3 new tests
- `README.md`: Document column-level overrides with example

## Design Decisions

- Column overrides use `"table.column"` string format (matching sqlc convention) rather than separate `table` and `column` fields. This is parsed by splitting on `.`.
- Precedence: column override > db_type override > schema-inferred type. This matches sqlc behavior.
- Case-insensitive matching for both table and column names.

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for column-level type overrides in addition to database-type overrides
  * Column-level overrides now take precedence over database-type overrides when both apply

* **Tests**
  * Added comprehensive test coverage for column-level override functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->