### PR TITLE
refactor(codegen): extract repeated predicates into shared helpers (#150)

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -113,11 +113,8 @@ fn render_adapter(
 
   let has_results =
     list.any(queries, fn(query) {
-      case query.base.command {
-        model.One | model.Many | model.BatchOne | model.BatchMany ->
-          !list.is_empty(query.result_columns)
-        _ -> False
-      }
+      model.is_result_command(query.base.command)
+      && !list.is_empty(query.result_columns)
     })
 
   let has_exec_rows =
@@ -126,26 +123,9 @@ fn render_adapter(
       || query.base.command == model.ExecResult
     })
 
-  let has_slices =
-    list.any(queries, fn(query) {
-      list.any(query.params, fn(param) { param.is_list })
-    })
+  let has_slices = common.queries_have_slices(queries)
 
-  let has_enums =
-    list.any(queries, fn(query) {
-      list.any(query.params, fn(param) {
-        case param.scalar_type {
-          model.EnumType(_) -> True
-          _ -> False
-        }
-      })
-      || list.any(query.result_columns, fn(col) {
-        case col {
-          model.ResultColumn(scalar_type: model.EnumType(_), ..) -> True
-          _ -> False
-        }
-      })
-    })
+  let has_enums = common.queries_have_enums(queries)
 
   let imports =
     list.flatten([
@@ -565,7 +545,7 @@ fn render_pog_query_call(
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = list.any(params, fn(p) { p.is_list })
+  let has_slices = common.has_slices(params)
 
   let param_lines = case params_str {
     "" -> []
@@ -598,7 +578,7 @@ fn render_pog_query_call(
 }
 
 fn render_pog_params(params: List(model.QueryParam), _prefix: String) -> String {
-  let has_slices = list.any(params, fn(p) { p.is_list })
+  let has_slices = common.has_slices(params)
   case has_slices {
     True -> render_pog_params_with_slices(params)
     False -> render_pog_params_simple(params)
@@ -701,7 +681,7 @@ fn render_pog_exec_last_id(
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = list.any(params, fn(p) { p.is_list })
+  let has_slices = common.has_slices(params)
 
   let param_lines = case params_str {
     "" -> []
@@ -759,7 +739,7 @@ fn render_sqlight_query_call(
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = list.any(params, fn(p) { p.is_list })
+  let has_slices = common.has_slices(params)
   case has_slices {
     True -> {
       let slice_expansion = render_slice_expansion_line(params, "?")
@@ -788,7 +768,7 @@ fn render_sqlight_params(
   params: List(model.QueryParam),
   _prefix: String,
 ) -> String {
-  let has_slices = list.any(params, fn(p) { p.is_list })
+  let has_slices = common.has_slices(params)
   case has_slices {
     True -> render_sqlight_params_with_slices(params)
     False -> render_sqlight_params_simple(params)
@@ -917,7 +897,7 @@ fn render_sqlight_exec_last_id(
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = list.any(params, fn(p) { p.is_list })
+  let has_slices = common.has_slices(params)
   let sql_var = case has_slices {
     True -> "sql"
     False -> "q.sql"

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -1,6 +1,43 @@
 import gleam/list
 import gleam/result
 import gleam/string
+import sqlode/model
+
+pub fn has_slices(params: List(model.QueryParam)) -> Bool {
+  list.any(params, fn(p) { p.is_list })
+}
+
+pub fn queries_have_slices(queries: List(model.AnalyzedQuery)) -> Bool {
+  list.any(queries, fn(query) { has_slices(query.params) })
+}
+
+pub fn queries_have_enum_params(queries: List(model.AnalyzedQuery)) -> Bool {
+  list.any(queries, fn(query) {
+    list.any(query.params, fn(param) {
+      case param.scalar_type {
+        model.EnumType(_) -> True
+        _ -> False
+      }
+    })
+  })
+}
+
+pub fn queries_have_enums(queries: List(model.AnalyzedQuery)) -> Bool {
+  list.any(queries, fn(query) {
+    list.any(query.params, fn(param) {
+      case param.scalar_type {
+        model.EnumType(_) -> True
+        _ -> False
+      }
+    })
+    || list.any(query.result_columns, fn(col) {
+      case col {
+        model.ResultColumn(scalar_type: model.EnumType(_), ..) -> True
+        _ -> False
+      }
+    })
+  })
+}
 
 pub fn escape_string(input: String) -> String {
   input

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -24,11 +24,8 @@ pub fn render(
   let row_types =
     queries
     |> list.filter(fn(query) {
-      case query.base.command {
-        model.One | model.Many | model.BatchOne | model.BatchMany ->
-          !list.is_empty(query.result_columns)
-        _ -> False
-      }
+      model.is_result_command(query.base.command)
+      && !list.is_empty(query.result_columns)
     })
     |> list.map(render_row_type_or_alias(
       naming_ctx,
@@ -191,8 +188,8 @@ fn collect_rich_types(
 
 fn needs_option_import_for_results(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
-    case query.base.command {
-      model.One | model.Many | model.BatchOne | model.BatchMany ->
+    case model.is_result_command(query.base.command) {
+      True ->
         list.any(query.result_columns, fn(col) {
           case col {
             model.ResultColumn(nullable: True, ..) -> True
@@ -201,7 +198,7 @@ fn needs_option_import_for_results(queries: List(model.AnalyzedQuery)) -> Bool {
             _ -> False
           }
         })
-      _ -> False
+      False -> False
     }
   })
 }
@@ -214,8 +211,8 @@ fn needs_option_import_for_tables(catalog: model.Catalog) -> Bool {
 
 fn has_custom_types_in_results(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
-    case query.base.command {
-      model.One | model.Many | model.BatchOne | model.BatchMany ->
+    case model.is_result_command(query.base.command) {
+      True ->
         list.any(query.result_columns, fn(col) {
           case col {
             model.ResultColumn(scalar_type: model.CustomType(..), ..) -> True
@@ -229,7 +226,7 @@ fn has_custom_types_in_results(queries: List(model.AnalyzedQuery)) -> Bool {
             _ -> False
           }
         })
-      _ -> False
+      False -> False
     }
   })
 }

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -1,5 +1,6 @@
 import gleam/list
 import gleam/string
+import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
 
@@ -9,20 +10,9 @@ pub fn render(
   type_mapping: model.TypeMapping,
   module_path: String,
 ) -> String {
-  let has_slices =
-    list.any(queries, fn(query) {
-      list.any(query.params, fn(param) { param.is_list })
-    })
+  let has_slices = common.queries_have_slices(queries)
 
-  let has_enums =
-    list.any(queries, fn(query) {
-      list.any(query.params, fn(param) {
-        case param.scalar_type {
-          model.EnumType(_) -> True
-          _ -> False
-        }
-      })
-    })
+  let has_enums = common.queries_have_enum_params(queries)
 
   let imports = case needs_option_import(queries) {
     True ->
@@ -102,7 +92,7 @@ fn render_params_declaration(
         "\n",
       )
     params -> {
-      let has_slices = list.any(params, fn(p) { p.is_list })
+      let has_slices = common.has_slices(params)
       let values_body = case has_slices {
         True ->
           "  list.flatten(["

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -117,11 +117,8 @@ fn generate_sql_block(
     _ -> {
       let has_row_types =
         list.any(analyzed, fn(query) {
-          case query.base.command {
-            model.One | model.Many | model.BatchOne | model.BatchMany ->
-              !list.is_empty(query.result_columns)
-            _ -> False
-          }
+          model.is_result_command(query.base.command)
+          && !list.is_empty(query.result_columns)
         })
 
       let has_models = has_row_types || !list.is_empty(catalog.tables)
@@ -490,10 +487,7 @@ fn try_match_query_to_table(
   query: model.AnalyzedQuery,
 ) -> Result(#(String, String), Nil) {
   // Only result-returning commands can match a table
-  use <- guard_result(case query.base.command {
-    model.One | model.Many | model.BatchOne | model.BatchMany -> True
-    _ -> False
-  })
+  use <- guard_result(model.is_result_command(query.base.command))
 
   // Queries with embedded columns never match a single table
   let has_embed =

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -119,6 +119,13 @@ pub type QueryCommand {
   CopyFrom
 }
 
+pub fn is_result_command(command: QueryCommand) -> Bool {
+  case command {
+    One | Many | BatchOne | BatchMany -> True
+    _ -> False
+  }
+}
+
 pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
   case value {
     ":one" -> Ok(One)


### PR DESCRIPTION
## Summary

- Add `model.is_result_command` to centralize the `One | Many | BatchOne | BatchMany` check used across 5 call sites
- Add `common.has_slices`, `common.queries_have_slices`, `common.queries_have_enum_params`, and `common.queries_have_enums` to eliminate 9+ duplicated predicate computations

## Changes

- **src/sqlode/model.gleam**: Add `is_result_command(command) -> Bool`
- **src/sqlode/codegen/common.gleam**: Add `has_slices`, `queries_have_slices`, `queries_have_enum_params`, `queries_have_enums`
- **src/sqlode/codegen/adapter.gleam**: Replace inline predicates with shared helpers (7 `has_slices` sites, 1 `has_enums`, 1 `has_results`)
- **src/sqlode/codegen/params.gleam**: Replace inline `has_slices` and `has_enums` with shared helpers
- **src/sqlode/codegen/models.gleam**: Replace inline `is_result_command` pattern in 3 functions
- **src/sqlode/generate.gleam**: Replace inline `is_result_command` pattern in 2 locations

## Design Decisions

- **`needs_option_import` not centralized**: Each module's option-import check has unique logic (adapter considers `One`/`BatchOne` commands, models checks tables separately), so these remain module-local rather than forcing a leaky abstraction.
- **Two enum helpers**: `queries_have_enum_params` (params only, for params.gleam) vs `queries_have_enums` (params + result columns, for adapter.gleam) because the two modules need different scopes.

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability. Consolidated duplicate detection logic across multiple modules into shared helper functions. Simplified conditional checks for identifying query characteristics and centralized command-type detection patterns to reduce redundancy and improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->