### PR TITLE
fix(writer): use filepath.join instead of string concatenation for path construction

### DIFF
--- a/src/sqlode/writer.gleam
+++ b/src/sqlode/writer.gleam
@@ -1,3 +1,4 @@
+import filepath
 import gleam/list
 import gleam/result
 import simplifile
@@ -23,7 +24,7 @@ pub fn write_all(files: List(GeneratedFile)) -> Result(List(String), WriteError)
       }),
     )
 
-    let full_path = file.directory <> "/" <> file.path
+    let full_path = filepath.join(file.directory, file.path)
 
     use _ <- result.try(
       simplifile.write(full_path, file.content)

--- a/test/writer_test.gleam
+++ b/test/writer_test.gleam
@@ -95,6 +95,28 @@ pub fn write_all_returns_paths_in_order_test() {
   cleanup()
 }
 
+pub fn write_all_trailing_slash_directory_test() {
+  cleanup()
+  let dir_with_slash = test_dir <> "/"
+  let files = [
+    writer.GeneratedFile(
+      directory: dir_with_slash,
+      path: "trailing.gleam",
+      content: "// trailing slash test",
+    ),
+  ]
+
+  let assert Ok(written) = writer.write_all(files)
+
+  // filepath.join normalizes the path — no double slash
+  written |> should.equal([test_dir <> "/trailing.gleam"])
+
+  let assert Ok(content) = simplifile.read(test_dir <> "/trailing.gleam")
+  content |> should.equal("// trailing slash test")
+
+  cleanup()
+}
+
 pub fn error_to_string_directory_error_test() {
   let error =
     writer.DirectoryCreateError(path: "/bad/path", detail: "Permission denied")


### PR DESCRIPTION
## Summary

- Replace manual string concatenation (`file.directory <> "/" <> file.path`) with `filepath.join(file.directory, file.path)` in `writer.gleam` for correct path handling
- Add test for trailing-slash directory to verify normalized path output

## Changes

- `src/sqlode/writer.gleam`: Import `filepath` module and use `filepath.join` for constructing file paths
- `test/writer_test.gleam`: Add `write_all_trailing_slash_directory_test` to verify paths are normalized when directory has a trailing slash

## Design Decisions

- Used `filepath.join` which is already the standard in the rest of the codebase (`generate.gleam`, `cli.gleam`)
- The trailing-slash test validates the core benefit: `filepath.join` normalizes paths that manual concatenation would produce as double-slashed

Closes #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where file paths with trailing slashes could result in double slashes, ensuring proper path handling and file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->