### PR TITLE
ux(cli): add CreateAuthor :exec to init stub files for complete CRUD example

### DIFF
--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -125,6 +125,9 @@ fn create_stub_files(base_dir: String) -> Nil {
     <> "SELECT id, name\n"
     <> "FROM authors\n"
     <> "ORDER BY name;\n"
+    <> "\n"
+    <> "-- name: CreateAuthor :exec\n"
+    <> "INSERT INTO authors (name, bio) VALUES ($1, $2);\n"
 
   let db_dir = filepath.join(base_dir, "db")
   let schema_path = filepath.join(db_dir, "schema.sql")


### PR DESCRIPTION
## Summary

- Add a `CreateAuthor :exec` query to the stub `query.sql` generated by `sqlode init`, giving users a complete CRUD starting point that matches the README tutorial

## Changes

- `src/sqlode/cli.gleam`: Append `CreateAuthor :exec` INSERT query to the stub query content

Closes #158