### PR TITLE
feat(schema): add SQL VIEW support in schema parser

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -59,7 +59,11 @@ fn parse_content(
   use tables <- result.try(
     statements
     |> list.try_fold([], fn(tables, statement) {
-      use maybe_table <- result.try(parse_statement(statement, all_enums))
+      use maybe_table <- result.try(parse_statement(
+        statement,
+        all_enums,
+        list.reverse(tables),
+      ))
       Ok(case maybe_table {
         Some(table) -> [table, ..tables]
         None -> tables
@@ -101,13 +105,126 @@ fn parse_create_enum(statement: String) -> Result(model.EnumDef, Nil) {
 fn parse_statement(
   statement: String,
   enums: List(model.EnumDef),
+  tables: List(model.Table),
 ) -> Result(Option(model.Table), ParseError) {
   let lowered = string.lowercase(statement)
 
   case string.starts_with(lowered, "create table") {
-    False -> Ok(None)
     True -> parse_create_table(statement, enums)
+    False ->
+      case
+        string.starts_with(lowered, "create view")
+        || string.starts_with(lowered, "create or replace view")
+      {
+        True -> Ok(parse_create_view(statement, tables))
+        False -> Ok(None)
+      }
   }
+}
+
+fn parse_create_view(
+  statement: String,
+  tables: List(model.Table),
+) -> Option(model.Table) {
+  let lowered =
+    statement
+    |> string.lowercase
+    |> string.replace("\n", " ")
+    |> string.replace("\r", " ")
+    |> string.replace("\t", " ")
+
+  // Extract view name: CREATE [OR REPLACE] VIEW <name> AS ...
+  case string.split_once(lowered, " as ") {
+    Error(_) -> None
+    Ok(#(header, select_part)) -> {
+      let view_name =
+        header
+        |> string.replace("create or replace view", "")
+        |> string.replace("create view", "")
+        |> string.trim
+        |> naming.normalize_identifier
+
+      // Extract column names from the SELECT clause
+      case string.split_once(select_part, " from ") {
+        Error(_) -> None
+        Ok(#(select_cols_text, from_part)) -> {
+          let select_cols =
+            select_cols_text
+            |> string.replace("select", "")
+            |> string.trim
+
+          // Extract the first table name from FROM clause
+          let source_table =
+            from_part
+            |> string.split(" ")
+            |> list.map(string.trim)
+            |> list.filter(fn(t) { t != "" })
+            |> list.first
+            |> result.map(naming.normalize_identifier)
+
+          case select_cols, source_table {
+            "*", Ok(table_name) ->
+              case list.find(tables, fn(t) { t.name == table_name }) {
+                Ok(table) ->
+                  Some(model.Table(name: view_name, columns: table.columns))
+                Error(_) -> None
+              }
+            _, Ok(_) -> {
+              let col_names =
+                select_cols
+                |> string.split(",")
+                |> list.map(fn(c) {
+                  let trimmed = string.trim(c)
+                  // Handle aliases: "col AS alias" → use alias
+                  case string.split_once(trimmed, " as ") {
+                    Ok(#(_, alias)) -> string.trim(alias)
+                    Error(_) ->
+                      // Handle table.column → use column
+                      case string.split_once(trimmed, ".") {
+                        Ok(#(_, col)) -> string.trim(col)
+                        Error(_) -> trimmed
+                      }
+                  }
+                })
+
+              let columns =
+                list.filter_map(col_names, fn(col_name) {
+                  let normalized = naming.normalize_identifier(col_name)
+                  case find_column_in_tables(tables, normalized) {
+                    Some(col) -> Ok(model.Column(..col, name: normalized))
+                    None ->
+                      Ok(model.Column(
+                        name: normalized,
+                        scalar_type: model.StringType,
+                        nullable: True,
+                      ))
+                  }
+                })
+
+              case columns {
+                [] -> None
+                _ -> Some(model.Table(name: view_name, columns:))
+              }
+            }
+            _, _ -> None
+          }
+        }
+      }
+    }
+  }
+}
+
+fn find_column_in_tables(
+  tables: List(model.Table),
+  column_name: String,
+) -> Option(model.Column) {
+  list.find_map(tables, fn(table) {
+    list.find(table.columns, fn(col) {
+      string.lowercase(col.name) == string.lowercase(column_name)
+    })
+    |> result.map_error(fn(_) { Nil })
+  })
+  |> option.from_result
 }
 
 fn parse_create_table(

--- a/test/fixtures/view_query.sql
+++ b/test/fixtures/view_query.sql
@@ -1,0 +1,5 @@
+-- name: GetActiveAuthor :one
+SELECT id, name FROM active_authors WHERE id = ?1;
+
+-- name: ListFullAuthors :many
+SELECT id, name, bio FROM full_authors;

--- a/test/fixtures/view_schema.sql
+++ b/test/fixtures/view_schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  bio TEXT
+);
+
+CREATE VIEW active_authors AS
+SELECT id, name FROM authors;
+
+CREATE VIEW full_authors AS
+SELECT * FROM authors;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -710,3 +710,52 @@ pub fn except_infers_columns_test() {
 
   cleanup_compound()
 }
+
+// --- VIEW tests ---
+
+const view_out = "test_output/generate_test_view"
+
+fn view_block() -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.SQLite,
+    schema: ["test/fixtures/view_schema.sql"],
+    queries: ["test/fixtures/view_query.sql"],
+    gleam: model.GleamOutput(package: "db", out: view_out, runtime: model.Raw),
+    overrides: model.empty_overrides(),
+  )
+}
+
+fn cleanup_view() {
+  let _ = simplifile.delete(view_out)
+  Nil
+}
+
+pub fn view_select_columns_inferred_test() {
+  cleanup_view()
+  let cfg = model.Config(version: 2, sql: [view_block()])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(view_out <> "/models.gleam")
+
+  // Query referencing active_authors view should have typed columns
+  string.contains(models, "GetActiveAuthorRow") |> should.be_true()
+  string.contains(models, "id: Int") |> should.be_true()
+  string.contains(models, "name: String") |> should.be_true()
+
+  cleanup_view()
+}
+
+pub fn view_select_star_inferred_test() {
+  cleanup_view()
+  let cfg = model.Config(version: 2, sql: [view_block()])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(view_out <> "/models.gleam")
+
+  // Query referencing full_authors view (SELECT *) should have all columns
+  string.contains(models, "ListFullAuthorsRow") |> should.be_true()
+  string.contains(models, "bio: Option(String)") |> should.be_true()
+
+  cleanup_view()
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -280,3 +280,13 @@ pub fn intersect_infers_columns_test() {
 pub fn except_infers_columns_test() {
   generate_test.except_infers_columns_test()
 }
+
+// --- VIEW tests ---
+
+pub fn view_select_columns_inferred_test() {
+  generate_test.view_select_columns_inferred_test()
+}
+
+pub fn view_select_star_inferred_test() {
+  generate_test.view_select_star_inferred_test()
+}


### PR DESCRIPTION
## Summary

Add support for `CREATE VIEW` statements in the schema parser. Views are parsed as virtual tables in the catalog, allowing queries that reference views to correctly resolve column types.

## Changes

- `src/sqlode/schema_parser.gleam`:
  - `parse_statement` now detects `CREATE VIEW` and `CREATE OR REPLACE VIEW` statements
  - Add `parse_create_view` function that extracts view name and columns from the view definition
  - Supports `SELECT *` (inherits all columns from source table) and explicit column lists
  - Column types are resolved from existing tables in the catalog
  - Add `find_column_in_tables` helper for cross-table column lookup
- `test/fixtures/view_schema.sql`: New fixture with `authors` table and two views (`active_authors`, `full_authors`)
- `test/fixtures/view_query.sql`: New fixture with queries referencing views
- `test/generate_test.gleam`: Add 2 E2E tests:
  - View with explicit column list resolves types from source table
  - View with `SELECT *` inherits all columns including nullable ones
- `test/sqlode_test.gleam`: Register 2 new tests

## Design Decisions

- Views are stored as regular `Table` entries in the catalog. This means query_analyzer resolves view columns identically to table columns — no changes needed in the analyzer.
- View parsing requires tables to already exist in the catalog, so `parse_statement` receives the accumulated table list. This means views must be defined after their source tables in the schema file (standard SQL ordering).
- Column aliases (`col AS alias`) and table-qualified columns (`table.col`) in view definitions are handled by extracting the alias/column name.
- Columns not found in any table default to `StringType, nullable: True` rather than failing, since views may reference computed expressions.

## Limitations

- Complex view definitions (JOINs, subqueries, expressions) have limited type inference — unresolvable columns default to String type.
- Views referencing other views are supported only if the referenced view is defined earlier in the schema file.

Closes #74