### PR TITLE
fix(config): reject MySQL with native runtime at config validation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ gleam add sqlight   # for SQLite with native runtime
 
 When `runtime` is set to `native`, sqlode generates adapter modules that wrap [pog](https://hexdocs.pm/pog/) (PostgreSQL) or [sqlight](https://hexdocs.pm/sqlight/) (SQLite).
 
-**Note:** MySQL adapter generation is not yet available. MySQL schema parsing and query/params generation work, but `runtime: "native"` will produce a stub adapter. Use `runtime: "raw"` with MySQL and handle database interaction manually.
+**Note:** MySQL adapter generation is not yet available. MySQL schema parsing and query/params generation work with `runtime: "raw"`. Configuring MySQL with `runtime: "native"` is rejected at config validation time — use `runtime: "raw"` and handle database interaction manually.
 
 ```yaml
 gen:

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -131,6 +131,15 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
     None -> Ok(model.Raw)
   })
 
+  use _ <- result.try(case engine, runtime {
+    model.MySQL, model.Native ->
+      Error(InvalidValue(
+        field: "sql.gen.gleam.runtime",
+        detail: "MySQL does not support runtime: \"native\" because no Gleam MySQL driver is available; use runtime: \"raw\" instead",
+      ))
+    _, _ -> Ok(Nil)
+  })
+
   let overrides = parse_overrides(node)
 
   Ok(model.SqlBlock(

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -95,6 +95,15 @@ pub fn reject_multiple_unsupported_root_fields_test() {
   string.contains(msg, "analyzer") |> should.be_true()
 }
 
+// MySQL + native runtime rejection
+
+pub fn reject_mysql_native_runtime_test() {
+  let assert Error(error) = config.load("test/fixtures/mysql_native.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "MySQL") |> should.be_true()
+  string.contains(msg, "raw") |> should.be_true()
+}
+
 // error_to_string coverage
 
 pub fn error_to_string_file_read_error_test() {

--- a/test/fixtures/mysql_native.yaml
+++ b/test/fixtures/mysql_native.yaml
@@ -1,0 +1,10 @@
+version: "2"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "mysql"
+    gen:
+      gleam:
+        package: "db"
+        out: "test_output/db"
+        runtime: "native"


### PR DESCRIPTION
## Summary

- Reject `engine: "mysql"` + `runtime: "native"` at config validation time instead of generating a non-functional stub adapter
- Add clear error message recommending `runtime: "raw"` for MySQL
- Update README to reflect the new validation behavior

## Changes

- **src/sqlode/config.gleam**: Add engine+runtime cross-validation in `parse_sql_block` after both values are parsed
- **test/config_test.gleam**: Add `reject_mysql_native_runtime_test` verifying the error message
- **test/fixtures/mysql_native.yaml**: New test fixture for MySQL + native config
- **README.md**: Update MySQL adapter note to reflect config-time rejection

## Design Decisions

- **Validate in config.gleam, not generate.gleam**: Fail at the earliest possible point (config parsing) rather than during code generation, following the existing validation pattern
- **Reuse `InvalidValue` error type**: Consistent with other config validation errors, no new error variant needed

Closes #97