### PR TITLE
fix(codegen): reject unknown enum values during native decoding

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -242,9 +242,11 @@ fn render_decoder(
               let field_name = naming.to_snake_case(naming_ctx, name)
               let base_decoder = case scalar_type {
                 model.EnumType(enum_name) ->
-                  "decode.map(decode.string, models."
+                  "decode.then(decode.string, fn(s) { case models."
                   <> model.enum_from_string_fn(enum_name)
-                  <> ")"
+                  <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(s, \"valid "
+                  <> enum_name
+                  <> " value\") } })"
                 _ -> config.decoder_function(scalar_type)
               }
               let full_decoder = case nullable {

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -101,13 +101,10 @@ fn render_enum_type(enum_def: model.EnumDef) -> String {
 
   let from_string_cases =
     enum_def.values
-    |> list.map(fn(v) { "    \"" <> v <> "\" -> " <> model.enum_value_name(v) })
+    |> list.map(fn(v) {
+      "    \"" <> v <> "\" -> Ok(" <> model.enum_value_name(v) <> ")"
+    })
     |> string.join("\n")
-
-  let default_value = case enum_def.values {
-    [first, ..] -> model.enum_value_name(first)
-    [] -> type_name
-  }
 
   string.join(
     [
@@ -121,10 +118,14 @@ fn render_enum_type(enum_def: model.EnumDef) -> String {
       "  }",
       "}",
       "",
-      "pub fn " <> from_string_fn <> "(value: String) -> " <> type_name <> " {",
+      "pub fn "
+        <> from_string_fn
+        <> "(value: String) -> Result("
+        <> type_name
+        <> ", String) {",
       "  case value {",
       from_string_cases,
-      "    _ -> " <> default_value,
+      "    _ -> Error(\"Unknown " <> enum_def.name <> " value: \" <> value)",
       "  }",
       "}",
     ],

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -464,6 +464,110 @@ fn analyzed_queries(path: String) -> List(model.AnalyzedQuery) {
   result
 }
 
+// --- Enum type tests ---
+
+pub fn render_enum_from_string_returns_result_test() {
+  let naming_ctx = naming.new()
+  let catalog = enum_test_catalog()
+  let analyzed = enum_analyzed_queries()
+  let rendered =
+    codegen.render_models_module(
+      naming_ctx,
+      catalog,
+      analyzed,
+      dict.new(),
+      model.StringMapping,
+    )
+
+  // from_string should return Result
+  string.contains(
+    rendered,
+    "pub fn status_from_string(value: String) -> Result(Status, String) {",
+  )
+  |> should.be_true()
+
+  // Valid values should return Ok
+  string.contains(rendered, "\"active\" -> Ok(Active)")
+  |> should.be_true()
+  string.contains(rendered, "\"inactive\" -> Ok(Inactive)")
+  |> should.be_true()
+  string.contains(rendered, "\"banned\" -> Ok(Banned)")
+  |> should.be_true()
+
+  // Unknown values should return Error
+  string.contains(rendered, "_ -> Error(\"Unknown status value: \" <> value)")
+  |> should.be_true()
+}
+
+pub fn render_enum_decoder_uses_decode_then_test() {
+  let naming_ctx = naming.new()
+  let analyzed = enum_analyzed_queries()
+
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/enum_schema.sql"],
+      queries: ["test/fixtures/enum_query.sql"],
+      gleam: model.GleamOutput(
+        out: "src/db",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let rendered =
+    codegen.render_adapter_module(naming_ctx, block, analyzed, dict.new())
+
+  // Should use decode.then, not decode.map for enums
+  string.contains(rendered, "decode.then(decode.string")
+  |> should.be_true()
+  string.contains(rendered, "status_from_string")
+  |> should.be_true()
+  string.contains(rendered, "decode.success(v)")
+  |> should.be_true()
+  string.contains(rendered, "decode.failure(s")
+  |> should.be_true()
+
+  // Should NOT use decode.map for enum decoding
+  string.contains(
+    rendered,
+    "decode.map(decode.string, models.status_from_string",
+  )
+  |> should.be_false()
+}
+
+fn enum_test_catalog() -> model.Catalog {
+  let assert Ok(schema_content) =
+    simplifile.read("test/fixtures/enum_schema.sql")
+  let assert Ok(catalog) =
+    schema_parser.parse_files([
+      #("test/fixtures/enum_schema.sql", schema_content),
+    ])
+  catalog
+}
+
+fn enum_analyzed_queries() -> List(model.AnalyzedQuery) {
+  let naming_ctx = naming.new()
+  let catalog = enum_test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/enum_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/enum_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(result) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result
+}
+
 pub fn out_to_module_path_strips_src_prefix_test() {
   common.out_to_module_path("src/db") |> should.equal("db")
   common.out_to_module_path("src/generated/db") |> should.equal("generated/db")

--- a/test/fixtures/enum_query.sql
+++ b/test/fixtures/enum_query.sql
@@ -1,0 +1,2 @@
+-- name: GetUser :one
+SELECT id, name, status FROM users WHERE id = $1;

--- a/test/fixtures/enum_schema.sql
+++ b/test/fixtures/enum_schema.sql
@@ -1,0 +1,7 @@
+CREATE TYPE status AS ENUM ('active', 'inactive', 'banned');
+
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  status status NOT NULL
+);

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -372,6 +372,14 @@ pub fn execresult_allowed_on_raw_runtime_test() {
   generate_test.execresult_allowed_on_raw_runtime_test()
 }
 
+pub fn render_enum_from_string_returns_result_test() {
+  codegen_test.render_enum_from_string_returns_result_test()
+}
+
+pub fn render_enum_decoder_uses_decode_then_test() {
+  codegen_test.render_enum_decoder_uses_decode_then_test()
+}
+
 pub fn singularize_regular_plural_test() {
   naming_test.singularize_regular_plural_test()
 }


### PR DESCRIPTION
## Summary
- Change generated `from_string` functions to return `Result(EnumType, String)` instead of silently falling back to the first enum constructor
- Update adapter decoders to use `decode.then` instead of `decode.map` so unknown enum values become decode failures
- Add tests for enum code generation (models and adapter decoder)

## Changes
- `src/sqlode/codegen/models.gleam`: Generate `Ok(Constructor)` for valid values and `Error("Unknown <enum> value: " <> value)` for unknowns
- `src/sqlode/codegen/adapter.gleam`: Replace `decode.map(decode.string, models.xxx_from_string)` with `decode.then(decode.string, ...)` that handles the `Result`
- `test/codegen_test.gleam`: Add `render_enum_from_string_returns_result_test` and `render_enum_decoder_uses_decode_then_test`
- `test/fixtures/enum_schema.sql`, `test/fixtures/enum_query.sql`: Test fixtures for enum queries

## Design Decisions
- Used `Result(EnumType, String)` over `Option(EnumType)` to provide actionable error messages
- Followed existing `decode.then` pattern already used for SQLite boolean decoding
- Error message includes the invalid value for debugging

Closes #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced enum value validation and decoding with more informative error messages when invalid enum values are encountered.

* **Tests**
  * Added comprehensive test coverage for enum value conversion and decoding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->