### PR TITLE
feat(codegen): add batch query annotations :batchone, :batchmany, :batchexec

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -112,7 +112,8 @@ fn render_adapter(
   let has_results =
     list.any(queries, fn(query) {
       case query.base.command {
-        model.One | model.Many -> !list.is_empty(query.result_columns)
+        model.One | model.Many | model.BatchOne | model.BatchMany ->
+          !list.is_empty(query.result_columns)
         _ -> False
       }
     })
@@ -174,7 +175,7 @@ fn render_adapter_function(
   let has_params = !list.is_empty(query.params)
 
   case query.base.command {
-    model.One ->
+    model.One | model.BatchOne ->
       render_adapter_one(
         naming_ctx,
         query,
@@ -183,7 +184,7 @@ fn render_adapter_function(
         table_matches,
         config,
       )
-    model.Many ->
+    model.Many | model.BatchMany ->
       render_adapter_many(
         naming_ctx,
         query,
@@ -192,7 +193,7 @@ fn render_adapter_function(
         table_matches,
         config,
       )
-    model.Exec ->
+    model.Exec | model.BatchExec ->
       render_adapter_exec(naming_ctx, query, fn_name, has_params, config)
     model.ExecResult | model.ExecRows ->
       render_adapter_exec_rows(naming_ctx, query, fn_name, has_params, config)
@@ -929,7 +930,8 @@ fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {
           _ -> False
         }
       })
-    let has_one_command = query.base.command == model.One
+    let has_one_command =
+      query.base.command == model.One || query.base.command == model.BatchOne
 
     has_nullable_params || has_nullable_results || has_one_command
   })

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -25,7 +25,8 @@ pub fn render(
     queries
     |> list.filter(fn(query) {
       case query.base.command {
-        model.One | model.Many -> !list.is_empty(query.result_columns)
+        model.One | model.Many | model.BatchOne | model.BatchMany ->
+          !list.is_empty(query.result_columns)
         _ -> False
       }
     })
@@ -136,7 +137,7 @@ fn collect_rich_types(
 fn needs_option_import_for_results(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
     case query.base.command {
-      model.One | model.Many ->
+      model.One | model.Many | model.BatchOne | model.BatchMany ->
         list.any(query.result_columns, fn(col) {
           case col {
             model.ResultColumn(nullable: True, ..) -> True
@@ -159,7 +160,7 @@ fn needs_option_import_for_tables(catalog: model.Catalog) -> Bool {
 fn has_custom_types_in_results(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
     case query.base.command {
-      model.One | model.Many ->
+      model.One | model.Many | model.BatchOne | model.BatchMany ->
         list.any(query.result_columns, fn(col) {
           case col {
             model.ResultColumn(scalar_type: model.CustomType(..), ..) -> True

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -87,7 +87,8 @@ fn generate_sql_block(
       let has_row_types =
         list.any(analyzed, fn(query) {
           case query.base.command {
-            model.One | model.Many -> !list.is_empty(query.result_columns)
+            model.One | model.Many | model.BatchOne | model.BatchMany ->
+              !list.is_empty(query.result_columns)
             _ -> False
           }
         })
@@ -386,7 +387,7 @@ fn compute_table_matches(
   queries
   |> list.filter_map(fn(query) {
     case query.base.command {
-      model.One | model.Many -> {
+      model.One | model.Many | model.BatchOne | model.BatchMany -> {
         // Queries with embedded columns never match a single table
         let has_embed =
           list.any(query.result_columns, fn(col) {

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -116,6 +116,9 @@ pub type QueryCommand {
   ExecResult
   ExecRows
   ExecLastId
+  BatchOne
+  BatchMany
+  BatchExec
 }
 
 pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
@@ -126,9 +129,12 @@ pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
     ":execresult" -> Ok(ExecResult)
     ":execrows" -> Ok(ExecRows)
     ":execlastid" -> Ok(ExecLastId)
+    ":batchone" -> Ok(BatchOne)
+    ":batchmany" -> Ok(BatchMany)
+    ":batchexec" -> Ok(BatchExec)
     _ ->
       Error(
-        "must be one of: :one, :many, :exec, :execresult, :execrows, :execlastid",
+        "must be one of: :one, :many, :exec, :execresult, :execrows, :execlastid, :batchone, :batchmany, :batchexec",
       )
   }
 }
@@ -141,6 +147,9 @@ pub fn query_command_to_variant(command: QueryCommand) -> String {
     ExecResult -> "QueryExecResult"
     ExecRows -> "QueryExecRows"
     ExecLastId -> "QueryExecLastId"
+    BatchOne -> "QueryBatchOne"
+    BatchMany -> "QueryBatchMany"
+    BatchExec -> "QueryBatchExec"
   }
 }
 

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -18,8 +18,12 @@ pub fn infer_result_columns(
   catalog: model.Catalog,
 ) -> Result(List(model.ResultColumn), AnalysisError) {
   case query.command {
-    model.Exec | model.ExecResult | model.ExecRows | model.ExecLastId -> Ok([])
-    model.One | model.Many -> {
+    model.Exec
+    | model.ExecResult
+    | model.ExecRows
+    | model.ExecLastId
+    | model.BatchExec -> Ok([])
+    model.One | model.Many | model.BatchOne | model.BatchMany -> {
       let normalized = context.normalize_sql(ctx, query.sql)
 
       case extract_returning_columns(ctx, normalized) {

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -9,6 +9,9 @@ pub type QueryCommand {
   QueryExecResult
   QueryExecRows
   QueryExecLastId
+  QueryBatchOne
+  QueryBatchMany
+  QueryBatchExec
 }
 
 pub type Value {

--- a/test/fixtures/all_commands_query.sql
+++ b/test/fixtures/all_commands_query.sql
@@ -15,3 +15,12 @@ SELECT id FROM posts;
 
 -- name: InsertPost :execlastid
 INSERT INTO posts (title, body) VALUES (?1, ?2);
+
+-- name: GetPostBatch :batchone
+SELECT id, title, body FROM posts WHERE id = ?1;
+
+-- name: ListPostsBatch :batchmany
+SELECT id, title FROM posts WHERE id = ?1;
+
+-- name: CreatePostBatch :batchexec
+INSERT INTO posts (title, body) VALUES (?1, ?2);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -756,13 +756,16 @@ pub fn all_commands_generate_queries_test() {
 
   let queries = read_commands_file("queries.gleam")
 
-  // All 6 query functions should exist
+  // All 9 query functions should exist
   string.contains(queries, "pub fn get_post()") |> should.be_true()
   string.contains(queries, "pub fn list_posts()") |> should.be_true()
   string.contains(queries, "pub fn create_post()") |> should.be_true()
   string.contains(queries, "pub fn update_post()") |> should.be_true()
   string.contains(queries, "pub fn count_posts()") |> should.be_true()
   string.contains(queries, "pub fn insert_post()") |> should.be_true()
+  string.contains(queries, "pub fn get_post_batch()") |> should.be_true()
+  string.contains(queries, "pub fn list_posts_batch()") |> should.be_true()
+  string.contains(queries, "pub fn create_post_batch()") |> should.be_true()
 
   // Verify command types
   string.contains(queries, "runtime.QueryOne") |> should.be_true()
@@ -771,6 +774,9 @@ pub fn all_commands_generate_queries_test() {
   string.contains(queries, "runtime.QueryExecResult") |> should.be_true()
   string.contains(queries, "runtime.QueryExecRows") |> should.be_true()
   string.contains(queries, "runtime.QueryExecLastId") |> should.be_true()
+  string.contains(queries, "runtime.QueryBatchOne") |> should.be_true()
+  string.contains(queries, "runtime.QueryBatchMany") |> should.be_true()
+  string.contains(queries, "runtime.QueryBatchExec") |> should.be_true()
 
   cleanup_commands()
 }
@@ -793,6 +799,10 @@ pub fn all_commands_generate_params_test() {
   string.contains(params, "InsertPostParams") |> should.be_true()
   // :many without params should still have type
   string.contains(params, "ListPostsParams") |> should.be_true()
+  // batch variants with params
+  string.contains(params, "GetPostBatchParams") |> should.be_true()
+  string.contains(params, "ListPostsBatchParams") |> should.be_true()
+  string.contains(params, "CreatePostBatchParams") |> should.be_true()
 
   cleanup_commands()
 }
@@ -813,6 +823,12 @@ pub fn all_commands_generate_models_test() {
   string.contains(models, "CreatePostRow") |> should.be_false()
   string.contains(models, "UpdatePostRow") |> should.be_false()
   string.contains(models, "InsertPostRow") |> should.be_false()
+
+  // :batchone and :batchmany generate row types
+  string.contains(models, "GetPostBatchRow") |> should.be_true()
+  string.contains(models, "ListPostsBatchRow") |> should.be_true()
+  // :batchexec should NOT generate row types
+  string.contains(models, "CreatePostBatchRow") |> should.be_false()
 
   cleanup_commands()
 }
@@ -841,6 +857,11 @@ pub fn all_commands_sqlight_adapter_test() {
   string.contains(adapter, "Result(Int, sqlight.Error)") |> should.be_true()
   // :execlastid returns Nil (same as exec for sqlight)
   string.contains(adapter, "fn insert_post(") |> should.be_true()
+
+  // batch variants generate adapter functions
+  string.contains(adapter, "fn get_post_batch(") |> should.be_true()
+  string.contains(adapter, "fn list_posts_batch(") |> should.be_true()
+  string.contains(adapter, "fn create_post_batch(") |> should.be_true()
 
   cleanup_commands()
 }

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -70,6 +70,18 @@ pub fn parse_query_command_execlastid_test() {
   |> should.equal(Ok(model.ExecLastId))
 }
 
+pub fn parse_query_command_batchone_test() {
+  model.parse_query_command(":batchone") |> should.equal(Ok(model.BatchOne))
+}
+
+pub fn parse_query_command_batchmany_test() {
+  model.parse_query_command(":batchmany") |> should.equal(Ok(model.BatchMany))
+}
+
+pub fn parse_query_command_batchexec_test() {
+  model.parse_query_command(":batchexec") |> should.equal(Ok(model.BatchExec))
+}
+
 pub fn parse_query_command_invalid_test() {
   model.parse_query_command(":select") |> should.be_error()
 }


### PR DESCRIPTION
## Summary

- Add `:batchone`, `:batchmany`, `:batchexec` query command annotations for PostgreSQL batch operations
- Batch queries generate the same raw-mode and native-adapter code as their non-batch equivalents, enabling users to call them in a loop for pseudo-batch behavior

## Changes

- `src/sqlode/model.gleam`: Add `BatchOne`, `BatchMany`, `BatchExec` variants to `QueryCommand`; update `parse_query_command` and `query_command_to_variant`
- `src/sqlode/runtime.gleam`: Add `QueryBatchOne`, `QueryBatchMany`, `QueryBatchExec` runtime variants
- `src/sqlode/query_analyzer/column_inferencer.gleam`: `BatchOne`/`BatchMany` infer result columns; `BatchExec` returns empty
- `src/sqlode/codegen/models.gleam`: `BatchOne`/`BatchMany` generate row types
- `src/sqlode/codegen/adapter.gleam`: Route batch variants to existing adapter handlers (`BatchOne` -> One, `BatchMany` -> Many, `BatchExec` -> Exec)
- `src/sqlode/generate.gleam`: Update `has_row_types` and `compute_table_matches` checks
- `test/fixtures/all_commands_query.sql`: Add batch query fixtures
- `test/generate_test.gleam`: Add batch assertions for queries, params, models, and adapter
- `test/model_test.gleam`: Add parse tests for batch annotations

## Design Decisions

- **Batch variants route through non-batch handlers in the native adapter**: Since pog (Gleam's PostgreSQL driver) does not support pgx-style batching, generating per-invocation adapter functions is the pragmatic choice — users can wrap them in `list.map` for pseudo-batch behavior
- **Distinct runtime variants**: `QueryBatchOne` etc. are separate from `QueryOne` so that raw-mode consumers can distinguish batch intent and implement true batching when driver support becomes available

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for batch query command modes (batch-one, batch-many, batch-exec) enabling batch processing of SQL queries with automatic result handling equivalent to standard command modes.

* **Tests**
  * Added comprehensive test coverage for batch query command parsing and code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->