### PR TITLE
feat(analyzer): support UNION/INTERSECT/EXCEPT in result column inference

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -641,7 +641,9 @@ fn infer_result_columns(
           }
         }
         None -> {
-          let main_sql = strip_cte(ctx, normalized)
+          let main_sql =
+            strip_cte(ctx, normalized)
+            |> strip_compound
           let table_names = extract_table_names(ctx, main_sql)
 
           case table_names {
@@ -681,6 +683,22 @@ fn strip_cte(ctx: AnalyzerContext, sql: String) -> String {
         [] -> sql
       }
     }
+  }
+}
+
+fn strip_compound(sql: String) -> String {
+  let keywords = [" union all ", " union ", " intersect ", " except "]
+  strip_first_compound(sql, keywords)
+}
+
+fn strip_first_compound(sql: String, keywords: List(String)) -> String {
+  case keywords {
+    [] -> sql
+    [keyword, ..rest] ->
+      case string.split_once(sql, keyword) {
+        Ok(#(before, _)) -> before |> string.trim
+        Error(_) -> strip_first_compound(sql, rest)
+      }
   }
 }
 

--- a/test/fixtures/compound_query.sql
+++ b/test/fixtures/compound_query.sql
@@ -1,0 +1,19 @@
+-- name: GetAllItems :many
+SELECT id, name, price FROM products
+UNION ALL
+SELECT id, name, price FROM services;
+
+-- name: GetUniqueNames :many
+SELECT name FROM products
+UNION
+SELECT name FROM services;
+
+-- name: GetProductOnly :many
+SELECT id, name FROM products
+INTERSECT
+SELECT id, name FROM services;
+
+-- name: GetExclusiveProducts :many
+SELECT id, name FROM products
+EXCEPT
+SELECT id, name FROM services;

--- a/test/fixtures/compound_schema.sql
+++ b/test/fixtures/compound_schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE products (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  price REAL NOT NULL
+);
+
+CREATE TABLE services (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  price REAL NOT NULL
+);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -633,3 +633,80 @@ pub fn run_with_no_queries_in_file_test() {
   }
   cleanup()
 }
+
+// --- UNION/INTERSECT/EXCEPT tests ---
+
+const compound_out = "test_output/generate_test_compound"
+
+fn compound_block() -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.SQLite,
+    schema: ["test/fixtures/compound_schema.sql"],
+    queries: ["test/fixtures/compound_query.sql"],
+    gleam: model.GleamOutput(
+      package: "db",
+      out: compound_out,
+      runtime: model.Raw,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+fn cleanup_compound() {
+  let _ = simplifile.delete(compound_out)
+  Nil
+}
+
+pub fn union_all_infers_columns_from_first_select_test() {
+  cleanup_compound()
+  let cfg = model.Config(version: 2, sql: [compound_block()])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(compound_out <> "/models.gleam")
+
+  // GetAllItems should have columns from the first SELECT (products table)
+  string.contains(models, "GetAllItemsRow") |> should.be_true()
+  string.contains(models, "id: Int") |> should.be_true()
+  string.contains(models, "name: String") |> should.be_true()
+  string.contains(models, "price: Float") |> should.be_true()
+
+  cleanup_compound()
+}
+
+pub fn union_infers_columns_test() {
+  cleanup_compound()
+  let cfg = model.Config(version: 2, sql: [compound_block()])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(compound_out <> "/models.gleam")
+
+  // GetUniqueNames should have the single column from first SELECT
+  string.contains(models, "GetUniqueNamesRow") |> should.be_true()
+
+  cleanup_compound()
+}
+
+pub fn intersect_infers_columns_test() {
+  cleanup_compound()
+  let cfg = model.Config(version: 2, sql: [compound_block()])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(compound_out <> "/models.gleam")
+
+  string.contains(models, "GetProductOnlyRow") |> should.be_true()
+
+  cleanup_compound()
+}
+
+pub fn except_infers_columns_test() {
+  cleanup_compound()
+  let cfg = model.Config(version: 2, sql: [compound_block()])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(compound_out <> "/models.gleam")
+
+  string.contains(models, "GetExclusiveProductsRow") |> should.be_true()
+
+  cleanup_compound()
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -262,3 +262,21 @@ pub fn run_with_missing_query_file_test() {
 pub fn run_with_no_queries_in_file_test() {
   generate_test.run_with_no_queries_in_file_test()
 }
+
+// --- UNION/INTERSECT/EXCEPT tests ---
+
+pub fn union_all_infers_columns_from_first_select_test() {
+  generate_test.union_all_infers_columns_from_first_select_test()
+}
+
+pub fn union_infers_columns_test() {
+  generate_test.union_infers_columns_test()
+}
+
+pub fn intersect_infers_columns_test() {
+  generate_test.intersect_infers_columns_test()
+}
+
+pub fn except_infers_columns_test() {
+  generate_test.except_infers_columns_test()
+}


### PR DESCRIPTION
## Summary

Add support for compound queries (UNION, UNION ALL, INTERSECT, EXCEPT) in result column type inference. Previously these queries could fail to infer column types correctly. Now sqlode strips the compound operator and subsequent SELECTs, inferring types from the first SELECT clause only (matching sqlc behavior).

## Changes

- `src/sqlode/query_analyzer.gleam`:
  - Add `strip_compound` and `strip_first_compound` functions that remove everything after UNION/INTERSECT/EXCEPT keywords from normalized SQL
  - Apply `strip_compound` after `strip_cte` in `infer_result_columns`
- `test/fixtures/compound_schema.sql`: New fixture with `products` and `services` tables
- `test/fixtures/compound_query.sql`: New fixture with 4 compound queries (UNION ALL, UNION, INTERSECT, EXCEPT)
- `test/generate_test.gleam`: Add 4 E2E tests verifying row types are generated for all compound query types
- `test/sqlode_test.gleam`: Register 4 new tests

## Design Decisions

- Types are inferred from the first SELECT only, matching SQL standard semantics (UNION requires compatible column types across all SELECTs, so the first is representative).
- `strip_compound` is applied after `strip_cte` so CTEs with UNION inside them are handled correctly.
- Detection uses simple string splitting on normalized (lowercased, whitespace-collapsed) SQL. `" union all "` is checked before `" union "` to avoid partial matching.

Closes #76