### PR TITLE
fix(codegen): align exec annotation adapters with documented contracts

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -200,7 +200,9 @@ fn render_adapter_function(
       )
     model.Exec | model.BatchExec | model.CopyFrom ->
       render_adapter_exec(naming_ctx, query, fn_name, has_params, config)
-    model.ExecResult | model.ExecRows ->
+    model.ExecResult ->
+      render_adapter_exec(naming_ctx, query, fn_name, has_params, config)
+    model.ExecRows ->
       render_adapter_exec_rows(naming_ctx, query, fn_name, has_params, config)
     model.ExecLastId ->
       render_adapter_exec_last_id(
@@ -833,7 +835,22 @@ fn render_sqlight_many_result() -> List(String) {
 }
 
 fn render_sqlight_exec_rows_result() -> List(String) {
-  ["  |> result.map(fn(rows) { list.length(rows) })"]
+  [
+    "  |> result.try(fn(_) {",
+    "    sqlight.query(",
+    "      \"SELECT changes()\",",
+    "      on: db,",
+    "      with: [],",
+    "      expecting: decode.at([0], decode.int),",
+    "    )",
+    "  })",
+    "  |> result.map(fn(rows) {",
+    "    case rows {",
+    "      [count, ..] -> count",
+    "      [] -> 0",
+    "    }",
+    "  })",
+  ]
 }
 
 fn render_sqlight_exec_last_id(

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -30,6 +30,7 @@ pub type GenerateError {
     query_paths: List(String),
     schema_paths: List(String),
   )
+  UnsupportedAnnotation(query_name: String, command: String, detail: String)
   WriteError(writer.WriteError)
 }
 
@@ -159,24 +160,26 @@ fn generate_sql_block(
         False -> base_files
       }
 
-      let files = case gleam.runtime {
-        model.Raw -> files
-        model.Native ->
-          list.append(files, [
-            writer.GeneratedFile(
-              directory: out,
-              path: adapter_filename(block.engine),
-              content: codegen.render_adapter_module(
-                naming_ctx,
-                block,
-                analyzed,
-                table_matches,
+      case gleam.runtime {
+        model.Raw -> Ok(files)
+        model.Native -> {
+          use Nil <- result.try(validate_native_annotations(analyzed))
+          Ok(
+            list.append(files, [
+              writer.GeneratedFile(
+                directory: out,
+                path: adapter_filename(block.engine),
+                content: codegen.render_adapter_module(
+                  naming_ctx,
+                  block,
+                  analyzed,
+                  table_matches,
+                ),
               ),
-            ),
-          ])
+            ]),
+          )
+        }
       }
-
-      Ok(files)
     }
   }
 }
@@ -443,6 +446,20 @@ fn find_column_rename(
   })
 }
 
+fn validate_native_annotations(
+  queries: List(model.AnalyzedQuery),
+) -> Result(Nil, GenerateError) {
+  case list.find(queries, fn(q) { q.base.command == model.ExecResult }) {
+    Ok(q) ->
+      Error(UnsupportedAnnotation(
+        query_name: q.base.name,
+        command: ":execresult",
+        detail: ":execresult is not supported with native runtime. Use :exec, :execrows, or :execlastid instead",
+      ))
+    Error(_) -> Ok(Nil)
+  }
+}
+
 fn adapter_filename(engine: model.Engine) -> String {
   case engine {
     model.PostgreSQL -> "pog_adapter.gleam"
@@ -587,6 +604,8 @@ pub fn error_to_string(error: GenerateError) -> String {
               "\n  Hint: Queries were parsed but none produced output. Check that your schema defines the tables referenced in your queries"
           }
       }
+    UnsupportedAnnotation(query_name:, command:, detail:) ->
+      "Query " <> query_name <> " uses " <> command <> ": " <> detail
     WriteError(inner) -> writer.error_to_string(inner)
   }
 }

--- a/test/fixtures/all_commands_query.sql
+++ b/test/fixtures/all_commands_query.sql
@@ -7,7 +7,7 @@ SELECT id, title FROM posts ORDER BY id;
 -- name: CreatePost :exec
 INSERT INTO posts (title, body) VALUES (?1, ?2);
 
--- name: UpdatePost :execresult
+-- name: UpdatePost :exec
 UPDATE posts SET title = ?1, body = ?2 WHERE id = ?3;
 
 -- name: CountPosts :execrows

--- a/test/fixtures/execresult_query.sql
+++ b/test/fixtures/execresult_query.sql
@@ -1,0 +1,2 @@
+-- name: UpdatePost :execresult
+UPDATE posts SET title = ?1 WHERE id = ?2;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -772,7 +772,6 @@ pub fn all_commands_generate_queries_test() {
   string.contains(queries, "runtime.QueryOne") |> should.be_true()
   string.contains(queries, "runtime.QueryMany") |> should.be_true()
   string.contains(queries, "runtime.QueryExec") |> should.be_true()
-  string.contains(queries, "runtime.QueryExecResult") |> should.be_true()
   string.contains(queries, "runtime.QueryExecRows") |> should.be_true()
   string.contains(queries, "runtime.QueryExecLastId") |> should.be_true()
   string.contains(queries, "runtime.QueryBatchOne") |> should.be_true()
@@ -796,7 +795,6 @@ pub fn all_commands_generate_params_test() {
   string.contains(params, "GetPostParams") |> should.be_true()
   // :exec with params
   string.contains(params, "CreatePostParams") |> should.be_true()
-  // :execresult with params
   string.contains(params, "UpdatePostParams") |> should.be_true()
   // :execlastid with params
   string.contains(params, "InsertPostParams") |> should.be_true()
@@ -824,7 +822,7 @@ pub fn all_commands_generate_models_test() {
   string.contains(models, "GetPostRow") |> should.be_true()
   string.contains(models, "ListPostsRow") |> should.be_true()
 
-  // :exec, :execresult, :execlastid should NOT generate row types
+  // :exec, :execlastid should NOT generate row types
   string.contains(models, "CreatePostRow") |> should.be_false()
   string.contains(models, "UpdatePostRow") |> should.be_false()
   string.contains(models, "InsertPostRow") |> should.be_false()
@@ -857,7 +855,7 @@ pub fn all_commands_sqlight_adapter_test() {
   // :exec returns Nil
   string.contains(adapter, "fn create_post(") |> should.be_true()
   string.contains(adapter, "Result(Nil, sqlight.Error)") |> should.be_true()
-  // :execresult returns Nil (same as exec for sqlight)
+  // :exec returns Nil
   string.contains(adapter, "fn update_post(") |> should.be_true()
   // :execrows returns Int
   string.contains(adapter, "fn count_posts(") |> should.be_true()
@@ -954,6 +952,50 @@ pub fn run_with_no_queries_in_file_test() {
     _ -> should.fail()
   }
   cleanup()
+}
+
+pub fn execresult_rejected_on_native_runtime_test() {
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.SQLite,
+      schema: ["test/fixtures/all_commands_schema.sql"],
+      queries: ["test/fixtures/execresult_query.sql"],
+      gleam: model.GleamOutput(
+        package: "db",
+        out: "test_output/execresult_reject",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let cfg = model.Config(version: 2, sql: [block])
+  let result = generate.generate_config(cfg)
+  case result {
+    Error(generate.UnsupportedAnnotation(..)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn execresult_allowed_on_raw_runtime_test() {
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.SQLite,
+      schema: ["test/fixtures/all_commands_schema.sql"],
+      queries: ["test/fixtures/execresult_query.sql"],
+      gleam: model.GleamOutput(
+        package: "db",
+        out: "test_output/execresult_raw",
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(_) = generate.generate_config(cfg)
+  let _ = simplifile.delete("test_output/execresult_raw")
+  Nil
 }
 
 // --- UNION/INTERSECT/EXCEPT tests ---

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -360,6 +360,14 @@ pub fn ignore_question_mark_in_string_mysql_test() {
   query_parser_test.ignore_question_mark_in_string_mysql_test()
 }
 
+pub fn execresult_rejected_on_native_runtime_test() {
+  generate_test.execresult_rejected_on_native_runtime_test()
+}
+
+pub fn execresult_allowed_on_raw_runtime_test() {
+  generate_test.execresult_allowed_on_raw_runtime_test()
+}
+
 pub fn singularize_regular_plural_test() {
   naming_test.singularize_regular_plural_test()
 }


### PR DESCRIPTION
## Summary

- Reject `:execresult` on native runtime with a clear error message, since its semantics were undefined and silently collapsed into `:execrows`
- Fix sqlight `:execrows` to return actual affected row count using `SELECT changes()` instead of `list.length(rows)`
- `:execresult` remains available on raw runtime as query metadata

## Changes

- `src/sqlode/generate.gleam`: Add `validate_native_annotations` that rejects `:execresult` with native runtime, add `UnsupportedAnnotation` error variant
- `src/sqlode/codegen/adapter.gleam`: Split `ExecResult | ExecRows` into separate cases — `ExecResult` now falls through to `:exec` (returns Nil) since native runtime rejects it before reaching this point. Fix `render_sqlight_exec_rows_result` to use `SELECT changes()` pattern (same approach as `:execlastid` uses `SELECT last_insert_rowid()`)
- `test/fixtures/all_commands_query.sql`: Change `UpdatePost` from `:execresult` to `:exec`
- `test/fixtures/execresult_query.sql`: New fixture for reject/allow tests

## Design Decisions

- Chose "reject until contract is real" approach from the issue's two options, since `:execresult` had no distinct semantics from `:execrows`
- sqlight `:execrows` now queries `SELECT changes()` after execution to get the true affected row count, following the same pattern already used by `:execlastid` with `SELECT last_insert_rowid()`
- pog `:execrows` remains unchanged — `returned.count` already provides correct affected rows

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code generation to properly separate handling of different command result types.
  * Added validation to detect and prevent unsupported command operations in native runtime configurations.
  * Enhanced error messages with clear descriptions of incompatible operations.

* **Tests**
  * Added test coverage for native runtime validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->