### PR TITLE
feat(generate): accept schema and queries directories like sqlc

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -181,9 +181,48 @@ fn generate_sql_block(
   }
 }
 
+fn expand_sql_paths(
+  paths: List(String),
+  error_fn: fn(String, String) -> GenerateError,
+) -> Result(List(String), GenerateError) {
+  paths
+  |> list.try_map(fn(path) {
+    case simplifile.is_directory(path) {
+      Ok(True) ->
+        case simplifile.get_files(in: path) {
+          Ok(files) -> {
+            let sql_files =
+              files
+              |> list.filter(fn(f) { string.ends_with(f, ".sql") })
+              |> list.sort(string.compare)
+            case sql_files {
+              [] -> Error(error_fn(path, "Directory contains no .sql files"))
+              _ -> Ok(sql_files)
+            }
+          }
+          Error(error) ->
+            Error(error_fn(
+              path,
+              "Failed to read directory: " <> simplifile.describe_error(error),
+            ))
+        }
+      Ok(False) -> Ok([path])
+      Error(error) ->
+        Error(error_fn(
+          path,
+          "Failed to access path: " <> simplifile.describe_error(error),
+        ))
+    }
+  })
+  |> result.map(list.flatten)
+}
+
 fn load_catalog(paths: List(String)) -> Result(model.Catalog, GenerateError) {
+  use expanded <- result.try(
+    expand_sql_paths(paths, fn(path, detail) { SchemaReadError(path:, detail:) }),
+  )
   use entries <- result.try(
-    paths
+    expanded
     |> list.try_map(fn(path) {
       simplifile.read(path)
       |> result.map(fn(content) { #(path, content) })
@@ -209,7 +248,13 @@ fn load_queries(
 ) -> Result(List(model.ParsedQuery), GenerateError) {
   let model.SqlBlock(engine:, queries:, ..) = block
 
-  queries
+  use expanded <- result.try(
+    expand_sql_paths(queries, fn(path, detail) {
+      QueryReadError(path:, detail:)
+    }),
+  )
+
+  expanded
   |> list.try_map(fn(path) {
     use content <- result.try(
       simplifile.read(path)

--- a/test/fixtures/query_dir/query.sql
+++ b/test/fixtures/query_dir/query.sql
@@ -1,0 +1,9 @@
+-- name: GetAuthor :one
+SELECT id, name
+FROM authors
+WHERE id = $1;
+
+-- name: ListAuthors :many
+SELECT id, name
+FROM authors
+ORDER BY name;

--- a/test/fixtures/schema_dir/schema.sql
+++ b/test/fixtures/schema_dir/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE authors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  bio TEXT
+);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1111,3 +1111,65 @@ pub fn run_resolves_paths_relative_to_config_dir_test() {
 
   cleanup_resolve()
 }
+
+// --- Directory input tests ---
+
+const dir_out = "test_output/generate_test_dir"
+
+fn cleanup_dir() {
+  let _ = simplifile.delete(dir_out)
+  Nil
+}
+
+pub fn accept_directory_for_schema_and_queries_test() {
+  cleanup_dir()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema_dir"],
+      queries: ["test/fixtures/query_dir"],
+      gleam: model.GleamOutput(
+        package: "db",
+        out: dir_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(files) = generate.generate_config(cfg)
+
+  list.length(files) |> should.equal(3)
+
+  let assert Ok(models) = simplifile.read(dir_out <> "/models.gleam")
+  string.contains(models, "Authors") |> should.be_true()
+
+  cleanup_dir()
+}
+
+pub fn mixed_file_and_directory_inputs_test() {
+  cleanup_dir()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/query_dir"],
+      gleam: model.GleamOutput(
+        package: "db",
+        out: dir_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(files) = generate.generate_config(cfg)
+
+  list.length(files) |> should.equal(3)
+
+  cleanup_dir()
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -330,3 +330,11 @@ pub fn run_resolves_paths_relative_to_config_dir_test() {
 pub fn out_to_module_path_strips_src_prefix_test() {
   codegen_test.out_to_module_path_strips_src_prefix_test()
 }
+
+pub fn accept_directory_for_schema_and_queries_test() {
+  generate_test.accept_directory_for_schema_and_queries_test()
+}
+
+pub fn mixed_file_and_directory_inputs_test() {
+  generate_test.mixed_file_and_directory_inputs_test()
+}


### PR DESCRIPTION
## Summary

- Allow `schema` and `queries` config entries to be directories, not just files
- Directories are recursively scanned for `.sql` files and processed in sorted order
- Supports mixing files and directories in the same list

## Changes

- `src/sqlode/generate.gleam`: Add `expand_sql_paths` helper that checks whether each path is a file or directory, expanding directories into sorted `.sql` file lists. Used by both `load_catalog` and `load_queries`
- `test/fixtures/schema_dir/`, `test/fixtures/query_dir/`: Directory fixtures for testing
- `test/generate_test.gleam`: Add tests for directory-only and mixed file/directory inputs

## Design Decisions

- Uses `simplifile.get_files` for recursive directory traversal, so nested subdirectories are supported
- Files are sorted alphabetically for deterministic processing order
- Empty directories (no `.sql` files) produce an explicit error rather than silently generating nothing

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for directory-based schema and query inputs—users can now specify directories and the system automatically discovers and processes all SQL files within them.
  * Mixed input support: combine individual SQL files with directories in the same configuration.

* **Tests**
  * Added comprehensive test coverage for directory-based and mixed input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->