### PR TITLE
refactor(query_analyzer): replace trivial Result-to-Option wrappers with option.from_result

### DIFF
--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -151,16 +151,7 @@ pub fn find_column(
       |> list.find(fn(column) {
         column.name == naming.normalize_identifier(column_name)
       })
-      |> column_result_to_option
-    Error(_) -> None
-  }
-}
-
-fn column_result_to_option(
-  result: Result(model.Column, a),
-) -> Option(model.Column) {
-  case result {
-    Ok(value) -> Some(value)
+      |> option.from_result
     Error(_) -> None
   }
 }

--- a/src/sqlode/query_analyzer/placeholder.gleam
+++ b/src/sqlode/query_analyzer/placeholder.gleam
@@ -48,7 +48,7 @@ pub fn placeholder_index_for_token(
       token
       |> string.replace("$", "")
       |> int.parse
-      |> int_result_to_option
+      |> option.from_result
     model.MySQL -> Some(occurrence)
     model.SQLite ->
       case string.starts_with(token, "?") && token != "?" {
@@ -56,7 +56,7 @@ pub fn placeholder_index_for_token(
           token
           |> string.replace("?", "")
           |> int.parse
-          |> int_result_to_option
+          |> option.from_result
         False -> Some(occurrence)
       }
   }
@@ -166,12 +166,5 @@ fn all_digits(value: String) -> Bool {
           all_digits(rest)
         _ -> False
       }
-  }
-}
-
-fn int_result_to_option(result: Result(Int, a)) -> Option(Int) {
-  case result {
-    Ok(value) -> Some(value)
-    Error(_) -> None
   }
 }


### PR DESCRIPTION
## Summary

- Replace custom `column_result_to_option` and `int_result_to_option` wrappers with the standard library's `option.from_result`
- Remove the now-unused wrapper function definitions

## Changes

- `src/sqlode/query_analyzer/context.gleam`: Replace `column_result_to_option` call with `option.from_result` and remove the function definition (the same file already uses `option.from_result` elsewhere)
- `src/sqlode/query_analyzer/placeholder.gleam`: Replace two `int_result_to_option` calls with `option.from_result` and remove the function definition

Closes #161