### PR TITLE
fix(codegen): derive generated import paths from out directory instead of package

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -2,6 +2,7 @@ import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
 import gleam/string
+import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
 
@@ -107,7 +108,8 @@ fn render_adapter(
   config: AdapterConfig,
 ) -> String {
   let model.SqlBlock(gleam:, ..) = block
-  let model.GleamOutput(package:, ..) = gleam
+  let model.GleamOutput(out:, ..) = gleam
+  let module_path = common.out_to_module_path(out)
 
   let has_results =
     list.any(queries, fn(query) {
@@ -151,10 +153,13 @@ fn render_adapter(
         False -> []
       },
       case has_results {
-        True -> ["import " <> package <> "/models"]
+        True -> ["import " <> module_path <> "/models"]
         False -> []
       },
-      ["import " <> package <> "/params", "import " <> package <> "/queries"],
+      [
+        "import " <> module_path <> "/params",
+        "import " <> module_path <> "/queries",
+      ],
     ])
 
   let functions =

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -8,3 +8,17 @@ pub fn escape_string(input: String) -> String {
   |> string.replace("\r", "\\r")
   |> string.replace("\t", "\\t")
 }
+
+/// Derive the Gleam module path from the output directory.
+/// Strips the "src/" prefix so imports match the actual file location.
+/// e.g. "src/db" -> "db", "/abs/path/src/db" -> "db"
+pub fn out_to_module_path(out: String) -> String {
+  case string.starts_with(out, "src/") {
+    True -> string.drop_start(out, 4)
+    False ->
+      case string.split(out, "/src/") {
+        [_, after] -> after
+        _ -> out
+      }
+  }
+}

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -11,7 +11,8 @@ pub fn render(
   queries: List(model.AnalyzedQuery),
 ) -> String {
   let model.SqlBlock(engine:, gleam:, ..) = block
-  let model.GleamOutput(package:, runtime:, ..) = gleam
+  let model.GleamOutput(package:, runtime:, out:, ..) = gleam
+  let module_path = common.out_to_module_path(out)
 
   let query_functions =
     queries
@@ -35,7 +36,7 @@ pub fn render(
       "// runtime: " <> model.runtime_to_string(runtime),
       "",
       "import sqlode/runtime",
-      "import " <> package <> "/params",
+      "import " <> module_path <> "/params",
       "",
       "pub type QueryInfo {",
       "  QueryInfo(",

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -6,6 +6,7 @@ import gleeunit
 import gleeunit/should
 import simplifile
 import sqlode/codegen
+import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
@@ -411,7 +412,7 @@ fn test_block() -> model.SqlBlock {
     queries: ["test/fixtures/query.sql"],
     gleam: model.GleamOutput(
       package: "db",
-      out: "test_output/db",
+      out: "src/db",
       runtime: model.Raw,
       type_mapping: model.StringMapping,
     ),
@@ -427,7 +428,7 @@ fn test_block_native() -> model.SqlBlock {
     queries: ["test/fixtures/query.sql"],
     gleam: model.GleamOutput(
       package: "db",
-      out: "test_output/db",
+      out: "src/db",
       runtime: model.Native,
       type_mapping: model.StringMapping,
     ),
@@ -457,6 +458,15 @@ fn analyzed_queries(path: String) -> List(model.AnalyzedQuery) {
       queries,
     )
   result
+}
+
+pub fn out_to_module_path_strips_src_prefix_test() {
+  common.out_to_module_path("src/db") |> should.equal("db")
+  common.out_to_module_path("src/generated/db") |> should.equal("generated/db")
+  common.out_to_module_path("/absolute/path/src/db") |> should.equal("db")
+  common.out_to_module_path("/abs/src/generated/db")
+  |> should.equal("generated/db")
+  common.out_to_module_path("test_output/db") |> should.equal("test_output/db")
 }
 
 fn analyzed_star_queries() -> List(model.AnalyzedQuery) {

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -326,3 +326,7 @@ pub fn view_select_star_inferred_test() {
 pub fn run_resolves_paths_relative_to_config_dir_test() {
   generate_test.run_resolves_paths_relative_to_config_dir_test()
 }
+
+pub fn out_to_module_path_strips_src_prefix_test() {
+  codegen_test.out_to_module_path_strips_src_prefix_test()
+}


### PR DESCRIPTION
## Summary

- Derive Gleam import paths from `out` config field instead of `package`, so generated imports always match the actual file location in Gleam's module system
- Add `out_to_module_path` helper that strips the `src/` prefix from the output path
- Handle both relative (`src/db`) and absolute (`/path/to/src/db`) output paths

## Changes

- `src/sqlode/codegen/common.gleam`: Add `out_to_module_path` function
- `src/sqlode/codegen/queries.gleam`: Use `out_to_module_path(out)` instead of `package` for import generation
- `src/sqlode/codegen/adapter.gleam`: Use `out_to_module_path(out)` instead of `package` for import generation
- `test/codegen_test.gleam`: Update test blocks to use `out: "src/db"`, add unit test for `out_to_module_path`

## Design Decisions

- Import path derivation strips `src/` prefix from `out` path (e.g., `src/generated/db` → `generated/db`), matching Gleam's convention where module names come from file paths under `src/`
- For absolute paths, splits on `/src/` segment to extract the module path (e.g., `/home/user/project/src/db` → `db`)
- `package` field is preserved in config for backward compatibility but no longer used for import generation

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved module import path generation in Gleam code output.
  * Enhanced handling of output directory paths for more accurate module path conversion.

* **Tests**
  * Added comprehensive tests for path-to-module conversion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->