### PR TITLE
fix(codegen): encode enum slice parameters correctly in native adapters

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -632,12 +632,20 @@ fn render_pog_params_with_slices(params: List(model.QueryParam)) -> String {
     let value_fn =
       model.scalar_type_to_value_function(model.PostgreSQL, param.scalar_type)
     case param.is_list {
-      True ->
+      True -> {
+        let value_expr = case param.scalar_type {
+          model.EnumType(name) ->
+            "models." <> model.enum_to_string_fn(name) <> "(v)"
+          _ -> "v"
+        }
         "  let query = list.fold(p."
         <> param.field_name
         <> ", query, fn(acc, v) { pog.parameter(acc, pog."
         <> value_fn
-        <> "(v)) })"
+        <> "("
+        <> value_expr
+        <> ")) })"
+      }
       False ->
         case param.nullable {
           False ->
@@ -835,11 +843,22 @@ fn render_sqlight_params_with_slices(params: List(model.QueryParam)) -> String {
             model.scalar_type_to_value_function(model.SQLite, param.scalar_type)
           case param.is_list {
             True ->
-              "list.map(p."
-              <> param.field_name
-              <> ", sqlight."
-              <> value_fn
-              <> ")"
+              case param.scalar_type {
+                model.EnumType(name) ->
+                  "list.map(p."
+                  <> param.field_name
+                  <> ", fn(v) { sqlight."
+                  <> value_fn
+                  <> "(models."
+                  <> model.enum_to_string_fn(name)
+                  <> "(v)) })"
+                _ ->
+                  "list.map(p."
+                  <> param.field_name
+                  <> ", sqlight."
+                  <> value_fn
+                  <> ")"
+              }
             False ->
               case param.nullable {
                 False ->

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -55,6 +55,7 @@ fn build_params(
       param_inferencer.infer_insert_params(ctx, engine, query, catalog),
       param_inferencer.infer_equality_params(ctx, engine, query, catalog),
     )
+    |> list.append(param_inferencer.infer_in_params(ctx, engine, query, catalog))
 
   let cast_dict = param_inferencer.extract_type_casts(ctx, engine, query.sql)
   let macro_dict = build_macro_dict(query.macros)

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -47,6 +47,7 @@ pub type AnalyzerContext {
     join_re: regexp.Regexp,
     select_columns_re: regexp.Regexp,
     type_cast_re: regexp.Regexp,
+    in_clause_re: regexp.Regexp,
   )
 }
 
@@ -84,6 +85,10 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     regexp.from_string("select\\s+(.+?)\\s+from\\s")
   let assert Ok(type_cast_re) =
     regexp.from_string("(\\$[0-9]+)::[a-zA-Z_][a-zA-Z0-9_]*")
+  let assert Ok(in_clause_re) =
+    regexp.from_string(
+      "([a-zA-Z_][a-zA-Z0-9_.]*)\\s+in\\s*\\(\\s*(\\$[0-9]+|\\?[0-9]*|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)\\s*\\)",
+    )
 
   AnalyzerContext(
     naming: naming_ctx,
@@ -102,6 +107,7 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     join_re:,
     select_columns_re:,
     type_cast_re:,
+    in_clause_re:,
   )
 }
 

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -170,6 +170,30 @@ fn scan_equality_matches(
   }
 }
 
+pub fn infer_in_params(
+  ctx: AnalyzerContext,
+  engine: model.Engine,
+  query: model.ParsedQuery,
+  catalog: model.Catalog,
+) -> List(#(Int, model.Column)) {
+  let normalized = context.normalize_sql(ctx, query.sql)
+  let table_name = context.primary_table_name(ctx, normalized)
+
+  case table_name {
+    None -> []
+    Some(name) ->
+      scan_equality_matches(
+        engine,
+        catalog,
+        name,
+        regexp.scan(ctx.in_clause_re, normalized),
+        1,
+        [],
+      )
+      |> list.reverse
+  }
+}
+
 pub fn extract_type_casts(
   ctx: AnalyzerContext,
   engine: model.Engine,

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -568,6 +568,73 @@ fn enum_analyzed_queries() -> List(model.AnalyzedQuery) {
   result
 }
 
+pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
+  let naming_ctx = naming.new()
+  let analyzed = enum_analyzed_queries()
+
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/enum_schema.sql"],
+      queries: ["test/fixtures/enum_query.sql"],
+      gleam: model.GleamOutput(
+        out: "src/db",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let rendered =
+    codegen.render_adapter_module(naming_ctx, block, analyzed, dict.new())
+
+  // Slice enum params should call to_string before pog.text
+  string.contains(rendered, "models.status_to_string(v)")
+  |> should.be_true()
+  string.contains(rendered, "pog.text(models.status_to_string(v))")
+  |> should.be_true()
+}
+
+pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
+  let naming_ctx = naming.new()
+  let catalog = enum_test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/enum_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/enum_query.sql",
+      model.SQLite,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.SQLite,
+      schema: ["test/fixtures/enum_schema.sql"],
+      queries: ["test/fixtures/enum_query.sql"],
+      gleam: model.GleamOutput(
+        out: "src/db",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let rendered =
+    codegen.render_adapter_module(naming_ctx, block, analyzed, dict.new())
+
+  // Slice enum params should call to_string before sqlight.text
+  string.contains(rendered, "models.status_to_string(v)")
+  |> should.be_true()
+  string.contains(
+    rendered,
+    "fn(v) { sqlight.text(models.status_to_string(v)) }",
+  )
+  |> should.be_true()
+}
+
 pub fn out_to_module_path_strips_src_prefix_test() {
   common.out_to_module_path("src/db") |> should.equal("db")
   common.out_to_module_path("src/generated/db") |> should.equal("generated/db")

--- a/test/fixtures/enum_query.sql
+++ b/test/fixtures/enum_query.sql
@@ -1,2 +1,5 @@
 -- name: GetUser :one
 SELECT id, name, status FROM users WHERE id = $1;
+
+-- name: ListUsersByStatuses :many
+SELECT id, name, status FROM users WHERE status IN (sqlc.slice(statuses));

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -380,6 +380,14 @@ pub fn render_enum_decoder_uses_decode_then_test() {
   codegen_test.render_enum_decoder_uses_decode_then_test()
 }
 
+pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
+  codegen_test.render_pog_adapter_enum_slice_converts_to_string_test()
+}
+
+pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
+  codegen_test.render_sqlight_adapter_enum_slice_converts_to_string_test()
+}
+
 pub fn singularize_regular_plural_test() {
   naming_test.singularize_regular_plural_test()
 }


### PR DESCRIPTION
## Summary
- Add IN-clause type inference so `column IN ($1)` correctly resolves the parameter's scalar type from the schema
- Generate `models.xxx_to_string(v)` calls for enum slice parameters in both pog and sqlight adapters
- Add tests for enum slice parameter encoding in both adapter backends

## Changes
- `src/sqlode/query_analyzer/context.gleam`: Add `in_clause_re` regex to match `column IN (placeholder)` patterns
- `src/sqlode/query_analyzer/param_inferencer.gleam`: Add `infer_in_params` to resolve IN-clause parameter types from catalog columns
- `src/sqlode/query_analyzer.gleam`: Include IN-clause inferences in `build_params`
- `src/sqlode/codegen/adapter.gleam`: Handle `EnumType` in `render_pog_params_with_slices` and `render_sqlight_params_with_slices` by wrapping values with `models.xxx_to_string()`
- `test/codegen_test.gleam`: Add `render_pog_adapter_enum_slice_converts_to_string_test` and `render_sqlight_adapter_enum_slice_converts_to_string_test`
- `test/fixtures/enum_query.sql`: Add `ListUsersByStatuses` slice query for testing

## Design Decisions
- Reused `scan_equality_matches` for IN-clause scanning since the submatch structure (column_name, placeholder_token) is identical
- The IN-clause regex matches single-placeholder `IN ($1)` which is the pattern produced after `sqlc.slice()` macro expansion

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enum list parameters in SQL IN clauses with automatic type conversion for both PostgreSQL and SQLite adapters.
  * Enhanced parameter type inference to include IN clause patterns for improved query parameter detection.

* **Tests**
  * Added test coverage for enum list parameter handling across database adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->