### PR TITLE
fix(generate): reject unsupported batch and copyfrom annotations (#120)

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -98,6 +98,7 @@ fn generate_sql_block(
       QueryAnalysisError(detail: query_analyzer.analysis_error_to_string(error))
     }),
   )
+  use Nil <- result.try(validate_unsupported_annotations(analyzed))
   let analyzed = apply_column_renames(analyzed, block.overrides.column_renames)
 
   let table_matches = compute_table_matches(naming_ctx, catalog, analyzed)
@@ -443,6 +444,38 @@ fn find_column_rename(
       False -> Error(Nil)
     }
   })
+}
+
+fn validate_unsupported_annotations(
+  queries: List(model.AnalyzedQuery),
+) -> Result(Nil, GenerateError) {
+  let unsupported = fn(command: model.QueryCommand) -> Bool {
+    case command {
+      model.BatchOne | model.BatchMany | model.BatchExec | model.CopyFrom ->
+        True
+      _ -> False
+    }
+  }
+  case list.find(queries, fn(q) { unsupported(q.base.command) }) {
+    Ok(q) -> {
+      let #(command, alternative) = case q.base.command {
+        model.BatchOne -> #(":batchone", ":one")
+        model.BatchMany -> #(":batchmany", ":many")
+        model.BatchExec -> #(":batchexec", ":exec")
+        model.CopyFrom -> #(":copyfrom", ":exec")
+        _ -> #("", ":exec")
+      }
+      Error(UnsupportedAnnotation(
+        query_name: q.base.name,
+        command: command,
+        detail: command
+          <> " is not yet supported. Use "
+          <> alternative
+          <> " instead",
+      ))
+    }
+    Error(_) -> Ok(Nil)
+  }
 }
 
 fn validate_native_annotations(

--- a/test/fixtures/all_commands_query.sql
+++ b/test/fixtures/all_commands_query.sql
@@ -15,15 +15,3 @@ SELECT id FROM posts;
 
 -- name: InsertPost :execlastid
 INSERT INTO posts (title, body) VALUES (?1, ?2);
-
--- name: GetPostBatch :batchone
-SELECT id, title, body FROM posts WHERE id = ?1;
-
--- name: ListPostsBatch :batchmany
-SELECT id, title FROM posts WHERE id = ?1;
-
--- name: CreatePostBatch :batchexec
-INSERT INTO posts (title, body) VALUES (?1, ?2);
-
--- name: BulkInsertPosts :copyfrom
-INSERT INTO posts (title, body) VALUES (?1, ?2);

--- a/test/fixtures/batchexec_query.sql
+++ b/test/fixtures/batchexec_query.sql
@@ -1,0 +1,2 @@
+-- name: CreatePostBatch :batchexec
+INSERT INTO posts (title, body) VALUES (?1, ?2);

--- a/test/fixtures/batchmany_query.sql
+++ b/test/fixtures/batchmany_query.sql
@@ -1,0 +1,2 @@
+-- name: ListPostsBatch :batchmany
+SELECT id, title FROM posts WHERE id = ?1;

--- a/test/fixtures/batchone_query.sql
+++ b/test/fixtures/batchone_query.sql
@@ -1,0 +1,2 @@
+-- name: GetPostBatch :batchone
+SELECT id, title, body FROM posts WHERE id = ?1;

--- a/test/fixtures/copyfrom_query.sql
+++ b/test/fixtures/copyfrom_query.sql
@@ -1,0 +1,2 @@
+-- name: BulkInsertPosts :copyfrom
+INSERT INTO posts (title, body) VALUES (?1, ?2);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -751,16 +751,13 @@ pub fn all_commands_generate_queries_test() {
 
   let queries = read_commands_file("queries.gleam")
 
-  // All 9 query functions should exist
+  // All 6 query functions should exist
   string.contains(queries, "pub fn get_post()") |> should.be_true()
   string.contains(queries, "pub fn list_posts()") |> should.be_true()
   string.contains(queries, "pub fn create_post()") |> should.be_true()
   string.contains(queries, "pub fn update_post()") |> should.be_true()
   string.contains(queries, "pub fn count_posts()") |> should.be_true()
   string.contains(queries, "pub fn insert_post()") |> should.be_true()
-  string.contains(queries, "pub fn get_post_batch()") |> should.be_true()
-  string.contains(queries, "pub fn list_posts_batch()") |> should.be_true()
-  string.contains(queries, "pub fn create_post_batch()") |> should.be_true()
 
   // Verify command types
   string.contains(queries, "runtime.QueryOne") |> should.be_true()
@@ -768,11 +765,6 @@ pub fn all_commands_generate_queries_test() {
   string.contains(queries, "runtime.QueryExec") |> should.be_true()
   string.contains(queries, "runtime.QueryExecRows") |> should.be_true()
   string.contains(queries, "runtime.QueryExecLastId") |> should.be_true()
-  string.contains(queries, "runtime.QueryBatchOne") |> should.be_true()
-  string.contains(queries, "runtime.QueryBatchMany") |> should.be_true()
-  string.contains(queries, "runtime.QueryBatchExec") |> should.be_true()
-  string.contains(queries, "pub fn bulk_insert_posts()") |> should.be_true()
-  string.contains(queries, "runtime.QueryCopyFrom") |> should.be_true()
 
   cleanup_commands()
 }
@@ -794,12 +786,6 @@ pub fn all_commands_generate_params_test() {
   string.contains(params, "InsertPostParams") |> should.be_true()
   // :many without params should still have type
   string.contains(params, "ListPostsParams") |> should.be_true()
-  // batch variants with params
-  string.contains(params, "GetPostBatchParams") |> should.be_true()
-  string.contains(params, "ListPostsBatchParams") |> should.be_true()
-  string.contains(params, "CreatePostBatchParams") |> should.be_true()
-  // :copyfrom with params
-  string.contains(params, "BulkInsertPostsParams") |> should.be_true()
 
   cleanup_commands()
 }
@@ -820,14 +806,6 @@ pub fn all_commands_generate_models_test() {
   string.contains(models, "CreatePostRow") |> should.be_false()
   string.contains(models, "UpdatePostRow") |> should.be_false()
   string.contains(models, "InsertPostRow") |> should.be_false()
-
-  // :batchone and :batchmany generate row types
-  string.contains(models, "GetPostBatchRow") |> should.be_true()
-  string.contains(models, "ListPostsBatchRow") |> should.be_true()
-  // :batchexec should NOT generate row types
-  string.contains(models, "CreatePostBatchRow") |> should.be_false()
-  // :copyfrom should NOT generate row types
-  string.contains(models, "BulkInsertPostsRow") |> should.be_false()
 
   cleanup_commands()
 }
@@ -856,13 +834,6 @@ pub fn all_commands_sqlight_adapter_test() {
   string.contains(adapter, "Result(Int, sqlight.Error)") |> should.be_true()
   // :execlastid returns Nil (same as exec for sqlight)
   string.contains(adapter, "fn insert_post(") |> should.be_true()
-
-  // batch variants generate adapter functions
-  string.contains(adapter, "fn get_post_batch(") |> should.be_true()
-  string.contains(adapter, "fn list_posts_batch(") |> should.be_true()
-  string.contains(adapter, "fn create_post_batch(") |> should.be_true()
-  // :copyfrom generates adapter function
-  string.contains(adapter, "fn bulk_insert_posts(") |> should.be_true()
 
   cleanup_commands()
 }
@@ -985,6 +956,63 @@ pub fn execresult_allowed_on_raw_runtime_test() {
   let assert Ok(_) = generate.generate_config(cfg)
   let _ = simplifile.delete("test_output/execresult_raw")
   Nil
+}
+
+// --- Unsupported batch/copyfrom annotation rejection tests ---
+
+fn unsupported_annotation_block(query_file: String) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.SQLite,
+    schema: ["test/fixtures/all_commands_schema.sql"],
+    queries: [query_file],
+    gleam: model.GleamOutput(
+      out: "test_output/unsupported_reject",
+      runtime: model.Raw,
+      type_mapping: model.StringMapping,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+pub fn batchone_rejected_test() {
+  let block = unsupported_annotation_block("test/fixtures/batchone_query.sql")
+  let cfg = model.Config(version: 2, sql: [block])
+  let result = generate.generate_config(cfg)
+  case result {
+    Error(generate.UnsupportedAnnotation(command: ":batchone", ..)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn batchmany_rejected_test() {
+  let block = unsupported_annotation_block("test/fixtures/batchmany_query.sql")
+  let cfg = model.Config(version: 2, sql: [block])
+  let result = generate.generate_config(cfg)
+  case result {
+    Error(generate.UnsupportedAnnotation(command: ":batchmany", ..)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn batchexec_rejected_test() {
+  let block = unsupported_annotation_block("test/fixtures/batchexec_query.sql")
+  let cfg = model.Config(version: 2, sql: [block])
+  let result = generate.generate_config(cfg)
+  case result {
+    Error(generate.UnsupportedAnnotation(command: ":batchexec", ..)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn copyfrom_rejected_test() {
+  let block = unsupported_annotation_block("test/fixtures/copyfrom_query.sql")
+  let cfg = model.Config(version: 2, sql: [block])
+  let result = generate.generate_config(cfg)
+  case result {
+    Error(generate.UnsupportedAnnotation(command: ":copyfrom", ..)) -> Nil
+    _ -> should.fail()
+  }
 }
 
 // --- UNION/INTERSECT/EXCEPT tests ---


### PR DESCRIPTION
## Summary

- Reject `:batchone`, `:batchmany`, `:batchexec`, and `:copyfrom` annotations at generation time with clear error messages suggesting supported alternatives
- Previously these annotations silently generated code identical to `:one`/`:many`/`:exec`, which is a semantic downgrade hazard for sqlc users

## Changes

- **src/sqlode/generate.gleam**: Add `validate_unsupported_annotations()` that checks for batch/copyfrom commands before code generation and returns `UnsupportedAnnotation` error with the suggested alternative (e.g., `:batchone` → `:one`)
- **test/fixtures/all_commands_query.sql**: Remove batch/copyfrom queries so existing "all commands" tests pass with supported commands only
- **test/fixtures/batch{one,many,exec}_query.sql, copyfrom_query.sql**: New fixtures for rejection tests
- **test/generate_test.gleam**: Remove assertions expecting batch/copyfrom generation to succeed; add 4 rejection tests verifying each unsupported annotation produces `UnsupportedAnnotation` error

## Design Decisions

- **Reject at generation time, not parse time**: Follows the existing `validate_native_annotations()` pattern and keeps parsing concerns separate from validation
- **Fail on first unsupported annotation**: Consistent with how `validate_native_annotations` works — reports one clear error rather than accumulating multiple

Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for SQL query annotations to detect and reject unsupported batch operations (`:batchone`, `:batchmany`, `:batchexec`, `:copyfrom`).
  * Generation now fails with descriptive error messages that include recommended alternatives for each unsupported command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->