### PR TITLE
fix(parser): ignore placeholders and parameter syntax inside SQL strings and comments

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -154,11 +154,13 @@ fn finalize_pending(
       case sql == "" {
         True -> Error(MissingSql(path:, line: start_line, name:))
         False -> {
-          let #(at_expanded, at_macros, next_idx) =
-            expand_at_name_shorthands(ctx, engine, sql)
+          let masked = mask_sql(sql)
+          let #(at_expanded, _at_masked, at_macros, next_idx) =
+            expand_at_name_shorthands(ctx, engine, sql, masked)
           let #(expanded_sql, sqlc_macros) =
             expand_sqlc_macros_from(ctx, engine, at_expanded, next_idx)
           let macros = list.append(at_macros, sqlc_macros)
+          let final_masked = mask_sql(expanded_sql)
           Ok([
             model.ParsedQuery(
               name:,
@@ -166,7 +168,7 @@ fn finalize_pending(
               command:,
               sql: expanded_sql,
               source_path: path,
-              param_count: count_parameters(ctx, engine, expanded_sql),
+              param_count: count_parameters(ctx, engine, final_masked),
               macros:,
             ),
             ..parsed_rev
@@ -290,24 +292,31 @@ fn expand_at_name_shorthands(
   ctx: ParserContext,
   engine: model.Engine,
   sql: String,
-) -> #(String, List(model.SqlcMacro), Int) {
+  masked: String,
+) -> #(String, String, List(model.SqlcMacro), Int) {
   case engine {
-    model.MySQL -> #(sql, [], 1)
+    model.MySQL -> #(sql, masked, [], 1)
     _ -> {
-      let matches = regexp.scan(ctx.at_name_re, sql)
+      let matches = regexp.scan(ctx.at_name_re, masked)
       case matches {
-        [] -> #(sql, [], 1)
+        [] -> #(sql, masked, [], 1)
         _ -> {
-          let #(expanded, macros, next_idx) =
-            list.fold(matches, #(sql, [], 1), fn(acc, match) {
-              let #(current_sql, macro_acc, idx) = acc
+          let #(expanded, expanded_masked, macros, next_idx) =
+            list.fold(matches, #(sql, masked, [], 1), fn(acc, match) {
+              let #(current_sql, current_masked, macro_acc, idx) = acc
               case match.submatches {
                 [Some(name)] -> {
                   let placeholder = engine_placeholder(engine, idx)
-                  let new_sql =
-                    replace_first(current_sql, match.content, placeholder)
+                  let #(new_sql, new_masked) =
+                    replace_first_in_masked(
+                      current_sql,
+                      current_masked,
+                      match.content,
+                      placeholder,
+                    )
                   #(
                     new_sql,
+                    new_masked,
                     [model.SqlcArg(index: idx, name:), ..macro_acc],
                     idx + 1,
                   )
@@ -315,7 +324,7 @@ fn expand_at_name_shorthands(
                 _ -> acc
               }
             })
-          #(expanded, list.reverse(macros), next_idx)
+          #(expanded, expanded_masked, list.reverse(macros), next_idx)
         }
       }
     }
@@ -342,7 +351,7 @@ fn expand_sqlc_macros_from(
               let name = strip_quotes(raw_name)
               let placeholder = engine_placeholder(engine, idx)
               let new_sql =
-                replace_first(current_sql, match.content, placeholder)
+                replace_first_simple(current_sql, match.content, placeholder)
               let sqlc_macro = case kind {
                 "narg" -> model.SqlcNarg(index: idx, name:)
                 "slice" -> model.SqlcSlice(index: idx, name:)
@@ -366,7 +375,7 @@ fn strip_quotes(name: String) -> String {
   }
 }
 
-fn replace_first(
+fn replace_first_simple(
   in text: String,
   each pattern: String,
   with replacement: String,
@@ -382,5 +391,87 @@ fn engine_placeholder(engine: model.Engine, index: Int) -> String {
     model.PostgreSQL -> "$" <> int.to_string(index)
     model.MySQL -> "?"
     model.SQLite -> "?" <> int.to_string(index)
+  }
+}
+
+fn replace_first_in_masked(
+  original: String,
+  masked: String,
+  pattern: String,
+  replacement: String,
+) -> #(String, String) {
+  case string.split_once(masked, pattern) {
+    Ok(#(before_masked, after_masked)) -> {
+      let pos = string.length(before_masked)
+      let before_orig = string.slice(original, 0, pos)
+      let after_orig = string.drop_start(original, pos + string.length(pattern))
+      #(
+        before_orig <> replacement <> after_orig,
+        before_masked <> replacement <> after_masked,
+      )
+    }
+    Error(_) -> #(original, masked)
+  }
+}
+
+// --- SQL masking (strip string literals and comments) ---
+
+type MaskState {
+  MaskNormal
+  MaskSingleQuote
+  MaskDoubleQuote
+  MaskLineComment
+  MaskBlockComment
+}
+
+fn mask_sql(sql: String) -> String {
+  let chars = string.to_graphemes(sql)
+  do_mask(chars, MaskNormal, [])
+  |> list.reverse
+  |> string.join("")
+}
+
+fn do_mask(
+  chars: List(String),
+  state: MaskState,
+  acc: List(String),
+) -> List(String) {
+  case state {
+    MaskNormal ->
+      case chars {
+        [] -> acc
+        ["'", ..rest] -> do_mask(rest, MaskSingleQuote, [" ", ..acc])
+        ["\"", ..rest] -> do_mask(rest, MaskDoubleQuote, [" ", ..acc])
+        ["-", "-", ..rest] -> do_mask(rest, MaskLineComment, [" ", " ", ..acc])
+        ["/", "*", ..rest] -> do_mask(rest, MaskBlockComment, [" ", " ", ..acc])
+        [c, ..rest] -> do_mask(rest, MaskNormal, [c, ..acc])
+      }
+    MaskSingleQuote ->
+      case chars {
+        [] -> acc
+        ["'", "'", ..rest] -> do_mask(rest, MaskSingleQuote, [" ", " ", ..acc])
+        ["'", ..rest] -> do_mask(rest, MaskNormal, [" ", ..acc])
+        [_, ..rest] -> do_mask(rest, MaskSingleQuote, [" ", ..acc])
+      }
+    MaskDoubleQuote ->
+      case chars {
+        [] -> acc
+        ["\"", "\"", ..rest] ->
+          do_mask(rest, MaskDoubleQuote, [" ", " ", ..acc])
+        ["\"", ..rest] -> do_mask(rest, MaskNormal, [" ", ..acc])
+        [_, ..rest] -> do_mask(rest, MaskDoubleQuote, [" ", ..acc])
+      }
+    MaskLineComment ->
+      case chars {
+        [] -> acc
+        ["\n", ..rest] -> do_mask(rest, MaskNormal, ["\n", ..acc])
+        [_, ..rest] -> do_mask(rest, MaskLineComment, [" ", ..acc])
+      }
+    MaskBlockComment ->
+      case chars {
+        [] -> acc
+        ["*", "/", ..rest] -> do_mask(rest, MaskNormal, [" ", " ", ..acc])
+        [_, ..rest] -> do_mask(rest, MaskBlockComment, [" ", ..acc])
+      }
   }
 }

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -374,6 +374,86 @@ pub fn multiline_sql_body_test() {
   string.contains(query.sql, "SELECT id,") |> should.be_true()
 }
 
+// --- Placeholder inside string literal / comment tests (#118) ---
+
+pub fn ignore_placeholder_in_single_quoted_string_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthorWithLiteral :one\n"
+    <> "SELECT id, name\n"
+    <> "FROM authors\n"
+    <> "WHERE note = '$2' OR id = $1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("lit.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  // $2 inside string should be ignored, only $1 counts
+  query.param_count |> should.equal(1)
+}
+
+pub fn ignore_placeholder_in_line_comment_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetById :one\n"
+    <> "SELECT id, name\n"
+    <> "FROM authors\n"
+    <> "WHERE id = $1; -- $2 is not used"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+}
+
+pub fn ignore_placeholder_in_block_comment_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetById :one\n"
+    <> "SELECT id, name\n"
+    <> "FROM authors\n"
+    <> "/* WHERE bio = $2 */\n"
+    <> "WHERE id = $1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+}
+
+pub fn ignore_at_name_in_string_literal_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByNote :one\n"
+    <> "SELECT id FROM authors\n"
+    <> "WHERE note = '@skip_me' AND id = @real_id;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  // @skip_me inside string should not be expanded
+  query.param_count |> should.equal(1)
+  query.macros |> should.equal([model.SqlcArg(index: 1, name: "real_id")])
+  string.contains(query.sql, "'@skip_me'") |> should.be_true()
+}
+
+pub fn ignore_question_mark_in_string_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetByNote :one\n"
+    <> "SELECT id FROM authors\n"
+    <> "WHERE note = 'is this a ?' AND id = ?;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("q.sql", model.MySQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+}
+
 pub fn error_to_string_coverage_test() {
   query_parser.error_to_string(query_parser.InvalidAnnotation(
     path: "test.sql",

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -338,3 +338,23 @@ pub fn accept_directory_for_schema_and_queries_test() {
 pub fn mixed_file_and_directory_inputs_test() {
   generate_test.mixed_file_and_directory_inputs_test()
 }
+
+pub fn ignore_placeholder_in_single_quoted_string_test() {
+  query_parser_test.ignore_placeholder_in_single_quoted_string_test()
+}
+
+pub fn ignore_placeholder_in_line_comment_test() {
+  query_parser_test.ignore_placeholder_in_line_comment_test()
+}
+
+pub fn ignore_placeholder_in_block_comment_test() {
+  query_parser_test.ignore_placeholder_in_block_comment_test()
+}
+
+pub fn ignore_at_name_in_string_literal_test() {
+  query_parser_test.ignore_at_name_in_string_literal_test()
+}
+
+pub fn ignore_question_mark_in_string_mysql_test() {
+  query_parser_test.ignore_question_mark_in_string_mysql_test()
+}


### PR DESCRIPTION
## Summary

- Placeholders (`$1`, `?`), `@name` shorthands, and other parameter syntax inside SQL string literals and comments are no longer treated as real parameters
- Add a SQL masking function that replaces content inside strings and comments with spaces while preserving string length

## Changes

- `src/sqlode/query_parser.gleam`:
  - Add `mask_sql` function with a character-by-character state machine that handles single-quoted strings (`''` escape), double-quoted identifiers, line comments (`--`), and block comments (`/* */`)
  - Add `replace_first_in_masked` for position-synchronized replacement across original and masked SQL
  - `expand_at_name_shorthands` now scans the masked SQL to avoid expanding `@name` inside strings/comments
  - `count_parameters` now operates on masked SQL to avoid counting placeholders inside strings/comments
  - `expand_sqlc_macros_from` continues to scan the original SQL since sqlc macro syntax uses quotes (`sqlc.arg('name')`) that would be incorrectly masked
- `test/query_parser_test.gleam`: Add 5 tests covering placeholders in single-quoted strings, line comments, block comments, `@name` in strings, and `?` in strings (MySQL)

## Design Decisions

- Masking replaces all characters inside strings/comments with spaces, preserving length so character positions stay aligned between original and masked SQL
- `@name` expansion uses masked SQL for scanning (preventing false matches inside strings) with position-synchronized replacement on the original SQL
- `sqlc.arg/narg/slice` expansion uses the original SQL for scanning because macro syntax contains quotes that would be masked. The expanded result is then re-masked before parameter counting
- Dollar-quoted PostgreSQL strings (`$$...$$`) are not handled in this initial implementation

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query parsing to correctly handle placeholder-like patterns inside string literals and SQL comments, ensuring accurate parameter counting.

* **Tests**
  * Added comprehensive tests for placeholder and macro expansion behavior in various SQL contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->