### PR TITLE
feat(parser): support @name shorthand for sqlc.arg on PostgreSQL and SQLite

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -28,6 +28,7 @@ type ParserContext {
     postgresql_param_re: regexp.Regexp,
     sqlite_param_re: regexp.Regexp,
     sqlc_macro_re: regexp.Regexp,
+    at_name_re: regexp.Regexp,
   )
 }
 
@@ -41,12 +42,14 @@ fn new_parser_context(naming_ctx: naming.NamingContext) -> ParserContext {
     regexp.from_string(
       "sqlc\\.(arg|narg|slice)\\(('[^']*'|\"[^\"]*\"|[a-zA-Z_][a-zA-Z0-9_]*)\\)",
     )
+  let assert Ok(at_name_re) = regexp.from_string("@([A-Za-z_][A-Za-z0-9_]*)")
 
   ParserContext(
     naming: naming_ctx,
     postgresql_param_re:,
     sqlite_param_re:,
     sqlc_macro_re:,
+    at_name_re:,
   )
 }
 
@@ -151,7 +154,11 @@ fn finalize_pending(
       case sql == "" {
         True -> Error(MissingSql(path:, line: start_line, name:))
         False -> {
-          let #(expanded_sql, macros) = expand_sqlc_macros(ctx, engine, sql)
+          let #(at_expanded, at_macros, next_idx) =
+            expand_at_name_shorthands(ctx, engine, sql)
+          let #(expanded_sql, sqlc_macros) =
+            expand_sqlc_macros_from(ctx, engine, at_expanded, next_idx)
+          let macros = list.append(at_macros, sqlc_macros)
           Ok([
             model.ParsedQuery(
               name:,
@@ -279,10 +286,47 @@ pub fn error_to_string(error: ParseError) -> String {
   }
 }
 
-fn expand_sqlc_macros(
+fn expand_at_name_shorthands(
   ctx: ParserContext,
   engine: model.Engine,
   sql: String,
+) -> #(String, List(model.SqlcMacro), Int) {
+  case engine {
+    model.MySQL -> #(sql, [], 1)
+    _ -> {
+      let matches = regexp.scan(ctx.at_name_re, sql)
+      case matches {
+        [] -> #(sql, [], 1)
+        _ -> {
+          let #(expanded, macros, next_idx) =
+            list.fold(matches, #(sql, [], 1), fn(acc, match) {
+              let #(current_sql, macro_acc, idx) = acc
+              case match.submatches {
+                [Some(name)] -> {
+                  let placeholder = engine_placeholder(engine, idx)
+                  let new_sql =
+                    replace_first(current_sql, match.content, placeholder)
+                  #(
+                    new_sql,
+                    [model.SqlcArg(index: idx, name:), ..macro_acc],
+                    idx + 1,
+                  )
+                }
+                _ -> acc
+              }
+            })
+          #(expanded, list.reverse(macros), next_idx)
+        }
+      }
+    }
+  }
+}
+
+fn expand_sqlc_macros_from(
+  ctx: ParserContext,
+  engine: model.Engine,
+  sql: String,
+  start_idx: Int,
 ) -> #(String, List(model.SqlcMacro)) {
   let matches = regexp.scan(ctx.sqlc_macro_re, sql)
 
@@ -290,7 +334,7 @@ fn expand_sqlc_macros(
     [] -> #(sql, [])
     _ -> {
       let #(expanded, macros, _) =
-        list.fold(matches, #(sql, [], 1), fn(acc, match) {
+        list.fold(matches, #(sql, [], start_idx), fn(acc, match) {
           let #(current_sql, macro_acc, idx) = acc
 
           case match.submatches {

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -143,8 +143,8 @@ pub fn sqlite_at_named_placeholder_test() {
     list.find(analyzed, fn(q) { q.base.name == "GetAuthorByEmail" })
   get_by_email.base.param_count |> should.equal(1)
   let assert [param] = get_by_email.params
-  // Column inference resolves to "name" (from equality match authors.name)
-  param.field_name |> should.equal("name")
+  // @author_name shorthand is equivalent to sqlc.arg(author_name)
+  param.field_name |> should.equal("author_name")
   param.scalar_type |> should.equal(model.StringType)
 }
 

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -188,6 +188,94 @@ pub fn expand_sqlc_slice_double_quoted_test() {
   |> should.equal([model.SqlcSlice(index: 1, name: "ids")])
 }
 
+// @name shorthand tests
+
+pub fn expand_at_name_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByName :one\n"
+    <> "SELECT id FROM authors WHERE name = @author_name;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+  string.contains(query.sql, "@author_name") |> should.be_false()
+  string.contains(query.sql, "$1") |> should.be_true()
+}
+
+pub fn expand_at_name_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByName :one\n"
+    <> "SELECT id FROM authors WHERE name = @author_name;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.SQLite, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+  string.contains(query.sql, "@author_name") |> should.be_false()
+  string.contains(query.sql, "?1") |> should.be_true()
+}
+
+pub fn expand_multiple_at_names_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpdateBio :exec\n"
+    <> "UPDATE authors SET bio = @new_bio WHERE id = @author_id;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(2)
+  query.macros
+  |> should.equal([
+    model.SqlcArg(index: 1, name: "new_bio"),
+    model.SqlcArg(index: 2, name: "author_id"),
+  ])
+  string.contains(query.sql, "$1") |> should.be_true()
+  string.contains(query.sql, "$2") |> should.be_true()
+}
+
+pub fn expand_at_name_mixed_with_sqlc_arg_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: Update :exec\n"
+    <> "UPDATE authors SET bio = @new_bio WHERE id = sqlc.arg(author_id);"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(2)
+  query.macros
+  |> should.equal([
+    model.SqlcArg(index: 1, name: "new_bio"),
+    model.SqlcArg(index: 2, name: "author_id"),
+  ])
+}
+
+pub fn at_name_not_expanded_on_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByName :one\n"
+    <> "SELECT id FROM authors WHERE name = @author_name;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.MySQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.macros |> should.equal([])
+  string.contains(query.sql, "@author_name") |> should.be_true()
+}
+
 // Error and boundary tests
 
 pub fn invalid_annotation_format_test() {


### PR DESCRIPTION
## Summary

- Expand `@name` shorthand into engine-appropriate placeholders (`$N` for PostgreSQL, `?N` for SQLite), equivalent to `sqlc.arg(name)`
- Skip expansion on MySQL (no native `@name` support), matching sqlc behavior
- Track expanded `@name` parameters as `SqlcArg` macros for correct field name resolution in codegen

## Changes

- **src/sqlode/query_parser.gleam**: Add `at_name_re` regex to `ParserContext`. Add `expand_at_name_shorthands` function that replaces `@name` tokens with engine placeholders and records `SqlcArg` macros. Rename `expand_sqlc_macros` to `expand_sqlc_macros_from` with a `start_idx` parameter so indices continue correctly after `@name` expansion
- **test/query_parser_test.gleam**: Add 5 tests: PostgreSQL expansion, SQLite expansion, multiple `@name` parameters, mixed `@name` + `sqlc.arg`, and MySQL no-op
- **test/dialect_test.gleam**: Update `sqlite_at_named_placeholder_test` to expect `field_name: "author_name"` (from the `@author_name` macro name) instead of `"name"` (from column inference)

## Design Decisions

- **Expand before `sqlc.arg/narg/slice` macros**: `@name` is expanded first, producing `SqlcArg` macros with sequential indices. Then `sqlc.arg()` expansion continues from the next index, ensuring no index collision
- **MySQL skipped**: sqlc does not support `@name` on MySQL, so we leave `@name` tokens untouched to avoid breaking user queries that use MySQL's `@variable` syntax

Closes #95