### PR TITLE
feat(parser): accept quoted names in sqlc.arg, sqlc.narg, and sqlc.slice

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -38,7 +38,9 @@ fn new_parser_context(naming_ctx: naming.NamingContext) -> ParserContext {
       "(\\?[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
     )
   let assert Ok(sqlc_macro_re) =
-    regexp.from_string("sqlc\\.(arg|narg|slice)\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)")
+    regexp.from_string(
+      "sqlc\\.(arg|narg|slice)\\(('[^']*'|\"[^\"]*\"|[a-zA-Z_][a-zA-Z0-9_]*)\\)",
+    )
 
   ParserContext(
     naming: naming_ctx,
@@ -292,7 +294,8 @@ fn expand_sqlc_macros(
           let #(current_sql, macro_acc, idx) = acc
 
           case match.submatches {
-            [Some(kind), Some(name)] -> {
+            [Some(kind), Some(raw_name)] -> {
+              let name = strip_quotes(raw_name)
               let placeholder = engine_placeholder(engine, idx)
               let new_sql =
                 replace_first(current_sql, match.content, placeholder)
@@ -309,6 +312,13 @@ fn expand_sqlc_macros(
 
       #(expanded, list.reverse(macros))
     }
+  }
+}
+
+fn strip_quotes(name: String) -> String {
+  case string.first(name) {
+    Ok("'") | Ok("\"") -> string.slice(name, 1, string.length(name) - 2)
+    _ -> name
   }
 }
 

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -122,6 +122,72 @@ pub fn expand_sqlc_arg_mysql_test() {
   string.contains(query.sql, "?") |> should.be_true()
 }
 
+// Quoted macro name tests
+
+pub fn expand_sqlc_arg_single_quoted_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByName :one\n"
+    <> "SELECT id FROM authors WHERE name = sqlc.arg('author_name');"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+  string.contains(query.sql, "sqlc.arg") |> should.be_false()
+  string.contains(query.sql, "$1") |> should.be_true()
+}
+
+pub fn expand_sqlc_arg_double_quoted_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByName :one\n"
+    <> "SELECT id FROM authors WHERE name = sqlc.arg(\"author_name\");"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+}
+
+pub fn expand_sqlc_narg_single_quoted_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpdateBio :exec\n"
+    <> "UPDATE authors SET bio = sqlc.narg('new_bio') WHERE id = sqlc.arg(author_id);"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(2)
+  query.macros
+  |> should.equal([
+    model.SqlcNarg(index: 1, name: "new_bio"),
+    model.SqlcArg(index: 2, name: "author_id"),
+  ])
+}
+
+pub fn expand_sqlc_slice_double_quoted_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByIds :many\n"
+    <> "SELECT id, name FROM authors WHERE id IN (sqlc.slice(\"ids\"));"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("slice.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.macros
+  |> should.equal([model.SqlcSlice(index: 1, name: "ids")])
+}
+
 // Error and boundary tests
 
 pub fn invalid_annotation_format_test() {


### PR DESCRIPTION
## Summary

- Accept single-quoted and double-quoted names in `sqlc.arg('name')`, `sqlc.narg('name')`, and `sqlc.slice("name")` in addition to bare identifiers
- Normalize all forms to the same internal parameter name (quotes stripped)

## Changes

- **src/sqlode/query_parser.gleam**: Extend `sqlc_macro_re` regex to match `'...'` and `"..."` in addition to bare identifiers. Add `strip_quotes` helper to normalize captured names
- **test/query_parser_test.gleam**: Add 4 test cases covering single-quoted arg, double-quoted arg, single-quoted narg mixed with bare arg, and double-quoted slice

## Design Decisions

- **Single regex with post-processing** rather than multiple capture groups: the regex captures the raw name (possibly with quotes), then `strip_quotes` removes them. This keeps the submatch pattern unchanged (`[Some(kind), Some(name)]`) and avoids complex alternation with multiple capture groups
- **Quotes are stripped at parse time**: downstream code (param inference, codegen) receives clean identifiers with no awareness of quoting

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL macros (`sqlc.arg`, `sqlc.narg`, `sqlc.slice`) now support quoted argument names in addition to unquoted identifiers, accepting both single-quoted and double-quoted strings.

* **Tests**
  * Added comprehensive test coverage for quoted macro arguments, validating functionality across all macro types and quote styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->