### PR TITLE
feat(config): reject unsupported sqlc config options with clear error messages

### DIFF
--- a/doc/reference/specs/sqlc-compatibility.md
+++ b/doc/reference/specs/sqlc-compatibility.md
@@ -56,7 +56,7 @@ sql:
 | `database` | Not implemented (live DB analysis) |
 | `analyzer` | Not implemented |
 
-These options are accepted in the config model but have no effect.
+These options are **rejected** with an error if present in the config file. sqlode prefers early errors over silently ignoring unsupported configuration. Remove these fields from your config to proceed.
 
 ## Query annotations
 

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -13,6 +13,7 @@ pub type ConfigError {
   ParseError(detail: String)
   MissingField(field: String)
   InvalidValue(field: String, detail: String)
+  UnsupportedFields(fields: List(String), message: String)
 }
 
 pub fn load(path: String) -> Result(model.Config, ConfigError) {
@@ -44,6 +45,7 @@ pub fn load(path: String) -> Result(model.Config, ConfigError) {
 
   let root = yay.document_root(doc)
 
+  use _ <- result.try(check_unknown_keys(root, ["version", "sql"], ""))
   use version <- result.try(parse_version(root))
   use sql <- result.try(parse_sql_blocks(root))
 
@@ -92,6 +94,11 @@ fn parse_sql_blocks(root: yay.Node) -> Result(List(model.SqlBlock), ConfigError)
 }
 
 fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
+  use _ <- result.try(check_unknown_keys(
+    node,
+    ["name", "engine", "schema", "queries", "gen", "overrides"],
+    "sql.",
+  ))
   let name = optional_string(node, "name")
 
   use engine_text <- result.try(required_string(node, "engine"))
@@ -104,7 +111,14 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
 
   use schema <- result.try(required_string_list(node, "schema"))
   use queries <- result.try(required_string_list(node, "queries"))
-  use gleam_node <- result.try(require_node(node, "gen.gleam"))
+  use gen_node <- result.try(require_node(node, "gen"))
+  use _ <- result.try(check_unknown_keys(gen_node, ["gleam"], "sql.gen."))
+  use gleam_node <- result.try(require_node(gen_node, "gleam"))
+  use _ <- result.try(check_unknown_keys(
+    gleam_node,
+    ["package", "out", "runtime"],
+    "sql.gen.gleam.",
+  ))
   use package <- result.try(required_string(gleam_node, "package"))
   use out <- result.try(required_string(gleam_node, "out"))
 
@@ -184,6 +198,37 @@ fn parse_overrides(node: yay.Node) -> model.Overrides {
   }
 }
 
+fn check_unknown_keys(
+  node: yay.Node,
+  known_keys: List(String),
+  prefix: String,
+) -> Result(Nil, ConfigError) {
+  case node {
+    yay.NodeMap(pairs) -> {
+      let unknown =
+        list.filter_map(pairs, fn(pair) {
+          case pair.0 {
+            yay.NodeStr(key) ->
+              case list.contains(known_keys, key) {
+                True -> Error(Nil)
+                False -> Ok(prefix <> key)
+              }
+            _ -> Error(Nil)
+          }
+        })
+      case unknown {
+        [] -> Ok(Nil)
+        fields ->
+          Error(UnsupportedFields(
+            fields:,
+            message: "these sqlc options are not supported by sqlode; please remove them from your config",
+          ))
+      }
+    }
+    _ -> Ok(Nil)
+  }
+}
+
 fn required_string(
   node: yay.Node,
   selector: String,
@@ -258,6 +303,11 @@ pub fn error_to_string(error: ConfigError) -> String {
     MissingField(field:) -> "Missing required config field: " <> field
     InvalidValue(field:, detail:) ->
       "Invalid value for " <> field <> ": " <> detail
+    UnsupportedFields(fields:, message:) ->
+      "Unsupported config fields: "
+      <> string.join(fields, ", ")
+      <> " — "
+      <> message
   }
 }
 

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -61,6 +61,40 @@ pub fn invalid_engine_value_test() {
   string.contains(msg, "engine") |> should.be_true()
 }
 
+// Unsupported field rejection
+
+pub fn reject_unsupported_root_field_test() {
+  let assert Error(error) =
+    config.load("test/fixtures/unsupported_root_field.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "database") |> should.be_true()
+  string.contains(msg, "Unsupported") |> should.be_true()
+}
+
+pub fn reject_unsupported_sql_block_field_test() {
+  let assert Error(error) =
+    config.load("test/fixtures/unsupported_sql_field.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "emit_exact_table_names") |> should.be_true()
+  string.contains(msg, "Unsupported") |> should.be_true()
+}
+
+pub fn reject_unsupported_gen_gleam_field_test() {
+  let assert Error(error) =
+    config.load("test/fixtures/unsupported_gen_field.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "emit_json_tags") |> should.be_true()
+  string.contains(msg, "Unsupported") |> should.be_true()
+}
+
+pub fn reject_multiple_unsupported_root_fields_test() {
+  let assert Error(error) =
+    config.load("test/fixtures/unsupported_multiple_fields.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "database") |> should.be_true()
+  string.contains(msg, "analyzer") |> should.be_true()
+}
+
 // error_to_string coverage
 
 pub fn error_to_string_file_read_error_test() {
@@ -69,6 +103,15 @@ pub fn error_to_string_file_read_error_test() {
     detail: "permission denied",
   ))
   |> string.contains("foo.yaml")
+  |> should.be_true()
+}
+
+pub fn error_to_string_unsupported_fields_test() {
+  config.error_to_string(config.UnsupportedFields(
+    fields: ["database", "analyzer"],
+    message: "not supported by sqlode",
+  ))
+  |> string.contains("database")
   |> should.be_true()
 }
 

--- a/test/fixtures/unsupported_gen_field.yaml
+++ b/test/fixtures/unsupported_gen_field.yaml
@@ -1,0 +1,10 @@
+version: "2"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "test_output/db"
+        emit_json_tags: true

--- a/test/fixtures/unsupported_multiple_fields.yaml
+++ b/test/fixtures/unsupported_multiple_fields.yaml
@@ -1,0 +1,13 @@
+version: "2"
+database:
+  uri: "postgresql://localhost:5432/mydb"
+analyzer:
+  plugin: "py"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "test_output/db"

--- a/test/fixtures/unsupported_root_field.yaml
+++ b/test/fixtures/unsupported_root_field.yaml
@@ -1,0 +1,11 @@
+version: "2"
+database:
+  uri: "postgresql://localhost:5432/mydb"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "test_output/db"

--- a/test/fixtures/unsupported_sql_field.yaml
+++ b/test/fixtures/unsupported_sql_field.yaml
@@ -1,0 +1,10 @@
+version: "2"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    emit_exact_table_names: true
+    gen:
+      gleam:
+        package: "db"
+        out: "test_output/db"


### PR DESCRIPTION
## Summary

Reject unsupported sqlc config options (e.g., `database`, `analyzer`, `emit_exact_table_names`) with clear error messages instead of silently ignoring them. This prevents migration traps for sqlc users whose config files appear valid but have no effect.

## Changes

- `src/sqlode/config.gleam`: Add `UnsupportedFields` variant to `ConfigError` and `check_unknown_keys` helper that validates YAML map keys at root, sql block, gen, and gen.gleam levels
- `test/config_test.gleam`: Add 5 tests covering unsupported field rejection at each config level, multiple fields, and error message formatting
- `test/fixtures/unsupported_*.yaml`: Add 4 test fixtures for unsupported field scenarios
- `doc/reference/specs/sqlc-compatibility.md`: Update docs to reflect rejection behavior

## Design Decisions

- **Reject rather than warn**: Consistent with the project's early-error philosophy. Users must remove unsupported fields rather than wondering why they have no effect.
- **Report all unknown fields at once**: Rather than failing on the first unknown key, all unknown keys in a single map are collected and reported together to avoid fix-one-see-next loops.
- **Validate at 4 levels** (root, sql block, gen, gen.gleam): Catches unsupported fields at every nesting depth. The `gen` level check ensures unsupported language targets (e.g., `gen.python`) are also caught.

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation is now stricter—files containing unsupported fields (`emit_exact_table_names`, `emit_sql_as_comment`, `query_parameter_limit`, `database`, `analyzer`) will now generate errors instead of being silently ignored. Users must remove these unsupported fields from configuration files to successfully load and proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->