### PR TITLE
feat(codegen): preserve explicit gleam_type overrides instead of collapsing to primitive scalars

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -198,7 +198,10 @@ fn apply_type_overrides(
                 Ok(gleam_type) ->
                   model.Column(
                     ..col,
-                    scalar_type: gleam_type_to_scalar(gleam_type),
+                    scalar_type: gleam_type_to_scalar(
+                      gleam_type,
+                      col.scalar_type,
+                    ),
                   )
                 Error(_) ->
                   case
@@ -211,7 +214,10 @@ fn apply_type_overrides(
                     Ok(gleam_type) ->
                       model.Column(
                         ..col,
-                        scalar_type: gleam_type_to_scalar(gleam_type),
+                        scalar_type: gleam_type_to_scalar(
+                          gleam_type,
+                          col.scalar_type,
+                        ),
                       )
                     Error(_) -> col
                   }
@@ -271,13 +277,17 @@ fn find_db_type_override(
   })
 }
 
-fn gleam_type_to_scalar(gleam_type: String) -> model.ScalarType {
+fn gleam_type_to_scalar(
+  gleam_type: String,
+  underlying: model.ScalarType,
+) -> model.ScalarType {
   case string.lowercase(gleam_type) {
     "int" -> model.IntType
     "float" -> model.FloatType
     "bool" -> model.BoolType
+    "string" -> model.StringType
     "bitarray" -> model.BytesType
-    _ -> model.StringType
+    _ -> model.CustomType(name: gleam_type, underlying:)
   }
 }
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -150,6 +150,7 @@ pub type ScalarType {
   UuidType
   JsonType
   EnumType(name: String)
+  CustomType(name: String, underlying: ScalarType)
 }
 
 pub type EnumDef {
@@ -165,6 +166,7 @@ pub fn scalar_type_to_gleam_type(scalar_type: ScalarType) -> String {
     BytesType -> "BitArray"
     DateTimeType | DateType | TimeType | UuidType | JsonType -> "String"
     EnumType(_) -> "String"
+    CustomType(name, _) -> name
   }
 }
 
@@ -177,6 +179,7 @@ pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
     BytesType -> "runtime.bytes"
     DateTimeType | DateType | TimeType | UuidType | JsonType -> "runtime.string"
     EnumType(_) -> "runtime.string"
+    CustomType(_, underlying) -> scalar_type_to_runtime_function(underlying)
   }
 }
 
@@ -193,6 +196,7 @@ pub fn scalar_type_to_db_name(scalar_type: ScalarType) -> String {
     UuidType -> "uuid"
     JsonType -> "json"
     EnumType(name) -> name
+    CustomType(_, underlying) -> scalar_type_to_db_name(underlying)
   }
 }
 
@@ -212,6 +216,8 @@ pub fn scalar_type_to_value_function(
       }
     DateTimeType | DateType | TimeType | UuidType | JsonType | EnumType(_) ->
       "text"
+    CustomType(_, underlying) ->
+      scalar_type_to_value_function(engine, underlying)
   }
 }
 
@@ -228,6 +234,7 @@ pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String
     BytesType -> "decode.bit_array"
     DateTimeType | DateType | TimeType | UuidType | JsonType | EnumType(_) ->
       "decode.string"
+    CustomType(_, underlying) -> scalar_type_to_decoder(engine, underlying)
   }
 }
 

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -142,6 +142,56 @@ pub fn type_override_multiple_overrides_test() {
   cleanup()
 }
 
+pub fn custom_type_override_preserves_type_name_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "UserId",
+            nullable: option.None,
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // id column is BIGSERIAL (IntType), override to UserId — should NOT become String
+  string.contains(models, "id: UserId") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn custom_column_override_preserves_type_name_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.ColumnOverride(
+            table: "authors",
+            column: "name",
+            gleam_type: "AuthorName",
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // name column should use the custom type name
+  string.contains(models, "name: AuthorName") |> should.be_true()
+
+  cleanup()
+}
+
 pub fn no_overrides_leaves_types_unchanged_test() {
   cleanup()
   let block = base_block(model.empty_overrides())

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -119,6 +119,19 @@ pub fn scalar_type_to_gleam_type_test() {
   model.scalar_type_to_gleam_type(model.JsonType) |> should.equal("String")
   model.scalar_type_to_gleam_type(model.EnumType("status"))
   |> should.equal("String")
+  model.scalar_type_to_gleam_type(model.CustomType("UserId", model.IntType))
+  |> should.equal("UserId")
+}
+
+pub fn custom_type_delegates_to_underlying_test() {
+  let custom = model.CustomType("UserId", model.IntType)
+  model.scalar_type_to_runtime_function(custom)
+  |> should.equal("runtime.int")
+  model.scalar_type_to_db_name(custom) |> should.equal("int")
+  model.scalar_type_to_value_function(model.PostgreSQL, custom)
+  |> should.equal("int")
+  model.scalar_type_to_decoder(model.PostgreSQL, custom)
+  |> should.equal("decode.int")
 }
 
 // scalar_type_to_runtime_function tests


### PR DESCRIPTION
## Summary

Fix type override handling so that custom `gleam_type` values (e.g., `UserId`, `AuthorName`) are preserved in generated code instead of being silently collapsed to `String`. Previously, `gleam_type_to_scalar` only recognized `Int`, `Float`, `Bool`, and `BitArray` — everything else fell through to `StringType`.

## Changes

- `src/sqlode/model.gleam`: Add `CustomType(name: String, underlying: ScalarType)` variant to `ScalarType`. All `scalar_type_to_*` functions delegate to the underlying type for runtime/decoder/value selection while using the custom name for type output.
- `src/sqlode/generate.gleam`: Update `gleam_type_to_scalar` to accept the original `ScalarType` as underlying and create `CustomType` for unrecognized type names instead of defaulting to `StringType`. Also recognize `"string"` as a primitive.
- `test/model_test.gleam`: Add tests for `CustomType` delegation to underlying type across all conversion functions.
- `test/generate_test.gleam`: Add tests verifying custom db_type and column overrides produce the specified type name in generated models.

## Design Decisions

- **`CustomType` wraps an underlying `ScalarType`**: This preserves the user-specified type name for codegen output while delegating to the underlying scalar for runtime functions, decoders, and value functions. This avoids changes to `Column`, `QueryParam`, and `ResultColumn` types.
- **The underlying type is the column's original scalar type**: When a user overrides `int` to `UserId`, the underlying remains `IntType`, so the correct `runtime.int` / `decode.int` functions are used.

## Limitations

- Custom types in adapter mode still use the underlying scalar's encoder/decoder. Users who need custom encode/decode logic must handle that externally. This is a documented gap for a potential future enhancement.

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom scalar type names are now properly preserved when applying database type and column overrides instead of falling back to default mappings.

* **Tests**
  * Added test coverage for custom type override preservation with both database-level and column-level overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->