### PR TITLE
fix(config): reject runtime "based" with a clear error until it has distinct semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,20 +125,21 @@ The `runtime` option controls what code sqlode generates and what dependencies y
 | Mode | Generated files | DB driver needed | Use case |
 |------|----------------|-----------------|----------|
 | `raw` | queries, params, models | No | You handle database interaction yourself |
-| `based` | queries, params, models, adapter | Yes (pog/sqlight) | Same as `native` (reserved for future use) |
 | `native` | queries, params, models, adapter | Yes (pog/sqlight) | Full adapter with parameter binding and result decoding |
 
-**Dependency note:** In all modes, sqlode must be a dependency (not just a dev-dependency) because the generated code imports `sqlode/runtime` for the `Value` type and `QueryCommand` type. The adapter modes (`based`, `native`) additionally require a database driver package:
+> **Note:** `runtime: "based"` is reserved for future use and is currently rejected. Use `"raw"` or `"native"` instead.
+
+**Dependency note:** In all modes, sqlode must be a dependency (not just a dev-dependency) because the generated code imports `sqlode/runtime` for the `Value` type and `QueryCommand` type. The `native` adapter mode additionally requires a database driver package:
 
 ```console
 gleam add sqlode
-gleam add pog       # for PostgreSQL with native/based runtime
-gleam add sqlight   # for SQLite with native/based runtime
+gleam add pog       # for PostgreSQL with native runtime
+gleam add sqlight   # for SQLite with native runtime
 ```
 
 ## Adapter generation
 
-When `runtime` is set to `native` or `based`, sqlode generates adapter modules that wrap [pog](https://hexdocs.pm/pog/) (PostgreSQL) or [sqlight](https://hexdocs.pm/sqlight/) (SQLite).
+When `runtime` is set to `native`, sqlode generates adapter modules that wrap [pog](https://hexdocs.pm/pog/) (PostgreSQL) or [sqlight](https://hexdocs.pm/sqlight/) (SQLite).
 
 **Note:** MySQL adapter generation is not yet available. MySQL schema parsing and query/params generation work, but `runtime: "native"` will produce a stub adapter. Use `runtime: "raw"` with MySQL and handle database interaction manually.
 

--- a/doc/reference/specs/sqlc-compatibility.md
+++ b/doc/reference/specs/sqlc-compatibility.md
@@ -42,7 +42,7 @@ sql:
 |--------|--------|-------|
 | `package` | Implemented | Package name for imports |
 | `out` | Implemented | Output directory |
-| `runtime` | Implemented | `raw`, `based`, `native` |
+| `runtime` | Implemented | `raw`, `native` (`based` is reserved, not yet supported) |
 | `overrides.types` | Implemented | Map DB types to Gleam types |
 | `overrides.renames` | Implemented | Rename columns in result types |
 

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -115,7 +115,7 @@ fn generate_sql_block(
 
       let files = case gleam.runtime {
         model.Raw -> files
-        _ ->
+        model.Native ->
           list.append(files, [
             writer.GeneratedFile(
               directory: out,

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -25,23 +25,22 @@ pub fn engine_to_string(engine: Engine) -> String {
 
 pub type Runtime {
   Raw
-  Based
   Native
 }
 
 pub fn parse_runtime(value: String) -> Result(Runtime, String) {
   case value {
     "raw" -> Ok(Raw)
-    "based" -> Ok(Based)
+    "based" ->
+      Error("\"based\" is not yet supported; use \"raw\" or \"native\" instead")
     "native" -> Ok(Native)
-    _ -> Error("must be one of: raw, based, native")
+    _ -> Error("must be one of: raw, native")
   }
 }
 
 pub fn runtime_to_string(runtime: Runtime) -> String {
   case runtime {
     Raw -> "raw"
-    Based -> "based"
     Native -> "native"
   }
 }

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -30,8 +30,8 @@ pub fn parse_runtime_raw_test() {
   model.parse_runtime("raw") |> should.equal(Ok(model.Raw))
 }
 
-pub fn parse_runtime_based_test() {
-  model.parse_runtime("based") |> should.equal(Ok(model.Based))
+pub fn parse_runtime_based_rejected_test() {
+  model.parse_runtime("based") |> should.be_error()
 }
 
 pub fn parse_runtime_native_test() {
@@ -86,7 +86,6 @@ pub fn engine_to_string_roundtrip_test() {
 
 pub fn runtime_to_string_roundtrip_test() {
   model.runtime_to_string(model.Raw) |> should.equal("raw")
-  model.runtime_to_string(model.Based) |> should.equal("based")
   model.runtime_to_string(model.Native) |> should.equal("native")
 }
 


### PR DESCRIPTION
## Summary

- Reject `runtime: "based"` during config parsing with an actionable error message instead of silently treating it as `native`
- Remove the `Based` variant from the `Runtime` type to eliminate dead code
- Update README and docs to reflect that `based` is reserved for future use

## Changes

- **src/sqlode/model.gleam**: Remove `Based` variant from `Runtime` type. `parse_runtime("based")` now returns a descriptive error suggesting `"raw"` or `"native"` instead
- **src/sqlode/generate.gleam**: Replace wildcard `_ ->` with explicit `model.Native ->` so the compiler catches future additions
- **test/model_test.gleam**: Update test to expect error for `"based"` input; remove `Based` from roundtrip test
- **README.md**: Remove `based` row from runtime table, add note that it is reserved, update dependency instructions

## Design Decisions

- **Removed `Based` variant entirely** rather than keeping it unparseable: avoids dead code in `runtime_to_string` and `generate.gleam`; version control preserves it if needed later
- **Distinct error message for `"based"`** vs unknown values: users who read older docs get clear guidance rather than a generic "invalid value" error

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed support for the `based` runtime mode. Use `raw` or `native` instead.

* **Documentation**
  * Updated configuration documentation to clarify supported runtime options and dependencies.
  * Enhanced error messages to guide users toward valid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->