### PR TITLE
docs(readme): fix examples and type mapping table to match actual generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Initial sqlc-style code generator for Gleam
 - PostgreSQL, MySQL, and SQLite engine support
-- Query annotations: `:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`
+- Query annotations: `:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`, `:batchone`, `:batchmany`, `:batchexec`, `:copyfrom`
 - sqlc macros: `sqlc.arg`, `sqlc.narg`, `sqlc.slice`, `sqlc.embed`
 - Type mapping for INT, FLOAT, BOOL, TEXT, BYTEA, UUID, JSON, TIMESTAMP, DATE, TIME
 - PostgreSQL ENUM type support

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ sqlode generates reusable record types for each table in the schema, plus per-qu
 ```gleam
 // Table record type (singularized) — reusable across queries
 pub type Author {
-  Author(id: Int, name: String, bio: Option(String), created_at: String)
+  Author(id: Int, name: String, bio: Option(String))
 }
 
 // Exact table match — alias instead of duplicate
@@ -156,7 +156,7 @@ pub type QueryInfo {
 pub fn all() -> List(QueryInfo) { ... }
 
 pub fn get_author() -> runtime.RawQuery(params.GetAuthorParams) { ... }
-pub fn list_authors() -> runtime.RawQuery(params.ListAuthorsParams) { ... }
+pub fn list_authors() -> runtime.RawQuery(Nil) { ... }
 pub fn create_author() -> runtime.RawQuery(params.CreateAuthorParams) { ... }
 ```
 
@@ -402,7 +402,7 @@ JOIN filtered ON authors.id = filtered.id;
 
 | SQL type | Gleam type |
 |---|---|
-| INT, INTEGER, BIGINT, SERIAL, BIGSERIAL | Int |
+| INT, INTEGER, SMALLINT, BIGINT, SERIAL, BIGSERIAL | Int |
 | FLOAT, DOUBLE, REAL, NUMERIC, DECIMAL | Float |
 | BOOLEAN, BOOL | Bool |
 | TEXT, VARCHAR, CHAR | String |


### PR DESCRIPTION
## Summary
- Fix README examples to match actual code generation behavior
- Add missing SMALLINT and batch annotations to documentation

## Changes
- Remove `created_at: String` from Author type example (not in actual schema fixture)
- Change `params.ListAuthorsParams` to `Nil` for parameterless ListAuthors query
- Add SMALLINT to the type mapping table
- Add `:batchone`, `:batchmany`, `:batchexec`, `:copyfrom` to CHANGELOG v0.1.0 annotations list

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Added new query annotation types: `:batchone`, `:batchmany`, `:batchexec`, and `:copyfrom` for enhanced query operations
* Updated generated code examples reflecting changes to type signatures
* Extended SQL-to-type mapping to support `SMALLINT` integer types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->