### PR TITLE
fix(config): reject malformed rename entries instead of silently discarding

### DIFF
--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -213,23 +213,27 @@ fn parse_overrides(node: yay.Node) -> Result(model.Overrides, ConfigError) {
         },
       )
 
-      let column_renames = case
-        yay.select_sugar(from: overrides_node, selector: "renames")
-      {
-        Ok(yay.NodeSeq(items)) ->
-          list.filter_map(items, fn(item) {
-            case
-              optional_string(item, "table"),
-              optional_string(item, "column"),
-              optional_string(item, "rename_to")
-            {
-              Some(table), Some(column), Some(rename_to) ->
-                Ok(model.ColumnRename(table:, column:, rename_to:))
-              _, _, _ -> Error(Nil)
-            }
-          })
-        _ -> []
-      }
+      use column_renames <- result.try(
+        case yay.select_sugar(from: overrides_node, selector: "renames") {
+          Ok(yay.NodeSeq(items)) ->
+            list.try_map(items, fn(item) {
+              case
+                optional_string(item, "table"),
+                optional_string(item, "column"),
+                optional_string(item, "rename_to")
+              {
+                Some(table), Some(column), Some(rename_to) ->
+                  Ok(model.ColumnRename(table:, column:, rename_to:))
+                _, _, _ ->
+                  Error(InvalidValue(
+                    field: "overrides.renames",
+                    detail: "each rename entry must have 'table', 'column', and 'rename_to' fields",
+                  ))
+              }
+            })
+          _ -> Ok([])
+        },
+      )
 
       Ok(model.Overrides(type_overrides:, column_renames:))
     }

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -135,6 +135,15 @@ pub fn reject_empty_gleam_type_test() {
   string.contains(msg, "empty") |> should.be_true()
 }
 
+// malformed rename entries
+
+pub fn reject_malformed_rename_entry_test() {
+  let assert Error(error) = config.load("test/fixtures/malformed_rename.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "renames") |> should.be_true()
+  string.contains(msg, "rename_to") |> should.be_true()
+}
+
 // error_to_string coverage
 
 pub fn error_to_string_file_read_error_test() {

--- a/test/fixtures/malformed_rename.yaml
+++ b/test/fixtures/malformed_rename.yaml
@@ -1,0 +1,14 @@
+version: "2"
+sql:
+  - schema: "schema.sql"
+    queries: "query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        package: "db"
+        out: "../../test_output/db"
+        runtime: "raw"
+    overrides:
+      renames:
+        - table: users
+          column: name


### PR DESCRIPTION
## Summary

- Replace `list.filter_map` with `list.try_map` in rename config parsing so malformed entries produce a clear error instead of being silently dropped
- Add test and fixture for missing `rename_to` field

## Changes

- `src/sqlode/config.gleam`: Change rename parsing from `list.filter_map` (silently discards invalid entries) to `list.try_map` with `InvalidValue` error, matching the pattern used by type overrides parsing
- `test/config_test.gleam`: Add `reject_malformed_rename_entry_test`
- `test/fixtures/malformed_rename.yaml`: Fixture with a rename entry missing the `rename_to` field

## Design Decisions

- Error message explicitly lists the three required fields (`table`, `column`, `rename_to`) to help users fix the config
- Follows the existing error pattern in `parse_overrides` where type overrides already use `list.try_map` + `InvalidValue`

Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now properly validates rename entries and reports errors for missing required fields, instead of silently ignoring invalid entries.

* **Tests**
  * Added test coverage for malformed configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->