### PR TITLE
feat(codegen): generate nested record types for sqlc.embed instead of flat expansion

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -230,34 +230,86 @@ fn render_decoder(
   case query.result_columns {
     [] -> "decode.success(Nil)"
     columns -> {
-      let field_lines =
-        columns
-        |> list.index_map(fn(col, idx) {
-          let field_name = naming.to_snake_case(naming_ctx, col.name)
-          let decoder = config.decoder_function(col.scalar_type)
-          let full_decoder = case col.nullable {
-            True -> "decode.optional(" <> decoder <> ")"
-            False -> decoder
+      let #(_, field_lines) =
+        list.fold(columns, #(0, []), fn(acc, col) {
+          let #(idx, lines) = acc
+          case col {
+            model.ResultColumn(name:, scalar_type:, nullable:, ..) -> {
+              let field_name = naming.to_snake_case(naming_ctx, name)
+              let decoder = config.decoder_function(scalar_type)
+              let full_decoder = case nullable {
+                True -> "decode.optional(" <> decoder <> ")"
+                False -> decoder
+              }
+              let line =
+                "    use "
+                <> field_name
+                <> " <- decode.field("
+                <> int.to_string(idx)
+                <> ", "
+                <> full_decoder
+                <> ")"
+              #(idx + 1, list.append(lines, [line]))
+            }
+            model.EmbeddedColumn(
+              name: embed_name,
+              table_name:,
+              columns: embed_cols,
+            ) -> {
+              let embed_field_name =
+                naming.to_snake_case(naming_ctx, embed_name)
+              let embed_type_name =
+                naming.to_pascal_case(naming_ctx, table_name)
+              let embed_lines =
+                list.index_map(embed_cols, fn(embed_col, embed_idx) {
+                  let field_name =
+                    naming.to_snake_case(naming_ctx, embed_col.name)
+                  let decoder = config.decoder_function(embed_col.scalar_type)
+                  let full_decoder = case embed_col.nullable {
+                    True -> "decode.optional(" <> decoder <> ")"
+                    False -> decoder
+                  }
+                  "    use "
+                  <> field_name
+                  <> " <- decode.field("
+                  <> int.to_string(idx + embed_idx)
+                  <> ", "
+                  <> full_decoder
+                  <> ")"
+                })
+              let embed_constructor_fields =
+                list.map(embed_cols, fn(c) {
+                  naming.to_snake_case(naming_ctx, c.name) <> ":"
+                })
+                |> string.join(", ")
+              let constructor_line =
+                "    let "
+                <> embed_field_name
+                <> " = models."
+                <> embed_type_name
+                <> "("
+                <> embed_constructor_fields
+                <> ")"
+              let all_lines = list.append(embed_lines, [constructor_line])
+              #(idx + list.length(embed_cols), list.append(lines, all_lines))
+            }
           }
-          "    use "
-          <> field_name
-          <> " <- decode.field("
-          <> int.to_string(idx)
-          <> ", "
-          <> full_decoder
-          <> ")"
         })
-        |> string.join("\n")
 
       let constructor_fields =
         columns
         |> list.map(fn(col) {
-          naming.to_snake_case(naming_ctx, col.name) <> ":"
+          case col {
+            model.ResultColumn(name:, ..) ->
+              naming.to_snake_case(naming_ctx, name) <> ":"
+            model.EmbeddedColumn(name:, ..) ->
+              naming.to_snake_case(naming_ctx, name) <> ":"
+          }
         })
         |> string.join(", ")
 
       "{\n"
-      <> field_lines
+      <> string.join(field_lines, "\n")
       <> "\n    decode.success(models."
       <> type_name
       <> "("
@@ -869,7 +921,14 @@ fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {
     let has_nullable_params =
       list.any(query.params, fn(param) { param.nullable })
     let has_nullable_results =
-      list.any(query.result_columns, fn(col) { col.nullable })
+      list.any(query.result_columns, fn(col) {
+        case col {
+          model.ResultColumn(nullable: True, ..) -> True
+          model.EmbeddedColumn(columns:, ..) ->
+            list.any(columns, fn(c) { c.nullable })
+          _ -> False
+        }
+      })
     let has_one_command = query.base.command == model.One
 
     has_nullable_params || has_nullable_results || has_one_command

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -113,13 +113,17 @@ fn collect_rich_types(
     queries
     |> list.flat_map(fn(query) {
       list.filter_map(query.result_columns, fn(col) {
-        case model.is_rich_type(col.scalar_type) {
-          True ->
-            Ok(model.scalar_type_to_gleam_type(
-              col.scalar_type,
-              model.RichMapping,
-            ))
-          False -> Error(Nil)
+        case col {
+          model.ResultColumn(scalar_type:, ..) ->
+            case model.is_rich_type(scalar_type) {
+              True ->
+                Ok(model.scalar_type_to_gleam_type(
+                  scalar_type,
+                  model.RichMapping,
+                ))
+              False -> Error(Nil)
+            }
+          model.EmbeddedColumn(..) -> Error(Nil)
         }
       })
     })
@@ -133,7 +137,14 @@ fn needs_option_import_for_results(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
     case query.base.command {
       model.One | model.Many ->
-        list.any(query.result_columns, fn(col) { col.nullable })
+        list.any(query.result_columns, fn(col) {
+          case col {
+            model.ResultColumn(nullable: True, ..) -> True
+            model.EmbeddedColumn(columns:, ..) ->
+              list.any(columns, fn(c) { c.nullable })
+            _ -> False
+          }
+        })
       _ -> False
     }
   })
@@ -150,8 +161,15 @@ fn has_custom_types_in_results(queries: List(model.AnalyzedQuery)) -> Bool {
     case query.base.command {
       model.One | model.Many ->
         list.any(query.result_columns, fn(col) {
-          case col.scalar_type {
-            model.CustomType(..) -> True
+          case col {
+            model.ResultColumn(scalar_type: model.CustomType(..), ..) -> True
+            model.EmbeddedColumn(columns:, ..) ->
+              list.any(columns, fn(c) {
+                case c.scalar_type {
+                  model.CustomType(..) -> True
+                  _ -> False
+                }
+              })
             _ -> False
           }
         })
@@ -220,15 +238,23 @@ fn render_row_type(
       let fields =
         columns
         |> list.map(fn(col) {
-          let gleam_type = case col.nullable {
-            True ->
-              "Option("
-              <> model.scalar_type_to_gleam_type(col.scalar_type, type_mapping)
-              <> ")"
-            False ->
-              model.scalar_type_to_gleam_type(col.scalar_type, type_mapping)
+          case col {
+            model.ResultColumn(name:, scalar_type:, nullable:, ..) -> {
+              let gleam_type = case nullable {
+                True ->
+                  "Option("
+                  <> model.scalar_type_to_gleam_type(scalar_type, type_mapping)
+                  <> ")"
+                False ->
+                  model.scalar_type_to_gleam_type(scalar_type, type_mapping)
+              }
+              naming.to_snake_case(naming_ctx, name) <> ": " <> gleam_type
+            }
+            model.EmbeddedColumn(name:, table_name:, ..) ->
+              naming.to_snake_case(naming_ctx, name)
+              <> ": "
+              <> naming.to_pascal_case(naming_ctx, table_name)
           }
-          naming.to_snake_case(naming_ctx, col.name) <> ": " <> gleam_type
         })
         |> string.join(", ")
 

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -335,9 +335,13 @@ fn apply_column_renames(
       list.map(queries, fn(query) {
         let result_columns =
           list.map(query.result_columns, fn(col) {
-            case find_column_rename(col.name, col.source_table, renames) {
-              Ok(new_name) -> model.ResultColumn(..col, name: new_name)
-              Error(_) -> col
+            case col {
+              model.ResultColumn(name:, source_table:, ..) ->
+                case find_column_rename(name, source_table, renames) {
+                  Ok(new_name) -> model.ResultColumn(..col, name: new_name)
+                  Error(_) -> col
+                }
+              model.EmbeddedColumn(..) -> col
             }
           })
         model.AnalyzedQuery(..query, result_columns:)
@@ -382,17 +386,31 @@ fn compute_table_matches(
   queries
   |> list.filter_map(fn(query) {
     case query.base.command {
-      model.One | model.Many ->
-        case query.result_columns {
-          [] -> Error(Nil)
-          [first, ..] ->
-            case first.source_table {
-              option.None -> Error(Nil)
-              option.Some(table_name) -> {
-                // All result columns must reference the same table
+      model.One | model.Many -> {
+        // Queries with embedded columns never match a single table
+        let has_embed =
+          list.any(query.result_columns, fn(col) {
+            case col {
+              model.EmbeddedColumn(..) -> True
+              _ -> False
+            }
+          })
+        case has_embed {
+          True -> Error(Nil)
+          False ->
+            case query.result_columns {
+              [] -> Error(Nil)
+              [
+                model.ResultColumn(source_table: option.Some(table_name), ..),
+                ..
+              ] -> {
                 let all_same_table =
                   list.all(query.result_columns, fn(col) {
-                    col.source_table == option.Some(table_name)
+                    case col {
+                      model.ResultColumn(source_table: src, ..) ->
+                        src == option.Some(table_name)
+                      model.EmbeddedColumn(..) -> False
+                    }
                   })
                 case all_same_table {
                   False -> Error(Nil)
@@ -413,8 +431,10 @@ fn compute_table_matches(
                     }
                 }
               }
+              _ -> Error(Nil)
             }
         }
+      }
       _ -> Error(Nil)
     }
   })
@@ -440,9 +460,13 @@ fn columns_match(
       list.zip(result_columns, table_columns)
       |> list.all(fn(pair) {
         let #(rc, tc) = pair
-        string.lowercase(rc.name) == string.lowercase(tc.name)
-        && rc.scalar_type == tc.scalar_type
-        && rc.nullable == tc.nullable
+        case rc {
+          model.ResultColumn(name:, scalar_type:, nullable:, ..) ->
+            string.lowercase(name) == string.lowercase(tc.name)
+            && scalar_type == tc.scalar_type
+            && nullable == tc.nullable
+          model.EmbeddedColumn(..) -> False
+        }
       })
   }
 }

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -326,6 +326,7 @@ pub type ResultColumn {
     nullable: Bool,
     source_table: Option(String),
   )
+  EmbeddedColumn(name: String, table_name: String, columns: List(Column))
 }
 
 pub type AnalyzedQuery {

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -255,16 +255,13 @@ fn resolve_select_columns(
               |> list.find(fn(table) { table.name == embed_name })
             {
               Ok(table) ->
-                Ok(
-                  list.map(table.columns, fn(col) {
-                    model.ResultColumn(
-                      name: col.name,
-                      scalar_type: col.scalar_type,
-                      nullable: col.nullable,
-                      source_table: Some(embed_name),
-                    )
-                  }),
-                )
+                Ok([
+                  model.EmbeddedColumn(
+                    name: embed_name,
+                    table_name: embed_name,
+                    columns: table.columns,
+                  ),
+                ])
               Error(_) ->
                 Error(TableNotFound(query_name:, table_name: embed_name))
             }

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -93,7 +93,8 @@ pub fn mysql_result_columns_test() {
   list.length(get.result_columns) |> should.equal(2)
   let assert [id_col, name_col] = get.result_columns
   id_col.name |> should.equal("id")
-  id_col.scalar_type |> should.equal(model.IntType)
+  let assert model.ResultColumn(scalar_type: id_scalar_type, ..) = id_col
+  id_scalar_type |> should.equal(model.IntType)
   name_col.name |> should.equal("name")
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1,3 +1,4 @@
+import gleam/list
 import gleam/option.{Some}
 import gleeunit
 import gleeunit/should
@@ -383,12 +384,12 @@ pub fn sqlc_embed_expands_table_columns_test() {
     )
   let assert [query] = analyzed
 
-  let assert [id_col, name_col, bio_col, title_col] = query.result_columns
-  id_col.name |> should.equal("id")
-  id_col.scalar_type |> should.equal(model.IntType)
-  name_col.name |> should.equal("name")
-  bio_col.name |> should.equal("bio")
-  bio_col.nullable |> should.equal(True)
+  let assert [embed_col, title_col] = query.result_columns
+  let assert model.EmbeddedColumn(name: embed_name, table_name:, columns:) =
+    embed_col
+  embed_name |> should.equal("authors")
+  table_name |> should.equal("authors")
+  list.length(columns) |> should.equal(3)
   title_col.name |> should.equal("title")
 }
 
@@ -445,7 +446,8 @@ pub fn cte_select_from_real_table_test() {
 
   let assert [id_col, name_col] = query.result_columns
   id_col.name |> should.equal("id")
-  id_col.scalar_type |> should.equal(model.IntType)
+  let assert model.ResultColumn(scalar_type: id_scalar_type, ..) = id_col
+  id_scalar_type |> should.equal(model.IntType)
   name_col.name |> should.equal("name")
 }
 

--- a/test/sqlc_compat_test.gleam
+++ b/test/sqlc_compat_test.gleam
@@ -123,7 +123,8 @@ pub fn all_types_result_columns_star_test() {
   list.length(get_all.result_columns) |> should.equal(23)
   let assert [id_col, ..] = get_all.result_columns
   id_col.name |> should.equal("id")
-  id_col.scalar_type |> should.equal(model.IntType)
+  let assert model.ResultColumn(scalar_type: id_col_type, ..) = id_col
+  id_col_type |> should.equal(model.IntType)
 
   // :many with SELECT * should also return all columns
   list.length(list_all.result_columns) |> should.equal(23)
@@ -226,10 +227,14 @@ pub fn complex_query_basic_crud_test() {
   get_post.base.command |> should.equal(model.One)
   list.length(get_post.result_columns) |> should.equal(4)
   let assert [id, title, body, published] = get_post.result_columns
-  id.scalar_type |> should.equal(model.IntType)
-  title.scalar_type |> should.equal(model.StringType)
-  body.scalar_type |> should.equal(model.StringType)
-  published.scalar_type |> should.equal(model.BoolType)
+  let assert model.ResultColumn(scalar_type: id_type, ..) = id
+  id_type |> should.equal(model.IntType)
+  let assert model.ResultColumn(scalar_type: title_type, ..) = title
+  title_type |> should.equal(model.StringType)
+  let assert model.ResultColumn(scalar_type: body_type, ..) = body
+  body_type |> should.equal(model.StringType)
+  let assert model.ResultColumn(scalar_type: published_type, ..) = published
+  published_type |> should.equal(model.BoolType)
 
   // CreatePost :exec - no result columns
   let assert Ok(create_post) =
@@ -268,9 +273,11 @@ pub fn complex_query_single_join_test() {
 
   let assert [title, username] = post_with_author.result_columns
   title.name |> should.equal("title")
-  title.scalar_type |> should.equal(model.StringType)
+  let assert model.ResultColumn(scalar_type: title_type, ..) = title
+  title_type |> should.equal(model.StringType)
   username.name |> should.equal("username")
-  username.scalar_type |> should.equal(model.StringType)
+  let assert model.ResultColumn(scalar_type: username_type, ..) = username
+  username_type |> should.equal(model.StringType)
 }
 
 pub fn complex_query_multi_join_test() {
@@ -324,7 +331,8 @@ pub fn complex_query_returning_clause_test() {
   list.length(create_returning.result_columns) |> should.equal(2)
   let assert [id, title] = create_returning.result_columns
   id.name |> should.equal("id")
-  id.scalar_type |> should.equal(model.IntType)
+  let assert model.ResultColumn(scalar_type: id_type, ..) = id
+  id_type |> should.equal(model.IntType)
   title.name |> should.equal("title")
 
   // DELETE ... RETURNING
@@ -340,7 +348,8 @@ pub fn complex_query_returning_clause_test() {
   list.length(update_returning.result_columns) |> should.equal(3)
   let assert [_, _, published] = update_returning.result_columns
   published.name |> should.equal("published")
-  published.scalar_type |> should.equal(model.BoolType)
+  let assert model.ResultColumn(scalar_type: published_type, ..) = published
+  published_type |> should.equal(model.BoolType)
 }
 
 pub fn complex_query_update_params_test() {


### PR DESCRIPTION
## Summary

- `sqlc.embed(table)` now generates nested record types referencing the table type, instead of flattening all embedded columns into the row type
- This matches sqlc's Go behavior and prevents name collisions when embedding multiple tables

## Changes

- `src/sqlode/model.gleam`: Add `EmbeddedColumn` variant to `ResultColumn` type with `name`, `table_name`, and `columns` fields
- `src/sqlode/query_analyzer/column_inferencer.gleam`: Return a single `EmbeddedColumn` instead of flattening table columns for `sqlc.embed()`
- `src/sqlode/codegen/models.gleam`: Handle `EmbeddedColumn` in row type rendering by referencing the table type (e.g., `authors: Authors`)
- `src/sqlode/codegen/adapter.gleam`: Update decoder generation to handle embedded columns with index offset tracking and nested table type construction
- `src/sqlode/generate.gleam`: Update `compute_table_matches`, `columns_match`, and `apply_column_renames` to handle the new variant
- `test/`: Update all test files with `ResultColumn` field access to use pattern matching (required by multi-variant type)

## Design Decisions

- **`EmbeddedColumn` stores `List(Column)`**: Embedding the table's column definitions allows the adapter decoder to know how many DB columns to consume and their types, without a catalog lookup at codegen time
- **Queries with embeds never match table aliases**: `compute_table_matches` skips queries containing `EmbeddedColumn` since their result shape is composite
- **Column renames skip embedded columns**: Renaming sub-fields of an embedded table doesn't make semantic sense; the table type is authoritative

## Limitations

- Nested embeds (`sqlc.embed(sqlc.embed(...))`) are not supported — the parser naturally rejects this since it looks up the argument as a table name

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for embedded columns in SQL query result sets, enabling proper handling of structured column groups from database queries.

* **Bug Fixes**
  * Improved nullable column detection for embedded structures to accurately identify when nested columns require optional handling.

* **Tests**
  * Updated test assertions to validate embedded column handling and code generation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->