### PR TITLE
fix(codegen): handle multiple /src/ segments in out_to_module_path

### DIFF
--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -1,3 +1,5 @@
+import gleam/list
+import gleam/result
 import gleam/string
 
 pub fn escape_string(input: String) -> String {
@@ -16,9 +18,8 @@ pub fn out_to_module_path(out: String) -> String {
   case string.starts_with(out, "src/") {
     True -> string.drop_start(out, 4)
     False ->
-      case string.split(out, "/src/") {
-        [_, after] -> after
-        _ -> out
-      }
+      string.split(out, "/src/")
+      |> list.last
+      |> result.unwrap(out)
   }
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -477,6 +477,10 @@ pub fn out_to_module_path_strips_src_prefix_test() {
   common.out_to_module_path("/abs/src/generated/db")
   |> should.equal("generated/db")
   common.out_to_module_path("test_output/db") |> should.equal("test_output/db")
+  // Multiple /src/ segments — take the part after the last /src/
+  common.out_to_module_path("/home/src/project/src/db") |> should.equal("db")
+  common.out_to_module_path("/home/src/project/src/generated/db")
+  |> should.equal("generated/db")
 }
 
 fn analyzed_star_queries() -> List(model.AnalyzedQuery) {


### PR DESCRIPTION
## Summary

- Fix `out_to_module_path` to correctly handle paths with multiple `/src/` segments by taking the part after the last `/src/` occurrence
- Add test cases for multiple `/src/` segment paths

## Changes

- `src/sqlode/codegen/common.gleam`: Replace two-element pattern match `[_, after]` with `list.last` on the split result, so paths like `/home/src/project/src/db` correctly resolve to `db`
- `test/codegen_test.gleam`: Add test cases for multiple `/src/` segments

## Design Decisions

- Used `list.last |> result.unwrap(out)` instead of `[_, ..rest] + join` because we want the part after the **last** `/src/`, not a reconstructed path including intermediate `/src/` segments

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved file path handling in code generation for complex directory structures containing multiple path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->