### PR TITLE
feat(codegen): generate typed RawQuery descriptors instead of detached Query and *_values helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,28 @@ pub type ListAuthorsRow {
 
 ### queries.gleam
 
+Each query function returns a typed `RawQuery(p)` descriptor that bundles the SQL text, command metadata, and a parameter encoder. The type parameter ties each query to its expected parameter type at compile time, preventing accidental misuse.
+
+`QueryInfo` and `all()` provide an untyped escape hatch for introspection (e.g. listing every query in a package).
+
 ```gleam
-pub type Query {
-  Query(name: String, sql: String, command: runtime.QueryCommand, param_count: Int)
+pub type QueryInfo {
+  QueryInfo(name: String, sql: String, command: runtime.QueryCommand, param_count: Int)
 }
 
-pub fn get_author() -> Query { ... }
-pub fn list_authors() -> Query { ... }
-pub fn create_author() -> Query { ... }
+pub fn all() -> List(QueryInfo) { ... }
+
+pub fn get_author() -> runtime.RawQuery(params.GetAuthorParams) { ... }
+pub fn list_authors() -> runtime.RawQuery(params.ListAuthorsParams) { ... }
+pub fn create_author() -> runtime.RawQuery(params.CreateAuthorParams) { ... }
+```
+
+Usage example — the compiler ensures you pass the right params to the right query:
+
+```gleam
+let q = queries.get_author()
+let values = q.encode(params.GetAuthorParams(id: 1))
+// q.sql, q.command, and values are now tied together
 ```
 
 ## Runtime modes
@@ -165,7 +179,7 @@ The `runtime` option controls what code sqlode generates and what dependencies y
 
 > **Note:** `runtime: "based"` is reserved for future use and is currently rejected. Use `"raw"` or `"native"` instead.
 
-**Dependency note:** In all modes, sqlode must be a dependency (not just a dev-dependency) because the generated code imports `sqlode/runtime` for the `Value` type and `QueryCommand` type. The `native` adapter mode additionally requires a database driver package:
+**Dependency note:** In all modes, sqlode must be a dependency (not just a dev-dependency) because the generated code imports `sqlode/runtime` for the `Value` type, `QueryCommand` type, and `RawQuery` type. The `native` adapter mode additionally requires a database driver package:
 
 ```console
 gleam add sqlode

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -34,8 +34,8 @@ Describe 'sqlode generate'
       The path "$TEST_OUTPUT_DIR/db/models.gleam" should be file
       The contents of file "$TEST_OUTPUT_DIR/db/params.gleam" should include 'GetAuthorParams(id: Int)'
       The contents of file "$TEST_OUTPUT_DIR/db/params.gleam" should include 'runtime.int(params.id)'
-      The contents of file "$TEST_OUTPUT_DIR/db/queries.gleam" should include 'pub fn get_author() -> Query {'
-      The contents of file "$TEST_OUTPUT_DIR/db/queries.gleam" should include 'pub fn list_authors() -> Query {'
+      The contents of file "$TEST_OUTPUT_DIR/db/queries.gleam" should include 'pub fn get_author() -> runtime.RawQuery(params.GetAuthorParams) {'
+      The contents of file "$TEST_OUTPUT_DIR/db/queries.gleam" should include 'pub fn list_authors() -> runtime.RawQuery(params.ListAuthorsParams) {'
       The contents of file "$TEST_OUTPUT_DIR/db/models.gleam" should include 'pub type GetAuthorRow {'
       The contents of file "$TEST_OUTPUT_DIR/db/models.gleam" should include 'pub type ListAuthorsRow {'
     End

--- a/src/sqlode/codegen.gleam
+++ b/src/sqlode/codegen.gleam
@@ -7,10 +7,11 @@ import sqlode/model
 import sqlode/naming
 
 pub fn render_queries_module(
+  naming_ctx: naming.NamingContext,
   block: model.SqlBlock,
   analyzed: List(model.AnalyzedQuery),
 ) -> String {
-  queries.render(block, analyzed)
+  queries.render(naming_ctx, block, analyzed)
 }
 
 pub fn render_params_module(

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -3,8 +3,10 @@ import gleam/list
 import gleam/string
 import sqlode/codegen/common
 import sqlode/model
+import sqlode/naming
 
 pub fn render(
+  naming_ctx: naming.NamingContext,
   block: model.SqlBlock,
   queries: List(model.AnalyzedQuery),
 ) -> String {
@@ -13,14 +15,14 @@ pub fn render(
 
   let query_functions =
     queries
-    |> list.map(fn(query) { render_query_function(query.base) })
+    |> list.map(render_query_function(naming_ctx, _))
     |> string.join("\n\n")
 
-  let all_queries = case queries {
+  let all_items = case queries {
     [] -> "[]"
     _ ->
       queries
-      |> list.map(fn(query) { query.base.function_name <> "()" })
+      |> list.map(fn(query) { render_query_info_literal(query.base) })
       |> string.join(", ")
       |> fn(items) { "[" <> items <> "]" }
   }
@@ -33,9 +35,10 @@ pub fn render(
       "// runtime: " <> model.runtime_to_string(runtime),
       "",
       "import sqlode/runtime",
+      "import " <> package <> "/params",
       "",
-      "pub type Query {",
-      "  Query(",
+      "pub type QueryInfo {",
+      "  QueryInfo(",
       "    name: String,",
       "    sql: String,",
       "    command: runtime.QueryCommand,",
@@ -43,8 +46,8 @@ pub fn render(
       "  )",
       "}",
       "",
-      "pub fn all() -> List(Query) {",
-      "  " <> all_queries,
+      "pub fn all() -> List(QueryInfo) {",
+      "  " <> all_items,
       "}",
       "",
       query_functions,
@@ -53,20 +56,44 @@ pub fn render(
   )
 }
 
-fn render_query_function(query: model.ParsedQuery) -> String {
+fn render_query_function(
+  naming_ctx: naming.NamingContext,
+  query: model.AnalyzedQuery,
+) -> String {
+  let params_type =
+    naming.to_pascal_case(naming_ctx, query.base.name) <> "Params"
+  let values_fn = query.base.function_name <> "_values"
+
   string.join(
     [
-      "pub fn " <> query.function_name <> "() -> Query {",
-      "  Query(",
-      "    name: \"" <> common.escape_string(query.name) <> "\",",
-      "    sql: \"" <> common.escape_string(query.sql) <> "\",",
+      "pub fn "
+        <> query.base.function_name
+        <> "() -> runtime.RawQuery(params."
+        <> params_type
+        <> ") {",
+      "  runtime.RawQuery(",
+      "    name: \"" <> common.escape_string(query.base.name) <> "\",",
+      "    sql: \"" <> common.escape_string(query.base.sql) <> "\",",
       "    command: runtime."
-        <> model.query_command_to_variant(query.command)
+        <> model.query_command_to_variant(query.base.command)
         <> ",",
-      "    param_count: " <> int.to_string(query.param_count) <> ",",
+      "    param_count: " <> int.to_string(query.base.param_count) <> ",",
+      "    encode: params." <> values_fn <> ",",
       "  )",
       "}",
     ],
     "\n",
   )
+}
+
+fn render_query_info_literal(query: model.ParsedQuery) -> String {
+  "QueryInfo(name: \""
+  <> common.escape_string(query.name)
+  <> "\", sql: \""
+  <> common.escape_string(query.sql)
+  <> "\", command: runtime."
+  <> model.query_command_to_variant(query.command)
+  <> ", param_count: "
+  <> int.to_string(query.param_count)
+  <> ")"
 }

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -107,7 +107,7 @@ fn generate_sql_block(
         writer.GeneratedFile(
           directory: out,
           path: "queries.gleam",
-          content: codegen.render_queries_module(block, analyzed),
+          content: codegen.render_queries_module(naming_ctx, block, analyzed),
         ),
       ]
 

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -20,6 +20,19 @@ pub type Value {
   SqlBytes(BitArray)
 }
 
+/// A typed raw query descriptor that bundles SQL metadata with its parameter
+/// encoder.  The type parameter `p` represents the parameter type for this
+/// query, which ties the query to its expected parameters at the type level.
+pub type RawQuery(p) {
+  RawQuery(
+    name: String,
+    sql: String,
+    command: QueryCommand,
+    param_count: Int,
+    encode: fn(p) -> List(Value),
+  )
+}
+
 pub fn null() -> Value {
   SqlNull
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -18,17 +18,25 @@ pub fn main() {
 }
 
 pub fn render_queries_module_test() {
+  let naming_ctx = naming.new()
   let block = test_block()
   let analyzed = analyzed_queries("test/fixtures/query.sql")
-  let rendered = codegen.render_queries_module(block, analyzed)
+  let rendered = codegen.render_queries_module(naming_ctx, block, analyzed)
 
-  string.contains(rendered, "pub fn get_author() -> Query {")
+  string.contains(
+    rendered,
+    "pub fn get_author() -> runtime.RawQuery(params.GetAuthorParams) {",
+  )
   |> should.be_true()
   string.contains(rendered, "import sqlode/runtime")
   |> should.be_true()
+  string.contains(rendered, "import db/params")
+  |> should.be_true()
   string.contains(rendered, "command: runtime.QueryOne")
   |> should.be_true()
-  string.contains(rendered, "pub fn all() -> List(Query) {")
+  string.contains(rendered, "encode: params.get_author_values,")
+  |> should.be_true()
+  string.contains(rendered, "pub fn all() -> List(QueryInfo) {")
   |> should.be_true()
   list.length(analyzed) |> should.equal(2)
 }


### PR DESCRIPTION
## Summary

- Add `RawQuery(p)` type to `sqlode/runtime` that bundles SQL metadata (name, sql, command, param_count) with a typed parameter encoder (`encode: fn(p) -> List(Value)`)
- Each generated query function now returns `runtime.RawQuery(params.XxxParams)` instead of the untyped `Query`, tying queries to their expected parameters at the type level
- Rename `Query` to `QueryInfo` and keep `all() -> List(QueryInfo)` as an untyped escape hatch for introspection

## Changes

- `src/sqlode/runtime.gleam`: Add `RawQuery(p)` type with `encode` field
- `src/sqlode/codegen/queries.gleam`: Generate typed `RawQuery(p)` descriptors; `all()` now inlines `QueryInfo` literals since typed query functions have heterogeneous return types
- `src/sqlode/codegen.gleam`: Pass `naming_ctx` to `render_queries_module`
- `src/sqlode/generate.gleam`: Update call site
- `test/codegen_test.gleam`: Update assertions for new API
- `README.md`: Document the new typed API with usage example

## Design Decisions

- **`RawQuery(p)` in runtime, not generated code**: Placing the type in the runtime module keeps it stable across regenerations and importable by user code
- **`QueryInfo` for `all()`**: Since `RawQuery(GetAuthorParams)` and `RawQuery(ListAuthorsParams)` are different types, they cannot be collected into a homogeneous list. `QueryInfo` provides untyped metadata for introspection use cases
- **No adapter changes needed**: The adapter only accesses `q.sql` from query objects, which exists on `RawQuery(p)` with the same field name

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an all() function to enumerate available queries.

* **Refactor**
  * Query API now uses stronger typing: query returns include associated parameter types for safer usage.
  * Renamed the aggregate query type to QueryInfo for clarity.
  * Enhanced parameter encoding wiring so queries carry their parameter encoder for type-safe construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->