### PR TITLE
feat(codegen): generate Gleam enum types for PostgreSQL ENUM columns

### DIFF
--- a/src/sqlode/codegen.gleam
+++ b/src/sqlode/codegen.gleam
@@ -18,8 +18,9 @@ pub fn render_params_module(
   naming_ctx: naming.NamingContext,
   analyzed: List(model.AnalyzedQuery),
   type_mapping: model.TypeMapping,
+  module_path: String,
 ) -> String {
-  params.render(naming_ctx, analyzed, type_mapping)
+  params.render(naming_ctx, analyzed, type_mapping, module_path)
 }
 
 pub fn render_models_module(

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -131,6 +131,22 @@ fn render_adapter(
       list.any(query.params, fn(param) { param.is_list })
     })
 
+  let has_enums =
+    list.any(queries, fn(query) {
+      list.any(query.params, fn(param) {
+        case param.scalar_type {
+          model.EnumType(_) -> True
+          _ -> False
+        }
+      })
+      || list.any(query.result_columns, fn(col) {
+        case col {
+          model.ResultColumn(scalar_type: model.EnumType(_), ..) -> True
+          _ -> False
+        }
+      })
+    })
+
   let imports =
     list.flatten([
       [
@@ -152,7 +168,7 @@ fn render_adapter(
         True -> ["import sqlode/runtime"]
         False -> []
       },
-      case has_results {
+      case has_results || has_enums {
         True -> ["import " <> module_path <> "/models"]
         False -> []
       },
@@ -244,10 +260,16 @@ fn render_decoder(
           case col {
             model.ResultColumn(name:, scalar_type:, nullable:, ..) -> {
               let field_name = naming.to_snake_case(naming_ctx, name)
-              let decoder = config.decoder_function(scalar_type)
+              let base_decoder = case scalar_type {
+                model.EnumType(enum_name) ->
+                  "decode.map(decode.string, models."
+                  <> model.enum_from_string_fn(enum_name)
+                  <> ")"
+                _ -> config.decoder_function(scalar_type)
+              }
               let full_decoder = case nullable {
-                True -> "decode.optional(" <> decoder <> ")"
-                False -> decoder
+                True -> "decode.optional(" <> base_decoder <> ")"
+                False -> base_decoder
               }
               let line =
                 "    use "
@@ -588,19 +610,35 @@ fn render_pog_params_simple(params: List(model.QueryParam)) -> String {
   |> list.map(fn(param) {
     let value_fn =
       model.scalar_type_to_value_function(model.PostgreSQL, param.scalar_type)
-    case param.nullable {
-      False ->
-        "  |> pog.parameter(pog."
-        <> value_fn
+    let field_expr = case param.scalar_type {
+      model.EnumType(name) ->
+        "models."
+        <> model.enum_to_string_fn(name)
         <> "(p."
         <> param.field_name
-        <> "))"
+        <> ")"
+      _ -> "p." <> param.field_name
+    }
+    case param.nullable {
+      False ->
+        "  |> pog.parameter(pog." <> value_fn <> "(" <> field_expr <> "))"
       True ->
-        "  |> pog.parameter(pog.nullable(pog."
-        <> value_fn
-        <> ", p."
-        <> param.field_name
-        <> "))"
+        case param.scalar_type {
+          model.EnumType(name) ->
+            "  |> pog.parameter(pog.nullable(fn(v) { pog."
+            <> value_fn
+            <> "(models."
+            <> model.enum_to_string_fn(name)
+            <> "(v)) }, p."
+            <> param.field_name
+            <> "))"
+          _ ->
+            "  |> pog.parameter(pog.nullable(pog."
+            <> value_fn
+            <> ", p."
+            <> param.field_name
+            <> "))"
+        }
     }
   })
   |> string.join("\n")
@@ -767,14 +805,34 @@ fn render_sqlight_params_simple(params: List(model.QueryParam)) -> String {
         |> list.map(fn(param) {
           let value_fn =
             model.scalar_type_to_value_function(model.SQLite, param.scalar_type)
-          case param.nullable {
-            False -> "sqlight." <> value_fn <> "(p." <> param.field_name <> ")"
-            True ->
-              "sqlight.nullable(sqlight."
-              <> value_fn
-              <> ", p."
+          let field_expr = case param.scalar_type {
+            model.EnumType(name) ->
+              "models."
+              <> model.enum_to_string_fn(name)
+              <> "(p."
               <> param.field_name
               <> ")"
+            _ -> "p." <> param.field_name
+          }
+          case param.nullable {
+            False -> "sqlight." <> value_fn <> "(" <> field_expr <> ")"
+            True ->
+              case param.scalar_type {
+                model.EnumType(name) ->
+                  "sqlight.nullable(fn(v) { sqlight."
+                  <> value_fn
+                  <> "(models."
+                  <> model.enum_to_string_fn(name)
+                  <> "(v)) }, p."
+                  <> param.field_name
+                  <> ")"
+                _ ->
+                  "sqlight.nullable(sqlight."
+                  <> value_fn
+                  <> ", p."
+                  <> param.field_name
+                  <> ")"
+              }
           }
         })
         |> string.join(", ")

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -56,8 +56,13 @@ pub fn render(
     False -> []
   }
 
+  let enum_types =
+    catalog.enums
+    |> list.map(render_enum_type)
+    |> string.join("\n\n")
+
   let body_parts =
-    [semantic_aliases, table_types, row_types]
+    [enum_types, semantic_aliases, table_types, row_types]
     |> list.filter(fn(s) { !string.is_empty(s) })
     |> string.join("\n\n")
 
@@ -78,6 +83,56 @@ pub fn render(
     ])
 
   string.join(lines, "\n")
+}
+
+fn render_enum_type(enum_def: model.EnumDef) -> String {
+  let type_name = model.enum_type_name(enum_def.name)
+  let to_string_fn = model.enum_to_string_fn(enum_def.name)
+  let from_string_fn = model.enum_from_string_fn(enum_def.name)
+
+  let constructors =
+    enum_def.values
+    |> list.map(fn(v) { "  " <> model.enum_value_name(v) })
+    |> string.join("\n")
+
+  let to_string_cases =
+    enum_def.values
+    |> list.map(fn(v) {
+      "    " <> model.enum_value_name(v) <> " -> \"" <> v <> "\""
+    })
+    |> string.join("\n")
+
+  let from_string_cases =
+    enum_def.values
+    |> list.map(fn(v) { "    \"" <> v <> "\" -> " <> model.enum_value_name(v) })
+    |> string.join("\n")
+
+  let default_value = case enum_def.values {
+    [first, ..] -> model.enum_value_name(first)
+    [] -> type_name
+  }
+
+  string.join(
+    [
+      "pub type " <> type_name <> " {",
+      constructors,
+      "}",
+      "",
+      "pub fn " <> to_string_fn <> "(value: " <> type_name <> ") -> String {",
+      "  case value {",
+      to_string_cases,
+      "  }",
+      "}",
+      "",
+      "pub fn " <> from_string_fn <> "(value: String) -> " <> type_name <> " {",
+      "  case value {",
+      from_string_cases,
+      "    _ -> " <> default_value,
+      "  }",
+      "}",
+    ],
+    "\n",
+  )
 }
 
 fn render_semantic_type_aliases(

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -7,10 +7,21 @@ pub fn render(
   naming_ctx: naming.NamingContext,
   queries: List(model.AnalyzedQuery),
   type_mapping: model.TypeMapping,
+  module_path: String,
 ) -> String {
   let has_slices =
     list.any(queries, fn(query) {
       list.any(query.params, fn(param) { param.is_list })
+    })
+
+  let has_enums =
+    list.any(queries, fn(query) {
+      list.any(query.params, fn(param) {
+        case param.scalar_type {
+          model.EnumType(_) -> True
+          _ -> False
+        }
+      })
     })
 
   let imports = case needs_option_import(queries) {
@@ -24,6 +35,10 @@ pub fn render(
           "import gleam/option.{type Option, None, Some}",
           "import sqlode/runtime.{type Value}",
         ],
+        case has_enums {
+          True -> ["import " <> module_path <> "/models"]
+          False -> []
+        },
       ])
     False ->
       list.flatten([
@@ -32,6 +47,10 @@ pub fn render(
           False -> []
         },
         ["import sqlode/runtime.{type Value}"],
+        case has_enums {
+          True -> ["import " <> module_path <> "/models"]
+          False -> []
+        },
       ])
   }
 
@@ -144,14 +163,31 @@ fn render_param_value(param: model.QueryParam) -> String {
   let value_expr = "params." <> param.field_name
   let runtime_fn = model.scalar_type_to_runtime_function(param.scalar_type)
 
-  case param.nullable {
-    True ->
-      "case "
-      <> value_expr
-      <> " { Some(value) -> "
-      <> runtime_fn
-      <> "(value) None -> runtime.null() }"
-    False -> runtime_fn <> "(" <> value_expr <> ")"
+  case param.scalar_type {
+    model.EnumType(name) -> {
+      let to_string_fn = "models." <> model.enum_to_string_fn(name)
+      case param.nullable {
+        True ->
+          "case "
+          <> value_expr
+          <> " { Some(value) -> "
+          <> runtime_fn
+          <> "("
+          <> to_string_fn
+          <> "(value)) None -> runtime.null() }"
+        False -> runtime_fn <> "(" <> to_string_fn <> "(" <> value_expr <> "))"
+      }
+    }
+    _ ->
+      case param.nullable {
+        True ->
+          "case "
+          <> value_expr
+          <> " { Some(value) -> "
+          <> runtime_fn
+          <> "(value) None -> runtime.null() }"
+        False -> runtime_fn <> "(" <> value_expr <> ")"
+      }
   }
 }
 
@@ -164,16 +200,47 @@ fn param_accessors_flattened(params: List(model.QueryParam)) -> List(String) {
     let runtime_fn = model.scalar_type_to_runtime_function(param.scalar_type)
 
     case param.is_list {
-      True -> "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
-      False ->
-        case param.nullable {
-          True ->
-            "[case "
+      True ->
+        case param.scalar_type {
+          model.EnumType(name) -> {
+            let to_str = "models." <> model.enum_to_string_fn(name)
+            "list.map("
             <> value_expr
-            <> " { Some(value) -> "
+            <> ", fn(v) { "
             <> runtime_fn
-            <> "(value) None -> runtime.null() }]"
-          False -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
+            <> "("
+            <> to_str
+            <> "(v)) })"
+          }
+          _ -> "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
+        }
+      False ->
+        case param.scalar_type {
+          model.EnumType(name) -> {
+            let to_str = "models." <> model.enum_to_string_fn(name)
+            case param.nullable {
+              True ->
+                "[case "
+                <> value_expr
+                <> " { Some(value) -> "
+                <> runtime_fn
+                <> "("
+                <> to_str
+                <> "(value)) None -> runtime.null() }]"
+              False ->
+                "[" <> runtime_fn <> "(" <> to_str <> "(" <> value_expr <> "))]"
+            }
+          }
+          _ ->
+            case param.nullable {
+              True ->
+                "[case "
+                <> value_expr
+                <> " { Some(value) -> "
+                <> runtime_fn
+                <> "(value) None -> runtime.null() }]"
+              False -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
+            }
         }
     }
   })

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -8,6 +8,7 @@ import gleam/result
 import gleam/string
 import simplifile
 import sqlode/codegen
+import sqlode/codegen/common
 import sqlode/config
 import sqlode/model
 import sqlode/naming
@@ -133,6 +134,7 @@ fn generate_sql_block(
             naming_ctx,
             analyzed,
             gleam.type_mapping,
+            common.out_to_module_path(out),
           ),
         ),
         writer.GeneratedFile(

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -1,4 +1,6 @@
+import gleam/list
 import gleam/option.{type Option}
+import gleam/string
 
 pub type Engine {
   PostgreSQL
@@ -228,7 +230,7 @@ pub fn scalar_type_to_gleam_type(
         RichMapping -> "SqlJson"
         StringMapping -> "String"
       }
-    EnumType(_) -> "String"
+    EnumType(name) -> enum_type_name(name)
     CustomType(name, _) -> name
   }
 }
@@ -347,4 +349,32 @@ pub type AnalyzedQuery {
     params: List(QueryParam),
     result_columns: List(ResultColumn),
   )
+}
+
+pub fn enum_type_name(name: String) -> String {
+  simple_pascal_case(name)
+}
+
+pub fn enum_value_name(value: String) -> String {
+  simple_pascal_case(value)
+}
+
+pub fn enum_to_string_fn(name: String) -> String {
+  string.lowercase(name) <> "_to_string"
+}
+
+pub fn enum_from_string_fn(name: String) -> String {
+  string.lowercase(name) <> "_from_string"
+}
+
+fn simple_pascal_case(input: String) -> String {
+  input
+  |> string.split("_")
+  |> list.map(fn(word) {
+    case string.pop_grapheme(word) {
+      Ok(#(first, rest)) -> string.uppercase(first) <> string.lowercase(rest)
+      Error(_) -> word
+    }
+  })
+  |> string.join("")
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -46,7 +46,12 @@ pub fn render_params_module_test() {
   let naming_ctx = naming.new()
   let analyzed = analyzed_queries("test/fixtures/query.sql")
   let rendered =
-    codegen.render_params_module(naming_ctx, analyzed, model.StringMapping)
+    codegen.render_params_module(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+    )
 
   string.contains(rendered, "pub type GetAuthorParams {")
   |> should.be_true()
@@ -200,7 +205,12 @@ pub fn render_params_module_slice_test() {
   let naming_ctx = naming.new()
   let analyzed = analyzed_slice_queries(model.PostgreSQL)
   let rendered =
-    codegen.render_params_module(naming_ctx, analyzed, model.StringMapping)
+    codegen.render_params_module(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+    )
 
   // The type should use List(...) for slice params
   string.contains(rendered, "ids: List(")

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -136,7 +136,7 @@ pub fn scalar_type_to_gleam_type_string_mapping_test() {
   model.scalar_type_to_gleam_type(model.UuidType, m) |> should.equal("String")
   model.scalar_type_to_gleam_type(model.JsonType, m) |> should.equal("String")
   model.scalar_type_to_gleam_type(model.EnumType("status"), m)
-  |> should.equal("String")
+  |> should.equal("Status")
   model.scalar_type_to_gleam_type(model.CustomType("UserId", model.IntType), m)
   |> should.equal("UserId")
 }
@@ -157,7 +157,7 @@ pub fn scalar_type_to_gleam_type_rich_mapping_test() {
   model.scalar_type_to_gleam_type(model.JsonType, m)
   |> should.equal("SqlJson")
   model.scalar_type_to_gleam_type(model.EnumType("status"), m)
-  |> should.equal("String")
+  |> should.equal("Status")
 }
 
 pub fn custom_type_delegates_to_underlying_test() {


### PR DESCRIPTION
## Summary

- PostgreSQL ENUM types (`CREATE TYPE ... AS ENUM (...)`) are now generated as Gleam custom types with constructors instead of being collapsed to plain `String`
- Generates `to_string`/`from_string` conversion functions for each enum
- Params encoding and adapter decoding automatically use the generated conversion functions

## Changes

- `src/sqlode/model.gleam`: Change `scalar_type_to_gleam_type(EnumType(name))` to return PascalCase enum type name. Add `enum_type_name`, `enum_value_name`, `enum_to_string_fn`, `enum_from_string_fn` helpers
- `src/sqlode/codegen/models.gleam`: Add `render_enum_type` that generates custom type, `to_string`, and `from_string` for each `EnumDef` in the catalog
- `src/sqlode/codegen/params.gleam`: Wrap enum params with `models.{name}_to_string()` before encoding. Add conditional `models` module import when enum params exist
- `src/sqlode/codegen/adapter.gleam`: Use `decode.map(decode.string, models.{name}_from_string)` decoder for enum result columns. Wrap enum params with `models.{name}_to_string()` for pog/sqlight parameter encoding. Add conditional `models` import for enum params/results
- `src/sqlode/codegen.gleam`, `src/sqlode/generate.gleam`: Pass `module_path` to params renderer for correct import generation

## Design Decisions

- Enum types use a simple PascalCase conversion (split on `_`, capitalize each word) without depending on NamingContext, keeping `scalar_type_to_gleam_type` signature unchanged
- `from_string` falls back to the first enum value for unrecognized strings rather than returning `Result`, keeping the generated API simple
- Enum conversion is handled at the codegen level (params/adapter) rather than changing `scalar_type_to_runtime_function`, preserving the existing architecture

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive support for database enum types in generated code.
  * Enum columns now generate as dedicated types with automatic serialization and deserialization functions.
  * Enum parameters are properly handled in query generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->