### PR TITLE
fix(codegen): generate executable SQL and parameter encoders for sqlc.slice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  verify:
+  build:
     name: Build and verify
     runs-on: ubuntu-latest
     steps:
@@ -48,15 +48,127 @@ jobs:
       - name: ShellSpec tests
         run: shellspec
 
+      - name: Integration tests
+        run: bash integration_test/run.sh
+
+      - name: Build escript binary
+        run: gleam run -m gleescript
+
+      - name: Smoke-test built escript
+        run: bash scripts/smoke_escript.sh ./sqlode
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlode
+          path: sqlode
+
+  publish:
+    name: Publish to Hex
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+
+      - name: Install rebar3
+        run: |
+          wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
+          chmod +x /usr/local/bin/rebar3
+
+      - name: Download dependencies
+        run: gleam deps download
+
+      - name: Build package
+        run: gleam build
+
+      - name: Publish to Hex
+        run: gleam publish -y
+        env:
+          HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: verify
+    needs: build
     steps:
-      - name: Create Release
-        uses: softprops/action-gh-release@v3
+      - name: Checkout code
+        uses: actions/checkout@v6
         with:
-          generate_release_notes: true
+          fetch-depth: 0
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sqlode
+          path: .
+
+      - name: Make binary executable
+        run: chmod +x sqlode
+
+      - name: Extract tag name
+        id: tag
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          TAG="${{ steps.tag.outputs.TAG_NAME }}"
+          TAG_WITHOUT_V="${TAG#v}"
+          CHANGELOG_FILE="changelog_content.md"
+
+          awk -v ver="$TAG_WITHOUT_V" '
+            BEGIN { found = 0; }
+            $0 ~ "^#{2,3} \\[?" ver "\\]?" { found = 1; next; }
+            /^#{2,3} \[?[0-9]+\.[0-9]+\.[0-9]+\]?/ { if (found) exit; }
+            found { print; }
+          ' CHANGELOG.md > "$CHANGELOG_FILE"
+
+          if [ ! -s "$CHANGELOG_FILE" ]; then
+            awk -v ver="$TAG" '
+              BEGIN { found = 0; }
+              $0 ~ "^#{2,3} \\[?" ver "\\]?" { found = 1; next; }
+              /^#{2,3} \[?v?[0-9]+\.[0-9]+\.[0-9]+\]?/ { if (found) exit; }
+              found { print; }
+            ' CHANGELOG.md > "$CHANGELOG_FILE"
+          fi
+
+          if [ ! -s "$CHANGELOG_FILE" ]; then
+            echo "No changelog entry found for version $TAG" > "$CHANGELOG_FILE"
+            echo "" >> "$CHANGELOG_FILE"
+            echo "Please check CHANGELOG.md for updates." >> "$CHANGELOG_FILE"
+          fi
+
+          {
+            echo 'CHANGELOG_CONTENT<<EOF'
+            cat "$CHANGELOG_FILE"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.TAG_NAME }}
+          name: ${{ steps.tag.outputs.TAG_NAME }}
+          body: |
+            ${{ steps.changelog.outputs.CHANGELOG_CONTENT }}
+
+            ## Install
+
+            Download the `sqlode` escript below and place it on your PATH.
+            Requires Erlang/OTP runtime.
+
+            ```sh
+            chmod +x sqlode
+            ./sqlode generate --config=sqlode.yaml
+            ```
+          files: sqlode
           draft: false
+          prerelease: ${{ contains(steps.tag.outputs.TAG_NAME, '-alpha') || contains(steps.tag.outputs.TAG_NAME, '-beta') || contains(steps.tag.outputs.TAG_NAME, '-rc') }}
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gleam.toml
+++ b/gleam.toml
@@ -15,3 +15,4 @@ yay = ">= 2.0.0 and < 3.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+gleescript = ">= 1.5.2 and < 2.0.0"

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+PROJECT_ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+
+echo "=== Running integration tests ==="
+
+bash "$PROJECT_ROOT/integration_test/compile_test.sh"
+bash "$PROJECT_ROOT/integration_test/sqlite_test.sh"
+
+echo "=== Integration tests passed ==="

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,13 +6,17 @@ packages = [
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]
@@ -21,6 +25,7 @@ packages = [
 argv = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleescript = { version = ">= 1.5.2 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glint = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/scripts/smoke_escript.sh
+++ b/scripts/smoke_escript.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <escript-path>" >&2
+  exit 1
+fi
+
+case "$1" in
+  /*) BINARY="$1" ;;
+  *) BINARY="$(pwd)/$1" ;;
+esac
+
+chmod +x "$BINARY"
+
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+"$BINARY" --help >/dev/null
+"$BINARY" generate --help >/dev/null
+
+(
+  cd "$TMP_DIR"
+
+  "$BINARY" init --output=sqlode.yaml >/dev/null
+
+  test -f sqlode.yaml
+  test -f db/schema.sql
+  test -f db/query.sql
+
+  "$BINARY" generate --config=sqlode.yaml >/dev/null
+
+  test -f src/db/params.gleam
+  test -f src/db/queries.gleam
+  test -f src/db/models.gleam
+)
+
+echo "Smoke test passed: $BINARY"

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -12,11 +12,20 @@ type AdapterConfig {
     value_function: fn(model.ScalarType) -> String,
     decoder_function: fn(model.ScalarType) -> String,
     render_params: fn(List(model.QueryParam), String) -> String,
-    render_query_call: fn(String, String, String, String) -> List(String),
+    render_query_call: fn(
+      String,
+      String,
+      String,
+      String,
+      List(model.QueryParam),
+    ) ->
+      List(String),
     render_one_result: fn() -> List(String),
     render_many_result: fn() -> List(String),
     render_exec_rows_result: fn() -> List(String),
-    render_exec_last_id: fn(String, String, String) -> List(String),
+    render_exec_last_id: fn(String, String, String, List(model.QueryParam)) ->
+      List(String),
+    placeholder_prefix: String,
   )
 }
 
@@ -51,6 +60,7 @@ fn pog_adapter_config() -> AdapterConfig {
     render_many_result: render_pog_many_result,
     render_exec_rows_result: render_pog_exec_rows_result,
     render_exec_last_id: render_pog_exec_last_id,
+    placeholder_prefix: "$",
   )
 }
 
@@ -67,6 +77,7 @@ fn sqlight_adapter_config() -> AdapterConfig {
     render_many_result: render_sqlight_many_result,
     render_exec_rows_result: render_sqlight_exec_rows_result,
     render_exec_last_id: render_sqlight_exec_last_id,
+    placeholder_prefix: "?",
   )
 }
 
@@ -97,6 +108,11 @@ fn render_adapter(
       || query.base.command == model.ExecResult
     })
 
+  let has_slices =
+    list.any(queries, fn(query) {
+      list.any(query.params, fn(param) { param.is_list })
+    })
+
   let imports =
     list.flatten([
       [
@@ -104,7 +120,7 @@ fn render_adapter(
         "",
         "import gleam/dynamic/decode",
       ],
-      case has_exec_rows {
+      case has_exec_rows || has_slices {
         True -> ["import gleam/list"]
         False -> []
       },
@@ -114,6 +130,10 @@ fn render_adapter(
         False -> []
       },
       [config.library_import],
+      case has_slices {
+        True -> ["import sqlode/runtime"]
+        False -> []
+      },
       case has_results {
         True -> ["import " <> package <> "/models"]
         False -> []
@@ -244,7 +264,13 @@ fn render_adapter_one(
           <> ") {",
         "  let q = queries." <> fn_name <> "()",
       ],
-      config.render_query_call(fn_name, params_str, decoder, "q.sql"),
+      config.render_query_call(
+        fn_name,
+        params_str,
+        decoder,
+        "q.sql",
+        query.params,
+      ),
       config.render_one_result(),
       ["}"],
     ]),
@@ -279,7 +305,13 @@ fn render_adapter_many(
           <> ") {",
         "  let q = queries." <> fn_name <> "()",
       ],
-      config.render_query_call(fn_name, params_str, decoder, "q.sql"),
+      config.render_query_call(
+        fn_name,
+        params_str,
+        decoder,
+        "q.sql",
+        query.params,
+      ),
       config.render_many_result(),
       ["}"],
     ]),
@@ -315,6 +347,7 @@ fn render_adapter_exec(
         params_str,
         "decode.success(Nil)",
         "q.sql",
+        query.params,
       ),
       [
         "  |> result.map(fn(_) { Nil })",
@@ -353,6 +386,7 @@ fn render_adapter_exec_rows(
         params_str,
         "decode.success(Nil)",
         "q.sql",
+        query.params,
       ),
       config.render_exec_rows_result(),
       ["}"],
@@ -384,7 +418,7 @@ fn render_adapter_exec_last_id(
           <> ") {",
         "  let q = queries." <> fn_name <> "()",
       ],
-      config.render_exec_last_id(fn_name, params_str, "q.sql"),
+      config.render_exec_last_id(fn_name, params_str, "q.sql", query.params),
       ["}"],
     ]),
     "\n",
@@ -400,7 +434,10 @@ fn render_pog_query_call(
   params_str: String,
   decoder: String,
   _sql_expr: String,
+  params: List(model.QueryParam),
 ) -> List(String) {
+  let has_slices = list.any(params, fn(p) { p.is_list })
+
   let param_lines = case params_str {
     "" -> []
     _ ->
@@ -409,14 +446,37 @@ fn render_pog_query_call(
       |> list.filter(fn(l) { l != "" })
   }
 
-  list.flatten([
-    ["  pog.query(q.sql)"],
-    param_lines,
-    ["  |> pog.returning(" <> decoder <> ")", "  |> pog.execute(db)"],
-  ])
+  case has_slices {
+    True -> {
+      let slice_expansion = render_slice_expansion_line(params, "$")
+      list.flatten([
+        ["  " <> slice_expansion, "  let query = pog.query(sql)"],
+        param_lines,
+        [
+          "  query",
+          "  |> pog.returning(" <> decoder <> ")",
+          "  |> pog.execute(db)",
+        ],
+      ])
+    }
+    False ->
+      list.flatten([
+        ["  pog.query(q.sql)"],
+        param_lines,
+        ["  |> pog.returning(" <> decoder <> ")", "  |> pog.execute(db)"],
+      ])
+  }
 }
 
 fn render_pog_params(params: List(model.QueryParam), _prefix: String) -> String {
+  let has_slices = list.any(params, fn(p) { p.is_list })
+  case has_slices {
+    True -> render_pog_params_with_slices(params)
+    False -> render_pog_params_simple(params)
+  }
+}
+
+fn render_pog_params_simple(params: List(model.QueryParam)) -> String {
   params
   |> list.map(fn(param) {
     let value_fn =
@@ -434,6 +494,38 @@ fn render_pog_params(params: List(model.QueryParam), _prefix: String) -> String 
         <> ", p."
         <> param.field_name
         <> "))"
+    }
+  })
+  |> string.join("\n")
+}
+
+fn render_pog_params_with_slices(params: List(model.QueryParam)) -> String {
+  params
+  |> list.map(fn(param) {
+    let value_fn =
+      model.scalar_type_to_value_function(model.PostgreSQL, param.scalar_type)
+    case param.is_list {
+      True ->
+        "  let query = list.fold(p."
+        <> param.field_name
+        <> ", query, fn(acc, v) { pog.parameter(acc, pog."
+        <> value_fn
+        <> "(v)) })"
+      False ->
+        case param.nullable {
+          False ->
+            "  let query = pog.parameter(query, pog."
+            <> value_fn
+            <> "(p."
+            <> param.field_name
+            <> "))"
+          True ->
+            "  let query = pog.parameter(query, pog.nullable(pog."
+            <> value_fn
+            <> ", p."
+            <> param.field_name
+            <> "))"
+        }
     }
   })
   |> string.join("\n")
@@ -462,7 +554,10 @@ fn render_pog_exec_last_id(
   _fn_name: String,
   params_str: String,
   _sql_expr: String,
+  params: List(model.QueryParam),
 ) -> List(String) {
+  let has_slices = list.any(params, fn(p) { p.is_list })
+
   let param_lines = case params_str {
     "" -> []
     _ ->
@@ -471,20 +566,41 @@ fn render_pog_exec_last_id(
       |> list.filter(fn(l) { l != "" })
   }
 
-  list.flatten([
-    ["  pog.query(q.sql)"],
-    param_lines,
-    [
-      "  |> pog.returning(decode.int)",
-      "  |> pog.execute(db)",
-      "  |> result.map(fn(returned) {",
-      "    case returned.rows {",
-      "      [id, ..] -> id",
-      "      [] -> 0",
-      "    }",
-      "  })",
-    ],
-  ])
+  case has_slices {
+    True -> {
+      let slice_expansion = render_slice_expansion_line(params, "$")
+      list.flatten([
+        ["  " <> slice_expansion, "  let query = pog.query(sql)"],
+        param_lines,
+        [
+          "  query",
+          "  |> pog.returning(decode.int)",
+          "  |> pog.execute(db)",
+          "  |> result.map(fn(returned) {",
+          "    case returned.rows {",
+          "      [id, ..] -> id",
+          "      [] -> 0",
+          "    }",
+          "  })",
+        ],
+      ])
+    }
+    False ->
+      list.flatten([
+        ["  pog.query(q.sql)"],
+        param_lines,
+        [
+          "  |> pog.returning(decode.int)",
+          "  |> pog.execute(db)",
+          "  |> result.map(fn(returned) {",
+          "    case returned.rows {",
+          "      [id, ..] -> id",
+          "      [] -> 0",
+          "    }",
+          "  })",
+        ],
+      ])
+  }
 }
 
 // ============================================================
@@ -496,21 +612,45 @@ fn render_sqlight_query_call(
   params_str: String,
   decoder: String,
   _sql_expr: String,
+  params: List(model.QueryParam),
 ) -> List(String) {
-  [
-    "  sqlight.query(",
-    "    q.sql,",
-    "    on: db,",
-    "    with: " <> params_str <> ",",
-    "    expecting: " <> decoder <> ",",
-    "  )",
-  ]
+  let has_slices = list.any(params, fn(p) { p.is_list })
+  case has_slices {
+    True -> {
+      let slice_expansion = render_slice_expansion_line(params, "?")
+      [
+        "  " <> slice_expansion,
+        "  sqlight.query(",
+        "    sql,",
+        "    on: db,",
+        "    with: " <> params_str <> ",",
+        "    expecting: " <> decoder <> ",",
+        "  )",
+      ]
+    }
+    False -> [
+      "  sqlight.query(",
+      "    q.sql,",
+      "    on: db,",
+      "    with: " <> params_str <> ",",
+      "    expecting: " <> decoder <> ",",
+      "  )",
+    ]
+  }
 }
 
 fn render_sqlight_params(
   params: List(model.QueryParam),
   _prefix: String,
 ) -> String {
+  let has_slices = list.any(params, fn(p) { p.is_list })
+  case has_slices {
+    True -> render_sqlight_params_with_slices(params)
+    False -> render_sqlight_params_simple(params)
+  }
+}
+
+fn render_sqlight_params_simple(params: List(model.QueryParam)) -> String {
   case params {
     [] -> "[]"
     _ ->
@@ -533,6 +673,42 @@ fn render_sqlight_params(
         |> string.join(", ")
       }
       <> "]"
+  }
+}
+
+fn render_sqlight_params_with_slices(params: List(model.QueryParam)) -> String {
+  case params {
+    [] -> "[]"
+    _ ->
+      "list.flatten(["
+      <> {
+        params
+        |> list.map(fn(param) {
+          let value_fn =
+            model.scalar_type_to_value_function(model.SQLite, param.scalar_type)
+          case param.is_list {
+            True ->
+              "list.map(p."
+              <> param.field_name
+              <> ", sqlight."
+              <> value_fn
+              <> ")"
+            False ->
+              case param.nullable {
+                False ->
+                  "[sqlight." <> value_fn <> "(p." <> param.field_name <> ")]"
+                True ->
+                  "[sqlight.nullable(sqlight."
+                  <> value_fn
+                  <> ", p."
+                  <> param.field_name
+                  <> ")]"
+              }
+          }
+        })
+        |> string.join(", ")
+      }
+      <> "])"
   }
 }
 
@@ -559,29 +735,42 @@ fn render_sqlight_exec_last_id(
   _fn_name: String,
   params_str: String,
   _sql_expr: String,
+  params: List(model.QueryParam),
 ) -> List(String) {
-  [
-    "  sqlight.query(",
-    "    q.sql,",
-    "    on: db,",
-    "    with: " <> params_str <> ",",
-    "    expecting: decode.success(Nil),",
-    "  )",
-    "  |> result.try(fn(_) {",
-    "    sqlight.query(",
-    "      \"SELECT last_insert_rowid()\",",
-    "      on: db,",
-    "      with: [],",
-    "      expecting: decode.at([0], decode.int),",
-    "    )",
-    "  })",
-    "  |> result.map(fn(rows) {",
-    "    case rows {",
-    "      [id, ..] -> id",
-    "      [] -> 0",
-    "    }",
-    "  })",
-  ]
+  let has_slices = list.any(params, fn(p) { p.is_list })
+  let sql_var = case has_slices {
+    True -> "sql"
+    False -> "q.sql"
+  }
+  let preamble = case has_slices {
+    True -> ["  " <> render_slice_expansion_line(params, "?")]
+    False -> []
+  }
+  list.flatten([
+    preamble,
+    [
+      "  sqlight.query(",
+      "    " <> sql_var <> ",",
+      "    on: db,",
+      "    with: " <> params_str <> ",",
+      "    expecting: decode.success(Nil),",
+      "  )",
+      "  |> result.try(fn(_) {",
+      "    sqlight.query(",
+      "      \"SELECT last_insert_rowid()\",",
+      "      on: db,",
+      "      with: [],",
+      "      expecting: decode.at([0], decode.int),",
+      "    )",
+      "  })",
+      "  |> result.map(fn(rows) {",
+      "    case rows {",
+      "      [id, ..] -> id",
+      "      [] -> 0",
+      "    }",
+      "  })",
+    ],
+  ])
 }
 
 // ============================================================
@@ -603,6 +792,33 @@ fn render_mysql_adapter() -> String {
 // ============================================================
 // Shared helpers
 // ============================================================
+
+fn render_slice_expansion_line(
+  params: List(model.QueryParam),
+  prefix: String,
+) -> String {
+  let slice_entries =
+    params
+    |> list.filter(fn(p) { p.is_list })
+    |> list.map(fn(p) {
+      "#("
+      <> int.to_string(p.index)
+      <> ", list.length(p."
+      <> p.field_name
+      <> "))"
+    })
+    |> string.join(", ")
+
+  let total_params = list.length(params)
+
+  "let sql = runtime.expand_slice_placeholders(q.sql, ["
+  <> slice_entries
+  <> "], "
+  <> int.to_string(total_params)
+  <> ", \""
+  <> prefix
+  <> "\")"
+}
 
 fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -7,12 +7,31 @@ pub fn render(
   naming_ctx: naming.NamingContext,
   queries: List(model.AnalyzedQuery),
 ) -> String {
+  let has_slices =
+    list.any(queries, fn(query) {
+      list.any(query.params, fn(param) { param.is_list })
+    })
+
   let imports = case needs_option_import(queries) {
-    True -> [
-      "import gleam/option.{type Option, None, Some}",
-      "import sqlode/runtime.{type Value}",
-    ]
-    False -> ["import sqlode/runtime.{type Value}"]
+    True ->
+      list.flatten([
+        case has_slices {
+          True -> ["import gleam/list"]
+          False -> []
+        },
+        [
+          "import gleam/option.{type Option, None, Some}",
+          "import sqlode/runtime.{type Value}",
+        ],
+      ])
+    False ->
+      list.flatten([
+        case has_slices {
+          True -> ["import gleam/list"]
+          False -> []
+        },
+        ["import sqlode/runtime.{type Value}"],
+      ])
   }
 
   let declarations =
@@ -61,7 +80,15 @@ fn render_params_declaration(
         ],
         "\n",
       )
-    params ->
+    params -> {
+      let has_slices = list.any(params, fn(p) { p.is_list })
+      let values_body = case has_slices {
+        True ->
+          "  list.flatten(["
+          <> string.join(param_accessors_flattened(params), ", ")
+          <> "])"
+        False -> "  [" <> string.join(param_accessors(params), ", ") <> "]"
+      }
       string.join(
         [
           "pub type " <> type_name <> " {",
@@ -77,11 +104,12 @@ fn render_params_declaration(
             <> "(params: "
             <> type_name
             <> ") -> List(Value) {",
-          "  [" <> string.join(param_accessors(params), ", ") <> "]",
+          values_body,
           "}",
         ],
         "\n",
       )
+    }
   }
 }
 
@@ -119,4 +147,28 @@ fn render_param_value(param: model.QueryParam) -> String {
       <> "(value) None -> runtime.null() }"
     False -> runtime_fn <> "(" <> value_expr <> ")"
   }
+}
+
+/// Render param values for queries with slice params.
+/// Scalars are wrapped in singleton lists, slices are mapped.
+fn param_accessors_flattened(params: List(model.QueryParam)) -> List(String) {
+  params
+  |> list.map(fn(param) {
+    let value_expr = "params." <> param.field_name
+    let runtime_fn = model.scalar_type_to_runtime_function(param.scalar_type)
+
+    case param.is_list {
+      True -> "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
+      False ->
+        case param.nullable {
+          True ->
+            "[case "
+            <> value_expr
+            <> " { Some(value) -> "
+            <> runtime_fn
+            <> "(value) None -> runtime.null() }]"
+          False -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
+        }
+    }
+  })
 }

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -1,3 +1,7 @@
+import gleam/int
+import gleam/list
+import gleam/string
+
 pub type QueryCommand {
   QueryOne
   QueryMany
@@ -38,4 +42,77 @@ pub fn bool(value: Bool) -> Value {
 
 pub fn bytes(value: BitArray) -> Value {
   SqlBytes(value)
+}
+
+/// Expand slice placeholders in a SQL string.
+///
+/// When a query uses `sqlc.slice(ids)`, the parser emits a single placeholder
+/// (e.g. `$1` or `?1`).  At runtime the placeholder must be expanded to match
+/// the actual list length, and every subsequent placeholder must be renumbered.
+///
+/// Arguments:
+/// - `sql`          – the SQL template with original placeholders
+/// - `slices`       – list of `#(original_index, slice_length)` for each slice param
+/// - `total_params` – total number of original parameter slots
+/// - `prefix`       – placeholder prefix: `"$"` for PostgreSQL, `"?"` for SQLite
+///
+/// Returns the expanded SQL string.
+pub fn expand_slice_placeholders(
+  sql: String,
+  slices: List(#(Int, Int)),
+  total_params: Int,
+  prefix: String,
+) -> String {
+  // Phase 1: Replace all original placeholders with unique markers
+  //          (from highest index to lowest to avoid partial matches)
+  // Note: int.range excludes the stop value, so use 0 to include 1
+  let marked =
+    int.range(from: total_params, to: 0, with: sql, run: fn(s, i) {
+      string.replace(
+        s,
+        prefix <> int.to_string(i),
+        "{{P" <> int.to_string(i) <> "}}",
+      )
+    })
+
+  // Phase 2: Compute a mapping from each original index to the new placeholder(s)
+  // Note: int.range excludes stop, so use total_params + 1 to include total_params
+  let #(_, mapping) =
+    int.range(
+      from: 1,
+      to: total_params + 1,
+      with: #(1, []),
+      run: fn(acc, orig_idx) {
+        let #(next_new_idx, map) = acc
+        let is_slice = list.find(slices, fn(s) { s.0 == orig_idx })
+        case is_slice {
+          Ok(#(_, len)) -> {
+            let expanded =
+              int.range(
+                from: next_new_idx,
+                to: next_new_idx + len,
+                with: [],
+                run: fn(items, i) {
+                  list.append(items, [prefix <> int.to_string(i)])
+                },
+              )
+              |> string.join(", ")
+            #(next_new_idx + len, [#(orig_idx, expanded), ..map])
+          }
+          Error(_) -> {
+            #(next_new_idx + 1, [
+              #(orig_idx, prefix <> int.to_string(next_new_idx)),
+              ..map
+            ])
+          }
+        }
+      },
+    )
+
+  // Phase 3: Replace markers with final placeholders
+  mapping
+  |> list.fold(marked, fn(s, entry) {
+    let #(orig_idx, replacement) = entry
+    string.replace(s, "{{P" <> int.to_string(orig_idx) <> "}}", replacement)
+  })
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -9,6 +9,7 @@ import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
 import sqlode/query_parser
+import sqlode/runtime
 import sqlode/schema_parser
 
 pub fn main() {
@@ -145,6 +146,127 @@ pub fn render_sqlight_adapter_test() {
   string.contains(rendered, "sqlight.query(") |> should.be_true()
   string.contains(rendered, "decode.success(models.GetAuthorRow(")
   |> should.be_true()
+}
+
+pub fn render_params_module_slice_test() {
+  let naming_ctx = naming.new()
+  let analyzed = analyzed_slice_queries(model.PostgreSQL)
+  let rendered = codegen.render_params_module(naming_ctx, analyzed)
+
+  // The type should use List(...) for slice params
+  string.contains(rendered, "ids: List(")
+  |> should.be_true()
+  // Should use list.flatten for values function
+  string.contains(rendered, "list.flatten(")
+  |> should.be_true()
+  string.contains(rendered, "list.map(params.ids, runtime.")
+  |> should.be_true()
+  // Should import gleam/list
+  string.contains(rendered, "import gleam/list")
+  |> should.be_true()
+}
+
+pub fn render_pog_adapter_slice_test() {
+  let naming_ctx = naming.new()
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/macro_edge_cases.sql"],
+      gleam: model.GleamOutput(
+        package: "db",
+        out: "test_output/db",
+        runtime: model.Native,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let analyzed = analyzed_slice_queries(model.PostgreSQL)
+  let rendered = codegen.render_adapter_module(naming_ctx, block, analyzed)
+
+  // Should import runtime for slice expansion
+  string.contains(rendered, "import sqlode/runtime")
+  |> should.be_true()
+  // Should call expand_slice_placeholders
+  string.contains(rendered, "runtime.expand_slice_placeholders(")
+  |> should.be_true()
+  // Should use list.fold for slice param binding
+  string.contains(rendered, "list.fold(p.ids")
+  |> should.be_true()
+  // Should use let query = style
+  string.contains(rendered, "let query = pog.query(sql)")
+  |> should.be_true()
+}
+
+pub fn render_sqlight_adapter_slice_test() {
+  let naming_ctx = naming.new()
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.SQLite,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/macro_edge_cases.sql"],
+      gleam: model.GleamOutput(
+        package: "db",
+        out: "test_output/db",
+        runtime: model.Native,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let analyzed = analyzed_slice_queries(model.SQLite)
+  let rendered = codegen.render_adapter_module(naming_ctx, block, analyzed)
+
+  // Should call expand_slice_placeholders with "?" prefix
+  string.contains(rendered, "runtime.expand_slice_placeholders(")
+  |> should.be_true()
+  // Should use list.flatten for sqlight params
+  string.contains(rendered, "list.flatten(")
+  |> should.be_true()
+  string.contains(rendered, "list.map(p.ids, sqlight.")
+  |> should.be_true()
+}
+
+pub fn expand_slice_placeholders_single_test() {
+  let sql = "SELECT id, name FROM authors WHERE id IN ($1)"
+  let result = runtime.expand_slice_placeholders(sql, [#(1, 3)], 1, "$")
+  result
+  |> should.equal("SELECT id, name FROM authors WHERE id IN ($1, $2, $3)")
+}
+
+pub fn expand_slice_placeholders_with_renumbering_test() {
+  let sql = "SELECT * FROM users WHERE name = $1 AND id IN ($2) AND status = $3"
+  let result = runtime.expand_slice_placeholders(sql, [#(2, 3)], 3, "$")
+  result
+  |> should.equal(
+    "SELECT * FROM users WHERE name = $1 AND id IN ($2, $3, $4) AND status = $5",
+  )
+}
+
+pub fn expand_slice_placeholders_sqlite_test() {
+  let sql = "SELECT id, name FROM authors WHERE id IN (?1)"
+  let result = runtime.expand_slice_placeholders(sql, [#(1, 2)], 1, "?")
+  result
+  |> should.equal("SELECT id, name FROM authors WHERE id IN (?1, ?2)")
+}
+
+pub fn expand_slice_placeholders_no_slices_test() {
+  let sql = "SELECT * FROM users WHERE id = $1"
+  let result = runtime.expand_slice_placeholders(sql, [], 1, "$")
+  result |> should.equal("SELECT * FROM users WHERE id = $1")
+}
+
+fn analyzed_slice_queries(engine: model.Engine) -> List(model.AnalyzedQuery) {
+  let naming_ctx = naming.new()
+  let assert Ok(schema_content) = simplifile.read("test/fixtures/schema.sql")
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("test/fixtures/schema.sql", schema_content)])
+  let sql =
+    "-- name: GetByIds :many\nSELECT id, name FROM authors WHERE id IN (sqlc.slice(ids));"
+  let assert Ok(queries) =
+    query_parser.parse_file("slice.sql", engine, naming_ctx, sql)
+  let assert Ok(result) =
+    query_analyzer.analyze_queries(engine, catalog, naming_ctx, queries)
+  result
 }
 
 fn test_block() -> model.SqlBlock {

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -143,6 +143,34 @@ pub fn render_sqlight_adapter_test() {
   codegen_test.render_sqlight_adapter_test()
 }
 
+pub fn render_params_module_slice_test() {
+  codegen_test.render_params_module_slice_test()
+}
+
+pub fn render_pog_adapter_slice_test() {
+  codegen_test.render_pog_adapter_slice_test()
+}
+
+pub fn render_sqlight_adapter_slice_test() {
+  codegen_test.render_sqlight_adapter_slice_test()
+}
+
+pub fn expand_slice_placeholders_single_test() {
+  codegen_test.expand_slice_placeholders_single_test()
+}
+
+pub fn expand_slice_placeholders_with_renumbering_test() {
+  codegen_test.expand_slice_placeholders_with_renumbering_test()
+}
+
+pub fn expand_slice_placeholders_sqlite_test() {
+  codegen_test.expand_slice_placeholders_sqlite_test()
+}
+
+pub fn expand_slice_placeholders_no_slices_test() {
+  codegen_test.expand_slice_placeholders_no_slices_test()
+}
+
 pub fn type_override_changes_scalar_type_test() {
   generate_test.type_override_changes_scalar_type_test()
 }


### PR DESCRIPTION
## Summary

- Fix `sqlc.slice()` codegen to produce executable SQL and correct parameter bindings for PostgreSQL and SQLite
- Add `runtime.expand_slice_placeholders` helper for dynamic SQL placeholder expansion at runtime
- Add tests for runtime placeholder expansion and codegen output for both engines

## Changes

### `src/sqlode/runtime.gleam`
- Add `expand_slice_placeholders(sql, slices, total_params, prefix)` function that:
  - Replaces a single slice placeholder with N placeholders matching the list length
  - Renumbers all subsequent placeholders to maintain correctness
  - Uses a three-phase marker approach to avoid partial-match conflicts

### `src/sqlode/codegen/params.gleam`
- When any parameter has `is_list=True`, the `_values` function now uses `list.flatten([...])` with `list.map` for slices and singleton wrappers for scalars
- Conditionally imports `gleam/list` when slice params are present

### `src/sqlode/codegen/adapter.gleam`
- Add `placeholder_prefix` field to `AdapterConfig` (`"$"` for PostgreSQL, `"?"` for SQLite)
- **pog adapter**: When slices are present, generates `let query = ...` binding style with `list.fold` for dynamic parameter chaining
- **sqlight adapter**: When slices are present, generates `list.flatten([...])` with `list.map` for parameter lists
- Both adapters generate `runtime.expand_slice_placeholders(...)` call and conditionally import `sqlode/runtime` and `gleam/list`

### Tests
- `expand_slice_placeholders_single_test` — single slice, no renumbering
- `expand_slice_placeholders_with_renumbering_test` — slice with subsequent placeholder renumbering
- `expand_slice_placeholders_sqlite_test` — SQLite `?N` prefix
- `expand_slice_placeholders_no_slices_test` — no-op when no slices
- `render_params_module_slice_test` — params module generates `List(T)` type and `list.flatten`
- `render_pog_adapter_slice_test` — pog adapter generates slice expansion and `list.fold`
- `render_sqlight_adapter_slice_test` — sqlight adapter generates slice expansion and `list.flatten`

## Design Decisions

- **Runtime expansion vs. compile-time**: SQL placeholder expansion must happen at runtime because the list length is unknown at compile time. The `expand_slice_placeholders` function uses a three-phase marker approach (`{{P1}}` temporary markers) to safely renumber placeholders without partial-match conflicts.
- **Adapter-specific rendering**: When slices are present, pog uses a `let query = ...` + `list.fold` style instead of the usual pipeline, since `pog.parameter` chaining requires a known number of calls. sqlight uses `list.flatten` since parameters are passed as a flat list.

## Limitations

- `sqlc.slice` with an empty list produces `IN ()` which is invalid SQL in most engines. This matches sqlc's behavior — users should guard against empty slices.

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for list/slice parameters in SQL queries, enabling flexible handling of variable-length parameter sets for efficient batch operations.

* **Tests**
  * Expanded test coverage for slice parameter handling across database adapter implementations.

* **Chores**
  * Automated package publishing to registry, improved release workflow, and added comprehensive binary validation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->