### PR TITLE
fix(parser): skip parenthesized expressions when splitting on AS in view parsing

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -134,7 +134,7 @@ fn parse_create_view(
     |> string.replace("\t", " ")
 
   // Extract view name: CREATE [OR REPLACE] VIEW <name> AS ...
-  case string.split_once(lowered, " as ") {
+  case split_once_outside_parens(lowered, " as ") {
     Error(_) -> None
     Ok(#(header, select_part)) -> {
       let view_name =
@@ -176,7 +176,7 @@ fn parse_create_view(
                 |> list.map(fn(c) {
                   let trimmed = string.trim(c)
                   // Handle aliases: "col AS alias" → use alias
-                  case string.split_once(trimmed, " as ") {
+                  case split_once_outside_parens(trimmed, " as ") {
                     Ok(#(_, alias)) -> string.trim(alias)
                     Error(_) ->
                       // Handle table.column → use column
@@ -488,6 +488,51 @@ fn find_enum(type_text: String, enums: List(model.EnumDef)) -> Option(String) {
   case list.find(enums, fn(e) { e.name == lowered }) {
     Ok(e) -> Some(e.name)
     Error(_) -> None
+  }
+}
+
+/// Split a string on the first occurrence of `delimiter` that is not inside
+/// parentheses.  Returns the same shape as `string.split_once`.
+fn split_once_outside_parens(
+  input: String,
+  delimiter: String,
+) -> Result(#(String, String), Nil) {
+  let graphemes = string.to_graphemes(input)
+  let delim_len = string.length(delimiter)
+  do_split_outside_parens(graphemes, delimiter, delim_len, 0, "")
+}
+
+fn do_split_outside_parens(
+  remaining: List(String),
+  delimiter: String,
+  delim_len: Int,
+  depth: Int,
+  acc: String,
+) -> Result(#(String, String), Nil) {
+  case remaining {
+    [] -> Error(Nil)
+    ["(", ..rest] ->
+      do_split_outside_parens(rest, delimiter, delim_len, depth + 1, acc <> "(")
+    [")", ..rest] -> {
+      let new_depth = case depth > 0 {
+        True -> depth - 1
+        False -> 0
+      }
+      do_split_outside_parens(rest, delimiter, delim_len, new_depth, acc <> ")")
+    }
+    [char, ..rest] -> {
+      let new_acc = acc <> char
+      case depth == 0 && string.ends_with(new_acc, delimiter) {
+        True -> {
+          let before =
+            string.slice(new_acc, 0, string.length(new_acc) - delim_len)
+          let after = string.concat(rest)
+          Ok(#(before, after))
+        }
+        False ->
+          do_split_outside_parens(rest, delimiter, delim_len, depth, new_acc)
+      }
+    }
   }
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -155,6 +155,18 @@ pub fn schema_enum_type_test() {
   mood_col.scalar_type |> should.equal(model.EnumType("mood"))
 }
 
+pub fn view_with_cast_expression_test() {
+  let content =
+    "CREATE TABLE t (x TEXT NOT NULL, y TEXT NOT NULL);\n"
+    <> "CREATE VIEW v AS SELECT CAST(x AS TEXT) AS col_a, y AS col_b FROM t;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("cast_view.sql", content)])
+
+  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["col_a", "col_b"])
+}
+
 pub fn error_to_string_invalid_column_test() {
   schema_parser.error_to_string(schema_parser.InvalidColumn(
     table: "users",

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -56,6 +56,10 @@ pub fn parse_extended_types_test() {
   schema_parser_test.parse_extended_types_test()
 }
 
+pub fn view_with_cast_expression_test() {
+  schema_parser_test.view_with_cast_expression_test()
+}
+
 pub fn infer_param_type_from_where_clause_test() {
   query_analyzer_test.infer_param_type_from_where_clause_test()
 }


### PR DESCRIPTION
## Summary

- Fix CREATE VIEW parsing to correctly handle `AS` keywords inside parenthesized expressions like `CAST(x AS TEXT)`
- Add `split_once_outside_parens` helper that respects parenthesis nesting depth

## Changes

- `src/sqlode/schema_parser.gleam`: Add `split_once_outside_parens` and `do_split_outside_parens` functions that track parenthesis depth and only split on delimiters at the top level. Replace `string.split_once` with this helper for both the view-level `AS` split (line 137) and the column alias `AS` split (line 179)
- `test/schema_parser_test.gleam`: Add `view_with_cast_expression_test` that verifies `CAST(x AS TEXT) AS col_a` is correctly parsed
- `test/sqlode_test.gleam`: Register the new test

## Design Decisions

- The helper is generic (`split_once_outside_parens(input, delimiter)`) so it can be reused for other context-sensitive splits if needed
- Only the ` as ` splits are updated; the ` from ` split is left unchanged as it is outside this issue's scope

Closes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema parser to correctly handle column aliases within CAST expressions and other parenthesized SQL constructs, preventing alias detection errors.

* **Tests**
  * Added test coverage for views containing CAST expressions with column aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->