### PR TITLE
fix(analyzer): track source tables for result columns to fix rename bleed in JOINs

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -289,14 +289,9 @@ fn apply_column_renames(
     [] -> queries
     _ ->
       list.map(queries, fn(query) {
-        let sql_lowered = string.lowercase(query.base.sql)
-        let applicable_renames =
-          list.filter(renames, fn(r) {
-            string.contains(sql_lowered, string.lowercase(r.table))
-          })
         let result_columns =
           list.map(query.result_columns, fn(col) {
-            case find_column_rename(col.name, applicable_renames) {
+            case find_column_rename(col.name, col.source_table, renames) {
               Ok(new_name) -> model.ResultColumn(..col, name: new_name)
               Error(_) -> col
             }
@@ -308,10 +303,17 @@ fn apply_column_renames(
 
 fn find_column_rename(
   column_name: String,
+  source_table: option.Option(String),
   renames: List(model.ColumnRename),
 ) -> Result(String, Nil) {
   list.find_map(renames, fn(r) {
-    case string.lowercase(r.column) == string.lowercase(column_name) {
+    let column_matches =
+      string.lowercase(r.column) == string.lowercase(column_name)
+    let table_matches = case source_table {
+      option.Some(table) -> string.lowercase(r.table) == string.lowercase(table)
+      option.None -> False
+    }
+    case column_matches && table_matches {
       True -> Ok(r.rename_to)
       False -> Error(Nil)
     }

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -254,7 +254,12 @@ pub type QueryParam {
 }
 
 pub type ResultColumn {
-  ResultColumn(name: String, scalar_type: ScalarType, nullable: Bool)
+  ResultColumn(
+    name: String,
+    scalar_type: ScalarType,
+    nullable: Bool,
+    source_table: Option(String),
+  )
 }
 
 pub type AnalyzedQuery {

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -8,6 +8,10 @@ import sqlode/query_analyzer/context.{
   type AnalysisError, type AnalyzerContext, ColumnNotFound, TableNotFound,
 }
 
+type ExtractedColumn {
+  ExtractedColumn(name: String, source_table: Option(String))
+}
+
 pub fn infer_result_columns(
   ctx: AnalyzerContext,
   query: model.ParsedQuery,
@@ -98,14 +102,18 @@ fn strip_first_compound(sql: String, keywords: List(String)) -> String {
 fn extract_returning_columns(
   ctx: AnalyzerContext,
   sql: String,
-) -> Option(List(String)) {
+) -> Option(List(ExtractedColumn)) {
   case regexp.scan(ctx.returning_re, sql) {
     [match, ..] ->
       case match.submatches {
         [Some(columns_text)] -> {
           let cols = case string.trim(columns_text) == "*" {
-            True -> ["*"]
-            False -> context.split_csv(columns_text)
+            True -> [ExtractedColumn(name: "*", source_table: None)]
+            False ->
+              context.split_csv(columns_text)
+              |> list.map(fn(c) {
+                ExtractedColumn(name: string.trim(c), source_table: None)
+              })
           }
           Some(cols)
         }
@@ -135,37 +143,50 @@ fn extract_join_tables(ctx: AnalyzerContext, sql: String) -> List(String) {
   })
 }
 
-fn extract_select_columns(ctx: AnalyzerContext, sql: String) -> List(String) {
+fn extract_select_columns(
+  ctx: AnalyzerContext,
+  sql: String,
+) -> List(ExtractedColumn) {
   case regexp.scan(ctx.select_columns_re, sql) {
     [match, ..] ->
       case match.submatches {
         [Some(columns_text)] -> {
           case string.trim(columns_text) == "*" {
-            True -> ["*"]
+            True -> [ExtractedColumn(name: "*", source_table: None)]
             False ->
               columns_text
               |> context.split_csv
               |> list.map(fn(col) {
                 let trimmed = string.trim(col)
                 case string.starts_with(trimmed, "sqlc.embed(") {
-                  True -> trimmed
+                  True -> ExtractedColumn(name: trimmed, source_table: None)
                   False ->
                     case string.contains(trimmed, " as ") {
                       True -> {
-                        let assert Ok(#(_, alias)) =
+                        let assert Ok(#(expr, alias)) =
                           string.split_once(trimmed, " as ")
-                        string.trim(alias)
+                        let table = extract_table_qualifier(string.trim(expr))
+                        ExtractedColumn(
+                          name: string.trim(alias),
+                          source_table: table,
+                        )
                       }
                       False ->
                         case string.contains(trimmed, ".") {
                           True -> {
                             let parts = string.split(trimmed, ".")
-                            case list.last(parts) {
+                            let table = case parts {
+                              [t, _] -> Some(string.trim(t))
+                              _ -> None
+                            }
+                            let name = case list.last(parts) {
                               Ok(last) -> string.trim(last)
                               Error(_) -> trimmed
                             }
+                            ExtractedColumn(name:, source_table: table)
                           }
-                          False -> trimmed
+                          False ->
+                            ExtractedColumn(name: trimmed, source_table: None)
                         }
                     }
                 }
@@ -178,15 +199,28 @@ fn extract_select_columns(ctx: AnalyzerContext, sql: String) -> List(String) {
   }
 }
 
+fn extract_table_qualifier(expr: String) -> Option(String) {
+  case string.contains(expr, ".") {
+    True -> {
+      let parts = string.split(expr, ".")
+      case parts {
+        [table, _] -> Some(string.trim(table))
+        _ -> None
+      }
+    }
+    False -> None
+  }
+}
+
 fn resolve_select_columns(
   query_name: String,
-  columns: List(String),
+  columns: List(ExtractedColumn),
   catalog: model.Catalog,
   primary_table: String,
   all_tables: List(String),
 ) -> Result(List(model.ResultColumn), AnalysisError) {
   case columns {
-    ["*"] ->
+    [ExtractedColumn(name: "*", ..)] ->
       case
         catalog.tables
         |> list.find(fn(table) { table.name == primary_table })
@@ -198,14 +232,15 @@ fn resolve_select_columns(
                 name: col.name,
                 scalar_type: col.scalar_type,
                 nullable: col.nullable,
+                source_table: Some(primary_table),
               )
             }),
           )
         Error(_) -> Error(TableNotFound(query_name:, table_name: primary_table))
       }
     _ ->
-      list.try_map(columns, fn(col_name) {
-        let trimmed = string.trim(col_name)
+      list.try_map(columns, fn(extracted) {
+        let trimmed = string.trim(extracted.name)
         case string.starts_with(trimmed, "sqlc.embed(") {
           True -> {
             let embed_name =
@@ -226,6 +261,7 @@ fn resolve_select_columns(
                       name: col.name,
                       scalar_type: col.scalar_type,
                       nullable: col.nullable,
+                      source_table: Some(embed_name),
                     )
                   }),
                 )
@@ -235,21 +271,45 @@ fn resolve_select_columns(
           }
           False -> {
             let normalized_name = string.lowercase(trimmed)
-            case find_column_in_tables(catalog, all_tables, normalized_name) {
-              Some(column) ->
-                Ok([
-                  model.ResultColumn(
-                    name: column.name,
-                    scalar_type: column.scalar_type,
-                    nullable: column.nullable,
-                  ),
-                ])
+            case extracted.source_table {
+              Some(table) ->
+                case context.find_column(catalog, table, normalized_name) {
+                  Some(column) ->
+                    Ok([
+                      model.ResultColumn(
+                        name: column.name,
+                        scalar_type: column.scalar_type,
+                        nullable: column.nullable,
+                        source_table: Some(table),
+                      ),
+                    ])
+                  None ->
+                    Error(ColumnNotFound(
+                      query_name:,
+                      table_name: table,
+                      column_name: normalized_name,
+                    ))
+                }
               None ->
-                Error(ColumnNotFound(
-                  query_name:,
-                  table_name: primary_table,
-                  column_name: normalized_name,
-                ))
+                case
+                  find_column_in_tables(catalog, all_tables, normalized_name)
+                {
+                  Some(#(found_table, column)) ->
+                    Ok([
+                      model.ResultColumn(
+                        name: column.name,
+                        scalar_type: column.scalar_type,
+                        nullable: column.nullable,
+                        source_table: Some(found_table),
+                      ),
+                    ])
+                  None ->
+                    Error(ColumnNotFound(
+                      query_name:,
+                      table_name: primary_table,
+                      column_name: normalized_name,
+                    ))
+                }
             }
           }
         }
@@ -262,10 +322,10 @@ fn find_column_in_tables(
   catalog: model.Catalog,
   table_names: List(String),
   column_name: String,
-) -> Option(model.Column) {
+) -> Option(#(String, model.Column)) {
   list.find_map(table_names, fn(name) {
     case context.find_column(catalog, name, column_name) {
-      Some(col) -> Ok(col)
+      Some(col) -> Ok(#(name, col))
       None -> Error(Nil)
     }
   })

--- a/test/fixtures/join_rename_query.sql
+++ b/test/fixtures/join_rename_query.sql
@@ -1,0 +1,2 @@
+-- name: GetBookWithAuthorIds :one
+SELECT authors.id, books.id, books.title FROM books JOIN authors ON books.author_id = authors.id WHERE books.id = $1;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -255,6 +255,72 @@ pub fn combined_type_override_and_column_rename_test() {
   cleanup()
 }
 
+// --- JOIN column rename regression test (issue #84) ---
+
+const join_rename_out = "test_output/generate_test_join_rename"
+
+fn join_rename_block(renames: List(model.ColumnRename)) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.PostgreSQL,
+    schema: ["test/fixtures/join_schema.sql"],
+    queries: ["test/fixtures/join_rename_query.sql"],
+    gleam: model.GleamOutput(
+      package: "db",
+      out: join_rename_out,
+      runtime: model.Raw,
+    ),
+    overrides: model.Overrides(type_overrides: [], column_renames: renames),
+  )
+}
+
+fn cleanup_join_rename() {
+  let _ = simplifile.delete(join_rename_out)
+  Nil
+}
+
+pub fn join_rename_only_renames_matching_table_column_test() {
+  cleanup_join_rename()
+  let block =
+    join_rename_block([
+      model.ColumnRename(table: "authors", column: "id", rename_to: "author_id"),
+    ])
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(join_rename_out <> "/models.gleam")
+
+  // authors.id should be renamed to author_id
+  string.contains(models, "author_id: Int") |> should.be_true()
+  // books.id should remain as id (not renamed)
+  string.contains(models, "id: Int") |> should.be_true()
+  // title should be unaffected
+  string.contains(models, "title: String") |> should.be_true()
+
+  cleanup_join_rename()
+}
+
+pub fn join_rename_does_not_rename_wrong_table_column_test() {
+  cleanup_join_rename()
+  let block =
+    join_rename_block([
+      model.ColumnRename(table: "books", column: "id", rename_to: "book_id"),
+    ])
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(_) = generate.generate_config(cfg)
+
+  let assert Ok(models) = simplifile.read(join_rename_out <> "/models.gleam")
+
+  // books.id should be renamed to book_id
+  string.contains(models, "book_id: Int") |> should.be_true()
+  // authors.id should remain as id
+  string.contains(models, "id: Int") |> should.be_true()
+
+  cleanup_join_rename()
+}
+
 // --- Column-level type override tests ---
 
 pub fn column_override_changes_specific_column_test() {

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1,3 +1,4 @@
+import gleam/option.{Some}
 import gleeunit
 import gleeunit/should
 import simplifile
@@ -108,21 +109,33 @@ pub fn infer_result_columns_for_select_test() {
 
   get_author.result_columns
   |> should.equal([
-    model.ResultColumn(name: "id", scalar_type: model.IntType, nullable: False),
+    model.ResultColumn(
+      name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      source_table: Some("authors"),
+    ),
     model.ResultColumn(
       name: "name",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("authors"),
     ),
   ])
 
   list_authors.result_columns
   |> should.equal([
-    model.ResultColumn(name: "id", scalar_type: model.IntType, nullable: False),
+    model.ResultColumn(
+      name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      source_table: Some("authors"),
+    ),
     model.ResultColumn(
       name: "name",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("authors"),
     ),
   ])
 }
@@ -169,16 +182,23 @@ pub fn infer_result_columns_with_star_test() {
 
   get_all.result_columns
   |> should.equal([
-    model.ResultColumn(name: "id", scalar_type: model.IntType, nullable: False),
+    model.ResultColumn(
+      name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      source_table: Some("authors"),
+    ),
     model.ResultColumn(
       name: "name",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("authors"),
     ),
     model.ResultColumn(
       name: "bio",
       scalar_type: model.StringType,
       nullable: True,
+      source_table: Some("authors"),
     ),
   ])
 }
@@ -202,11 +222,17 @@ pub fn infer_result_columns_with_table_prefix_test() {
 
   get_author.result_columns
   |> should.equal([
-    model.ResultColumn(name: "id", scalar_type: model.IntType, nullable: False),
+    model.ResultColumn(
+      name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      source_table: Some("authors"),
+    ),
     model.ResultColumn(
       name: "name",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("authors"),
     ),
   ])
 }
@@ -329,11 +355,13 @@ pub fn join_result_columns_test() {
       name: "title",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("books"),
     ),
     model.ResultColumn(
       name: "name",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("authors"),
     ),
   ])
 }
@@ -383,11 +411,17 @@ pub fn returning_clause_result_columns_test() {
 
   query.result_columns
   |> should.equal([
-    model.ResultColumn(name: "id", scalar_type: model.IntType, nullable: False),
+    model.ResultColumn(
+      name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      source_table: Some("authors"),
+    ),
     model.ResultColumn(
       name: "name",
       scalar_type: model.StringType,
       nullable: False,
+      source_table: Some("authors"),
     ),
   ])
 }


### PR DESCRIPTION
## Summary

Fix column rename bleed in JOIN queries where renames for one table's column incorrectly applied to identically-named columns from other tables. The root cause was that `ResultColumn` had no source table metadata, so `apply_column_renames` relied on SQL substring matching to determine applicability.

## Changes

- `src/sqlode/model.gleam`: Add `source_table: Option(String)` field to `ResultColumn`
- `src/sqlode/query_analyzer/column_inferencer.gleam`: Introduce `ExtractedColumn` type to carry table qualifiers through column extraction, update `extract_select_columns` to preserve table prefixes, update `find_column_in_tables` to return which table matched, and propagate `source_table` into all `ResultColumn` construction sites
- `src/sqlode/generate.gleam`: Replace SQL substring-based rename matching with direct `source_table` comparison in `apply_column_renames` and `find_column_rename`
- `test/query_analyzer_test.gleam`: Update all `ResultColumn` assertions with expected `source_table` values
- `test/generate_test.gleam`: Add two regression tests for JOIN rename correctness
- `test/fixtures/join_rename_query.sql`: Test fixture for JOIN query with duplicate column names

## Design Decisions

- **`source_table` is `Option(String)`**: Columns from expressions or aggregates may not have a clear source table. For `SELECT *`, the primary table is used. For qualified names like `authors.id`, the qualifier is captured directly.
- **`ExtractedColumn` is private to column_inferencer**: It's an internal type for carrying table context through the extraction pipeline, not exposed in the public API.
- **`find_column_in_tables` returns `#(String, Column)` tuple**: When a column is found by searching all tables, the matched table name is preserved so it can be stored in `source_table`.

## Limitations

- Table aliases (e.g., `SELECT a.id FROM authors a`) are captured as-is (`a`), not resolved to the actual table name. Renames specifying the full table name won't match aliased references. This is a pre-existing limitation.

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Column renaming now correctly handles JOINs by matching both column name and source table, preventing unintended renames when multiple tables share the same column name.

* **Tests**
  * Added regression tests for JOIN-column renaming behavior to ensure accurate renaming in complex queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->