### PR TITLE
feat(codegen): add :copyfrom annotation for bulk insert

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -193,7 +193,7 @@ fn render_adapter_function(
         table_matches,
         config,
       )
-    model.Exec | model.BatchExec ->
+    model.Exec | model.BatchExec | model.CopyFrom ->
       render_adapter_exec(naming_ctx, query, fn_name, has_params, config)
     model.ExecResult | model.ExecRows ->
       render_adapter_exec_rows(naming_ctx, query, fn_name, has_params, config)

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -119,6 +119,7 @@ pub type QueryCommand {
   BatchOne
   BatchMany
   BatchExec
+  CopyFrom
 }
 
 pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
@@ -132,9 +133,10 @@ pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
     ":batchone" -> Ok(BatchOne)
     ":batchmany" -> Ok(BatchMany)
     ":batchexec" -> Ok(BatchExec)
+    ":copyfrom" -> Ok(CopyFrom)
     _ ->
       Error(
-        "must be one of: :one, :many, :exec, :execresult, :execrows, :execlastid, :batchone, :batchmany, :batchexec",
+        "must be one of: :one, :many, :exec, :execresult, :execrows, :execlastid, :batchone, :batchmany, :batchexec, :copyfrom",
       )
   }
 }
@@ -150,6 +152,7 @@ pub fn query_command_to_variant(command: QueryCommand) -> String {
     BatchOne -> "QueryBatchOne"
     BatchMany -> "QueryBatchMany"
     BatchExec -> "QueryBatchExec"
+    CopyFrom -> "QueryCopyFrom"
   }
 }
 

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -22,7 +22,8 @@ pub fn infer_result_columns(
     | model.ExecResult
     | model.ExecRows
     | model.ExecLastId
-    | model.BatchExec -> Ok([])
+    | model.BatchExec
+    | model.CopyFrom -> Ok([])
     model.One | model.Many | model.BatchOne | model.BatchMany -> {
       let normalized = context.normalize_sql(ctx, query.sql)
 

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -12,6 +12,7 @@ pub type QueryCommand {
   QueryBatchOne
   QueryBatchMany
   QueryBatchExec
+  QueryCopyFrom
 }
 
 pub type Value {

--- a/test/fixtures/all_commands_query.sql
+++ b/test/fixtures/all_commands_query.sql
@@ -24,3 +24,6 @@ SELECT id, title FROM posts WHERE id = ?1;
 
 -- name: CreatePostBatch :batchexec
 INSERT INTO posts (title, body) VALUES (?1, ?2);
+
+-- name: BulkInsertPosts :copyfrom
+INSERT INTO posts (title, body) VALUES (?1, ?2);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -777,6 +777,8 @@ pub fn all_commands_generate_queries_test() {
   string.contains(queries, "runtime.QueryBatchOne") |> should.be_true()
   string.contains(queries, "runtime.QueryBatchMany") |> should.be_true()
   string.contains(queries, "runtime.QueryBatchExec") |> should.be_true()
+  string.contains(queries, "pub fn bulk_insert_posts()") |> should.be_true()
+  string.contains(queries, "runtime.QueryCopyFrom") |> should.be_true()
 
   cleanup_commands()
 }
@@ -803,6 +805,8 @@ pub fn all_commands_generate_params_test() {
   string.contains(params, "GetPostBatchParams") |> should.be_true()
   string.contains(params, "ListPostsBatchParams") |> should.be_true()
   string.contains(params, "CreatePostBatchParams") |> should.be_true()
+  // :copyfrom with params
+  string.contains(params, "BulkInsertPostsParams") |> should.be_true()
 
   cleanup_commands()
 }
@@ -829,6 +833,8 @@ pub fn all_commands_generate_models_test() {
   string.contains(models, "ListPostsBatchRow") |> should.be_true()
   // :batchexec should NOT generate row types
   string.contains(models, "CreatePostBatchRow") |> should.be_false()
+  // :copyfrom should NOT generate row types
+  string.contains(models, "BulkInsertPostsRow") |> should.be_false()
 
   cleanup_commands()
 }
@@ -862,6 +868,8 @@ pub fn all_commands_sqlight_adapter_test() {
   string.contains(adapter, "fn get_post_batch(") |> should.be_true()
   string.contains(adapter, "fn list_posts_batch(") |> should.be_true()
   string.contains(adapter, "fn create_post_batch(") |> should.be_true()
+  // :copyfrom generates adapter function
+  string.contains(adapter, "fn bulk_insert_posts(") |> should.be_true()
 
   cleanup_commands()
 }

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -82,6 +82,10 @@ pub fn parse_query_command_batchexec_test() {
   model.parse_query_command(":batchexec") |> should.equal(Ok(model.BatchExec))
 }
 
+pub fn parse_query_command_copyfrom_test() {
+  model.parse_query_command(":copyfrom") |> should.equal(Ok(model.CopyFrom))
+}
+
 pub fn parse_query_command_invalid_test() {
   model.parse_query_command(":select") |> should.be_error()
 }


### PR DESCRIPTION
## Summary

- Add `:copyfrom` query command annotation for bulk insert operations
- Routes through the same exec adapter handler since Gleam database drivers do not yet support COPY protocol

## Changes

- `src/sqlode/model.gleam`: Add `CopyFrom` variant to `QueryCommand`; update `parse_query_command` and `query_command_to_variant`
- `src/sqlode/runtime.gleam`: Add `QueryCopyFrom` runtime variant
- `src/sqlode/query_analyzer/column_inferencer.gleam`: `CopyFrom` returns empty result columns (like `Exec`)
- `src/sqlode/codegen/adapter.gleam`: Route `CopyFrom` to existing exec adapter handler
- `test/fixtures/all_commands_query.sql`: Add `:copyfrom` fixture
- `test/generate_test.gleam`: Add copyfrom assertions for queries, params, models, and adapter
- `test/model_test.gleam`: Add parse test for `:copyfrom`

## Design Decisions

- **CopyFrom routes through Exec handler**: Since pog and sqlight do not support database-level COPY protocol, generating a standard exec adapter function is the pragmatic choice. Users can wrap calls in `list.map` for pseudo-bulk behavior. The distinct `QueryCopyFrom` runtime variant allows raw-mode consumers to detect copyfrom intent and implement true bulk operations when driver support becomes available.

## Limitations

- No true COPY protocol support — requires driver-level changes in pog/sqlight

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `:copyfrom` command type, enabling a new bulk operation execution mode in SQL queries.
  * Extended code generation to handle the new command type alongside existing execution modes.

* **Tests**
  * Added comprehensive test coverage for the new `:copyfrom` command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->