### PR TITLE
feat(analyzer): support type cast expressions (::type) in query analysis

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -53,6 +53,7 @@ type AnalyzerContext {
     returning_re: regexp.Regexp,
     join_re: regexp.Regexp,
     select_columns_re: regexp.Regexp,
+    type_cast_re: regexp.Regexp,
   )
 }
 
@@ -88,6 +89,8 @@ fn new_analyzer_context(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     regexp.from_string("join\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s")
   let assert Ok(select_columns_re) =
     regexp.from_string("select\\s+(.+?)\\s+from\\s")
+  let assert Ok(type_cast_re) =
+    regexp.from_string("(\\$[0-9]+)::[a-zA-Z_][a-zA-Z0-9_]*")
 
   AnalyzerContext(
     naming: naming_ctx,
@@ -105,6 +108,7 @@ fn new_analyzer_context(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     returning_re:,
     join_re:,
     select_columns_re:,
+    type_cast_re:,
   )
 }
 
@@ -144,6 +148,7 @@ fn build_params(
       infer_equality_params(ctx, engine, query, catalog),
     )
 
+  let cast_dict = extract_type_casts(ctx, engine, query.sql)
   let macro_dict = build_macro_dict(query.macros)
   let inference_dict = build_inference_dict(inferences)
 
@@ -154,32 +159,36 @@ fn build_params(
     let inferred =
       dict.get(inference_dict, occurrence.index) |> option.from_result
 
-    let #(field_name, scalar_type, nullable, is_list) = case macro_info {
-      Some(model.SqlcArg(name:, ..)) -> {
-        let st = case inferred {
-          Some(column) -> column.scalar_type
+    let cast_type = dict.get(cast_dict, occurrence.index) |> option.from_result
+    let inferred_type = case inferred {
+      Some(column) -> column.scalar_type
+      None ->
+        case cast_type {
+          Some(st) -> st
           None -> model.StringType
         }
+    }
+
+    let #(field_name, scalar_type, nullable, is_list) = case macro_info {
+      Some(model.SqlcArg(name:, ..)) -> {
         let n = case inferred {
           Some(column) -> column.nullable
           None -> False
         }
-        #(naming.to_snake_case(ctx.naming, name), st, n, False)
+        #(naming.to_snake_case(ctx.naming, name), inferred_type, n, False)
       }
-      Some(model.SqlcNarg(name:, ..)) -> {
-        let st = case inferred {
-          Some(column) -> column.scalar_type
-          None -> model.StringType
-        }
-        #(naming.to_snake_case(ctx.naming, name), st, True, False)
-      }
-      Some(model.SqlcSlice(name:, ..)) -> {
-        let st = case inferred {
-          Some(column) -> column.scalar_type
-          None -> model.StringType
-        }
-        #(naming.to_snake_case(ctx.naming, name), st, False, True)
-      }
+      Some(model.SqlcNarg(name:, ..)) -> #(
+        naming.to_snake_case(ctx.naming, name),
+        inferred_type,
+        True,
+        False,
+      )
+      Some(model.SqlcSlice(name:, ..)) -> #(
+        naming.to_snake_case(ctx.naming, name),
+        inferred_type,
+        False,
+        True,
+      )
       None ->
         case inferred {
           Some(column) -> #(
@@ -188,7 +197,15 @@ fn build_params(
             column.nullable,
             False,
           )
-          None -> #(occurrence.default_name, model.StringType, False, False)
+          None -> #(
+            occurrence.default_name,
+            case cast_type {
+              Some(st) -> st
+              None -> model.StringType
+            },
+            False,
+            False,
+          )
         }
     }
 
@@ -240,6 +257,58 @@ fn build_inference_dict(
     let #(index, column) = entry
     dict.insert(d, index, column)
   })
+}
+
+fn extract_type_casts(
+  ctx: AnalyzerContext,
+  engine: model.Engine,
+  sql: String,
+) -> dict.Dict(Int, model.ScalarType) {
+  case engine {
+    model.PostgreSQL -> {
+      let normalized = normalize_sql(ctx, sql)
+      regexp.scan(ctx.type_cast_re, normalized)
+      |> list.filter_map(fn(match) {
+        case match.submatches {
+          [Some(placeholder)] -> {
+            let cast_type =
+              string.replace(match.content, placeholder <> "::", "")
+            case
+              placeholder
+              |> string.replace("$", "")
+              |> int.parse
+            {
+              Ok(index) -> Ok(#(index, cast_type_to_scalar(cast_type)))
+              Error(_) -> Error(Nil)
+            }
+          }
+          _ -> Error(Nil)
+        }
+      })
+      |> list.fold(dict.new(), fn(d, entry) {
+        let #(index, scalar_type) = entry
+        dict.insert(d, index, scalar_type)
+      })
+    }
+    _ -> dict.new()
+  }
+}
+
+fn cast_type_to_scalar(type_name: String) -> model.ScalarType {
+  let lowered = string.lowercase(string.trim(type_name))
+  case lowered {
+    "int" | "integer" | "bigint" | "smallint" | "serial" | "bigserial" ->
+      model.IntType
+    "float" | "double" | "real" | "numeric" | "decimal" -> model.FloatType
+    "bool" | "boolean" -> model.BoolType
+    "bytea" | "blob" | "binary" -> model.BytesType
+    "uuid" -> model.UuidType
+    "json" | "jsonb" -> model.JsonType
+    "timestamp" | "datetime" -> model.DateTimeType
+    "date" -> model.DateType
+    "time" | "timetz" -> model.TimeType
+    _ -> model.StringType
+  }
 }
 
 fn infer_insert_params(

--- a/test/fixtures/typecast_query.sql
+++ b/test/fixtures/typecast_query.sql
@@ -1,0 +1,5 @@
+-- name: GetUserByUuid :one
+SELECT id, name FROM users WHERE id = $1::int;
+
+-- name: CreateUserWithUuid :exec
+INSERT INTO users (name, metadata) VALUES ($1::text, $2::jsonb);

--- a/test/fixtures/typecast_schema.sql
+++ b/test/fixtures/typecast_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  metadata TEXT
+);

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -423,6 +423,43 @@ fn test_catalog() -> model.Catalog {
   catalog
 }
 
+pub fn type_cast_infers_param_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = typecast_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/typecast_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/typecast_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  // GetUserByUuid: $1::int should infer IntType
+  let assert [get_user, create_user] = analyzed
+  let assert [param] = get_user.params
+  param.scalar_type |> should.equal(model.IntType)
+
+  // CreateUserWithUuid: $2::jsonb should infer JsonType
+  let assert [_, param2] = create_user.params
+  param2.scalar_type |> should.equal(model.JsonType)
+}
+
+fn typecast_catalog() -> model.Catalog {
+  let assert Ok(content) = simplifile.read("test/fixtures/typecast_schema.sql")
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("test/fixtures/typecast_schema.sql", content)])
+
+  catalog
+}
+
 fn join_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/join_schema.sql")
   let assert Ok(catalog) =

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -95,6 +95,10 @@ pub fn parse_enum_column_type_test() {
   query_analyzer_test.parse_enum_column_type_test()
 }
 
+pub fn type_cast_infers_param_type_test() {
+  query_analyzer_test.type_cast_infers_param_type_test()
+}
+
 pub fn join_result_columns_test() {
   query_analyzer_test.join_result_columns_test()
 }


### PR DESCRIPTION
## Summary

Add support for PostgreSQL type cast expressions (`$1::int`, `$2::jsonb`, etc.) in parameter type inference. When a placeholder has an explicit type cast, that type is used instead of the default `StringType` fallback.

## Changes

- `src/sqlode/query_analyzer.gleam`:
  - Add `type_cast_re` regex to `AnalyzerContext` for detecting `$N::type` patterns
  - Add `extract_type_casts` function that scans SQL for type cast expressions and builds a `Dict(Int, ScalarType)` mapping placeholder index to cast type
  - Add `cast_type_to_scalar` function mapping SQL type names to ScalarType (int, float, bool, uuid, json, etc.)
  - Modify `build_params` to consult cast_dict when neither schema inference nor macro provides a type
- `test/fixtures/typecast_schema.sql`: New fixture with `users` table
- `test/fixtures/typecast_query.sql`: New fixture with `$1::int` and `$2::jsonb` casts
- `test/query_analyzer_test.gleam`: Add test verifying cast types are inferred correctly
- `test/sqlode_test.gleam`: Register new test

## Design Decisions

- Type casts are PostgreSQL-specific (`::type` syntax), so `extract_type_casts` returns an empty dict for MySQL and SQLite engines.
- Cast types serve as a fallback: schema-inferred types (from table column definitions) take precedence, then cast types, then the default `StringType`. This matches sqlc's behavior where explicit schema information is preferred.
- The `cast_type_to_scalar` mapping mirrors `schema_parser`'s `infer_scalar_type` but is kept separate to avoid making that function public.

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved parameter type inference: Query parameters with PostgreSQL-style type casts (e.g., `$1::int`, `$2::jsonb`) now have their types automatically inferred, enabling better type safety and validation for parameterized queries.

* **Tests**
  * Added comprehensive test coverage for type cast parameter inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->