### PR TITLE
fix(generate): resolve paths relative to config file directory

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -62,7 +62,11 @@ fn resolve_config_paths(cfg: model.Config, base_dir: String) -> model.Config {
 fn resolve_path(base_dir: String, path: String) -> String {
   case filepath.is_absolute(path) {
     True -> path
-    False -> filepath.join(base_dir, path)
+    False ->
+      case filepath.expand(filepath.join(base_dir, path)) {
+        Ok(expanded) -> expanded
+        Error(_) -> filepath.join(base_dir, path)
+      }
   }
 }
 

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -1,3 +1,4 @@
+import filepath
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/io
@@ -38,7 +39,31 @@ pub fn run(config_path: String) -> Result(List(String), GenerateError) {
     |> result.map_error(ConfigError),
   )
 
-  generate_config(cfg)
+  let config_dir = filepath.directory_name(config_path)
+  let resolved = resolve_config_paths(cfg, config_dir)
+  generate_config(resolved)
+}
+
+fn resolve_config_paths(cfg: model.Config, base_dir: String) -> model.Config {
+  let sql =
+    list.map(cfg.sql, fn(block) {
+      let schema = list.map(block.schema, resolve_path(base_dir, _))
+      let queries = list.map(block.queries, resolve_path(base_dir, _))
+      let gleam =
+        model.GleamOutput(
+          ..block.gleam,
+          out: resolve_path(base_dir, block.gleam.out),
+        )
+      model.SqlBlock(..block, schema:, queries:, gleam:)
+    })
+  model.Config(..cfg, sql:)
+}
+
+fn resolve_path(base_dir: String, path: String) -> String {
+  case filepath.is_absolute(path) {
+    True -> path
+    False -> filepath.join(base_dir, path)
+  }
 }
 
 pub fn generate_config(cfg: model.Config) -> Result(List(String), GenerateError) {

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -15,10 +15,10 @@ pub fn load_sqlc_style_config_test() {
 
   let assert [block] = cfg.sql
   block.engine |> should.equal(model.PostgreSQL)
-  block.schema |> should.equal(["test/fixtures/schema.sql"])
-  block.queries |> should.equal(["test/fixtures/query.sql"])
+  block.schema |> should.equal(["schema.sql"])
+  block.queries |> should.equal(["query.sql"])
   block.gleam.package |> should.equal("db")
-  block.gleam.out |> should.equal("test_output/db")
+  block.gleam.out |> should.equal("../../test_output/db")
   block.gleam.runtime |> should.equal(model.Raw)
 }
 

--- a/test/fixtures/sqlode.yaml
+++ b/test/fixtures/sqlode.yaml
@@ -1,10 +1,10 @@
 version: "2"
 sql:
-  - schema: "test/fixtures/schema.sql"
-    queries: "test/fixtures/query.sql"
+  - schema: "schema.sql"
+    queries: "query.sql"
     engine: "postgresql"
     gen:
       gleam:
         package: "db"
-        out: "test_output/db"
+        out: "../../test_output/db"
         runtime: "raw"

--- a/test/fixtures/subdir/sqlode_relative.yaml
+++ b/test/fixtures/subdir/sqlode_relative.yaml
@@ -1,0 +1,10 @@
+version: "2"
+sql:
+  - schema: "../schema.sql"
+    queries: "../query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "/tmp/sqlode_resolve_paths_test"
+        runtime: "raw"

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1,3 +1,4 @@
+import gleam/list
 import gleam/option
 import gleam/string
 import gleeunit/should
@@ -1085,4 +1086,28 @@ pub fn view_select_star_inferred_test() {
   string.contains(models, "bio: Option(String)") |> should.be_true()
 
   cleanup_view()
+}
+
+// --- Config path resolution tests ---
+
+const resolve_out = "/tmp/sqlode_resolve_paths_test"
+
+fn cleanup_resolve() {
+  let _ = simplifile.delete(resolve_out)
+  Nil
+}
+
+pub fn run_resolves_paths_relative_to_config_dir_test() {
+  cleanup_resolve()
+  let assert Ok(files) =
+    generate.run("test/fixtures/subdir/sqlode_relative.yaml")
+
+  // schema and queries are resolved relative to config dir (test/fixtures/subdir/)
+  // so ../schema.sql and ../query.sql resolve to test/fixtures/schema.sql etc.
+  list.length(files) |> should.equal(3)
+
+  let assert Ok(models) = simplifile.read(resolve_out <> "/models.gleam")
+  string.contains(models, "Authors") |> should.be_true()
+
+  cleanup_resolve()
 }

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -322,3 +322,7 @@ pub fn view_select_columns_inferred_test() {
 pub fn view_select_star_inferred_test() {
   generate_test.view_select_star_inferred_test()
 }
+
+pub fn run_resolves_paths_relative_to_config_dir_test() {
+  generate_test.run_resolves_paths_relative_to_config_dir_test()
+}


### PR DESCRIPTION
## Summary

- Resolve `schema`, `queries`, and `out` paths in the config relative to the config file's directory, not the current working directory
- Absolute paths are left unchanged
- Add test verifying path resolution with a config file in a subdirectory

## Changes

- `src/sqlode/generate.gleam`: Add `resolve_config_paths` and `resolve_path` helpers that resolve relative paths using `filepath.directory_name` and `filepath.join` before passing the config to `generate_config`
- `test/fixtures/subdir/sqlode_relative.yaml`: Test fixture with relative paths (`../schema.sql`, `../query.sql`)
- `test/generate_test.gleam`: Add `run_resolves_paths_relative_to_config_dir_test`

## Design Decisions

- Path resolution happens once in `generate.run()` after loading the config, before passing to `generate_config()`. This keeps `generate_config()` unchanged and avoids threading config directory through the entire call chain
- `filepath.is_absolute` is used to skip resolution for absolute paths

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration file paths are now resolved relative to the configuration file's directory, and generated output paths are normalized accordingly—improves portability of configs using relative paths.

* **Tests**
  * Added tests and fixtures to verify resolution of relative schema, query, and output paths and to ensure generated artifacts are placed as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->