### PR TITLE
test: add missing unit tests for views, error paths, model functions, and escape_string

### DIFF
--- a/doc/reference/design/sqlode-architecture.md
+++ b/doc/reference/design/sqlode-architecture.md
@@ -72,7 +72,7 @@ Generates Gleam source files from analyzed queries:
 - `queries.gleam` — query metadata (name, SQL, command, param count)
 - `models.gleam` — result row types (only when queries return rows)
 - `<engine>_adapter.gleam` — database adapter functions (when runtime
-  is `native` or `based`)
+  is `native`)
 
 ### Adapter generation
 
@@ -90,18 +90,29 @@ patterns.
 
 ```text
 src/sqlode/
-  cli.gleam            — CLI commands (generate, init)
+  cli.gleam            — CLI commands (generate, init, version)
   config.gleam         — YAML config parsing
   generate.gleam       — orchestrates the pipeline
   model.gleam          — shared types (Engine, Config, Query, ScalarType, etc.)
   naming.gleam         — NamingContext, identifier normalization, case conversion
-  query_analyzer.gleam — query analysis with AnalyzerContext
   query_parser.gleam   — query annotation parsing with ParserContext
   schema_parser.gleam  — DDL schema parsing
-  codegen.gleam        — Gleam source code generation with AdapterConfig
   runtime.gleam        — runtime types (Value, QueryCommand)
   version.gleam        — version constant
   writer.gleam         — file output
+
+  query_analyzer/
+    column_inferencer.gleam — result column inference
+    context.gleam           — AnalyzerContext with pre-compiled regexes
+    param_inferencer.gleam  — parameter type inference
+    placeholder.gleam       — placeholder extraction and indexing
+
+  codegen/
+    adapter.gleam  — database adapter generation (pog, sqlight)
+    common.gleam   — shared codegen utilities
+    models.gleam   — result row type generation
+    params.gleam   — parameter type generation
+    queries.gleam  — query metadata generation
 ```
 
 ## IR types (`model.gleam`)
@@ -113,7 +124,8 @@ The IR consumed by codegen:
 - `ParsedQuery`, `QueryCommand`, `SqlcMacro`
 - `AnalyzedQuery`, `QueryParam`, `ResultColumn`
 - `ScalarType` — IntType, FloatType, BoolType, StringType, BytesType,
-  DateTimeType, DateType, TimeType, UuidType, JsonType, EnumType
+  DateTimeType, DateType, TimeType, UuidType, JsonType, EnumType,
+  CustomType(name, underlying)
 
 ## Runtime strategy
 
@@ -135,7 +147,7 @@ A single flat `runtime.gleam` module exports:
 ### Completed
 
 - Config parsing with overrides and column renames
-- All 6 query annotations (`:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`)
+- All 10 query annotations (`:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`, `:batchone`, `:batchmany`, `:batchexec`, `:copyfrom`)
 - All sqlc macros (`sqlc.arg`, `sqlc.narg`, `sqlc.slice`, `sqlc.embed`)
 - Comprehensive type mapping (integers, floats, booleans, strings, bytes,
   date/time/timestamp, UUID, JSON/JSONB, PostgreSQL enums)
@@ -147,8 +159,7 @@ A single flat `runtime.gleam` module exports:
 ### Not yet implemented
 
 - `database` / `analyzer` config fields for live DB analysis
-- `emit_exact_table_names`, `emit_sql_as_comment`, `query_parameter_limit`
-- Batch annotations (`:batchexec`, `:batchmany`, `:batchone`, `:copyfrom`)
+- `query_parameter_limit`
 - MySQL native adapter (no Gleam MySQL driver exists)
 - PostgreSQL arrays
 - Golden-file / snapshot testing for codegen output

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -665,3 +665,26 @@ fn analyzed_star_queries() -> List(model.AnalyzedQuery) {
     )
   result
 }
+
+// --- escape_string tests ---
+
+pub fn escape_string_backslash_test() {
+  common.escape_string("a\\b") |> should.equal("a\\\\b")
+}
+
+pub fn escape_string_double_quote_test() {
+  common.escape_string("say \"hello\"") |> should.equal("say \\\"hello\\\"")
+}
+
+pub fn escape_string_newline_and_tab_test() {
+  common.escape_string("line1\nline2\ttab")
+  |> should.equal("line1\\nline2\\ttab")
+}
+
+pub fn escape_string_carriage_return_test() {
+  common.escape_string("a\rb") |> should.equal("a\\rb")
+}
+
+pub fn escape_string_no_special_chars_test() {
+  common.escape_string("hello world") |> should.equal("hello world")
+}

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -1,3 +1,4 @@
+import gleam/string
 import gleeunit
 import gleeunit/should
 import sqlode/model
@@ -186,4 +187,85 @@ pub fn scalar_type_to_runtime_function_test() {
   |> should.equal("runtime.bytes")
   model.scalar_type_to_runtime_function(model.EnumType("status"))
   |> should.equal("runtime.string")
+}
+
+// parse_type_mapping tests
+
+pub fn parse_type_mapping_string_test() {
+  model.parse_type_mapping("string") |> should.equal(Ok(model.StringMapping))
+}
+
+pub fn parse_type_mapping_rich_test() {
+  model.parse_type_mapping("rich") |> should.equal(Ok(model.RichMapping))
+}
+
+pub fn parse_type_mapping_invalid_test() {
+  let assert Error(msg) = model.parse_type_mapping("unknown")
+  string.contains(msg, "string") |> should.be_true()
+  string.contains(msg, "rich") |> should.be_true()
+}
+
+// is_rich_type tests
+
+pub fn is_rich_type_datetime_test() {
+  model.is_rich_type(model.DateTimeType) |> should.be_true()
+  model.is_rich_type(model.DateType) |> should.be_true()
+  model.is_rich_type(model.TimeType) |> should.be_true()
+  model.is_rich_type(model.UuidType) |> should.be_true()
+  model.is_rich_type(model.JsonType) |> should.be_true()
+}
+
+pub fn is_rich_type_non_rich_test() {
+  model.is_rich_type(model.IntType) |> should.be_false()
+  model.is_rich_type(model.FloatType) |> should.be_false()
+  model.is_rich_type(model.BoolType) |> should.be_false()
+  model.is_rich_type(model.StringType) |> should.be_false()
+  model.is_rich_type(model.BytesType) |> should.be_false()
+  model.is_rich_type(model.EnumType("status")) |> should.be_false()
+}
+
+// scalar_type_to_decoder tests
+
+pub fn scalar_type_to_decoder_sqlite_bool_test() {
+  model.scalar_type_to_decoder(model.SQLite, model.BoolType)
+  |> string.contains("decode.then")
+  |> should.be_true()
+}
+
+pub fn scalar_type_to_decoder_postgresql_bool_test() {
+  model.scalar_type_to_decoder(model.PostgreSQL, model.BoolType)
+  |> should.equal("decode.bool")
+}
+
+// scalar_type_to_value_function tests
+
+pub fn scalar_type_to_value_function_bytes_postgresql_test() {
+  model.scalar_type_to_value_function(model.PostgreSQL, model.BytesType)
+  |> should.equal("bytea")
+}
+
+pub fn scalar_type_to_value_function_bytes_sqlite_test() {
+  model.scalar_type_to_value_function(model.SQLite, model.BytesType)
+  |> should.equal("blob")
+}
+
+// enum helper function tests
+
+pub fn enum_type_name_test() {
+  model.enum_type_name("status") |> should.equal("Status")
+  model.enum_type_name("user_role") |> should.equal("UserRole")
+}
+
+pub fn enum_value_name_test() {
+  model.enum_value_name("active") |> should.equal("Active")
+  model.enum_value_name("in_progress") |> should.equal("InProgress")
+}
+
+pub fn enum_to_string_fn_test() {
+  model.enum_to_string_fn("status") |> should.equal("status_to_string")
+  model.enum_to_string_fn("UserRole") |> should.equal("userrole_to_string")
+}
+
+pub fn enum_from_string_fn_test() {
+  model.enum_from_string_fn("status") |> should.equal("status_from_string")
 }

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1,11 +1,13 @@
 import gleam/list
 import gleam/option.{Some}
+import gleam/string
 import gleeunit
 import gleeunit/should
 import simplifile
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
+import sqlode/query_analyzer/context
 import sqlode/query_parser
 import sqlode/schema_parser
 
@@ -494,6 +496,47 @@ fn typecast_catalog() -> model.Catalog {
     schema_parser.parse_files([#("test/fixtures/typecast_schema.sql", content)])
 
   catalog
+}
+
+// Error path tests
+
+pub fn table_not_found_error_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetMissing :many\nSELECT * FROM nonexistent WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("missing.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result |> should.be_error()
+}
+
+pub fn analysis_error_to_string_table_not_found_test() {
+  let error = context.TableNotFound(query_name: "GetUsers", table_name: "users")
+  let msg = query_analyzer.analysis_error_to_string(error)
+  string.contains(msg, "GetUsers") |> should.be_true()
+  string.contains(msg, "users") |> should.be_true()
+  string.contains(msg, "not found") |> should.be_true()
+}
+
+pub fn analysis_error_to_string_column_not_found_test() {
+  let error =
+    context.ColumnNotFound(
+      query_name: "GetUser",
+      table_name: "users",
+      column_name: "email",
+    )
+  let msg = query_analyzer.analysis_error_to_string(error)
+  string.contains(msg, "GetUser") |> should.be_true()
+  string.contains(msg, "email") |> should.be_true()
+  string.contains(msg, "users") |> should.be_true()
 }
 
 fn join_catalog() -> model.Catalog {

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -167,6 +167,68 @@ pub fn view_with_cast_expression_test() {
   col_names |> should.equal(["col_a", "col_b"])
 }
 
+pub fn view_basic_select_test() {
+  let content =
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT);\n"
+    <> "CREATE VIEW active_users AS SELECT id, name FROM users;"
+  let assert Ok(catalog) = schema_parser.parse_files([#("view.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "active_users" })
+  list.length(view.columns) |> should.equal(2)
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["id", "name"])
+}
+
+pub fn view_with_alias_test() {
+  let content =
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "CREATE VIEW user_names AS SELECT id, name AS display_name FROM users;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("view_alias.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "user_names" })
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["id", "display_name"])
+}
+
+pub fn view_star_test() {
+  let content =
+    "CREATE TABLE items (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "CREATE VIEW all_items AS SELECT * FROM items;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("view_star.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "all_items" })
+  list.length(view.columns) |> should.equal(2)
+}
+
+pub fn view_or_replace_test() {
+  let content =
+    "CREATE TABLE t (id BIGSERIAL PRIMARY KEY, val TEXT NOT NULL);\n"
+    <> "CREATE OR REPLACE VIEW v AS SELECT id FROM t;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("or_replace.sql", content)])
+
+  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  list.length(view.columns) |> should.equal(1)
+}
+
+pub fn view_nonexistent_table_test() {
+  let content = "CREATE VIEW v AS SELECT id FROM nonexistent;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("noexist.sql", content)])
+
+  // View referencing nonexistent table still creates view with fallback types
+  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  let assert [col] = view.columns
+  col.name |> should.equal("id")
+  col.scalar_type |> should.equal(model.StringType)
+  col.nullable |> should.equal(True)
+}
+
 pub fn error_to_string_invalid_column_test() {
   schema_parser.error_to_string(schema_parser.InvalidColumn(
     table: "users",

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -2,6 +2,7 @@ import codegen_test
 import config_test
 import generate_test
 import gleeunit
+import model_test
 import naming_test
 import query_analyzer_test
 import query_parser_test
@@ -386,6 +387,118 @@ pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
 
 pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
   codegen_test.render_sqlight_adapter_enum_slice_converts_to_string_test()
+}
+
+// escape_string tests
+
+pub fn escape_string_backslash_test() {
+  codegen_test.escape_string_backslash_test()
+}
+
+pub fn escape_string_double_quote_test() {
+  codegen_test.escape_string_double_quote_test()
+}
+
+pub fn escape_string_newline_and_tab_test() {
+  codegen_test.escape_string_newline_and_tab_test()
+}
+
+pub fn escape_string_carriage_return_test() {
+  codegen_test.escape_string_carriage_return_test()
+}
+
+pub fn escape_string_no_special_chars_test() {
+  codegen_test.escape_string_no_special_chars_test()
+}
+
+// model tests
+
+pub fn parse_type_mapping_string_test() {
+  model_test.parse_type_mapping_string_test()
+}
+
+pub fn parse_type_mapping_rich_test() {
+  model_test.parse_type_mapping_rich_test()
+}
+
+pub fn parse_type_mapping_invalid_test() {
+  model_test.parse_type_mapping_invalid_test()
+}
+
+pub fn is_rich_type_datetime_test() {
+  model_test.is_rich_type_datetime_test()
+}
+
+pub fn is_rich_type_non_rich_test() {
+  model_test.is_rich_type_non_rich_test()
+}
+
+pub fn scalar_type_to_decoder_sqlite_bool_test() {
+  model_test.scalar_type_to_decoder_sqlite_bool_test()
+}
+
+pub fn scalar_type_to_decoder_postgresql_bool_test() {
+  model_test.scalar_type_to_decoder_postgresql_bool_test()
+}
+
+pub fn scalar_type_to_value_function_bytes_postgresql_test() {
+  model_test.scalar_type_to_value_function_bytes_postgresql_test()
+}
+
+pub fn scalar_type_to_value_function_bytes_sqlite_test() {
+  model_test.scalar_type_to_value_function_bytes_sqlite_test()
+}
+
+pub fn enum_type_name_test() {
+  model_test.enum_type_name_test()
+}
+
+pub fn enum_value_name_test() {
+  model_test.enum_value_name_test()
+}
+
+pub fn enum_to_string_fn_test() {
+  model_test.enum_to_string_fn_test()
+}
+
+pub fn enum_from_string_fn_test() {
+  model_test.enum_from_string_fn_test()
+}
+
+// schema_parser view tests
+
+pub fn view_basic_select_test() {
+  schema_parser_test.view_basic_select_test()
+}
+
+pub fn view_with_alias_test() {
+  schema_parser_test.view_with_alias_test()
+}
+
+pub fn view_star_test() {
+  schema_parser_test.view_star_test()
+}
+
+pub fn view_or_replace_test() {
+  schema_parser_test.view_or_replace_test()
+}
+
+pub fn view_nonexistent_table_test() {
+  schema_parser_test.view_nonexistent_table_test()
+}
+
+// query_analyzer error tests
+
+pub fn table_not_found_error_test() {
+  query_analyzer_test.table_not_found_error_test()
+}
+
+pub fn analysis_error_to_string_table_not_found_test() {
+  query_analyzer_test.analysis_error_to_string_table_not_found_test()
+}
+
+pub fn analysis_error_to_string_column_not_found_test() {
+  query_analyzer_test.analysis_error_to_string_column_not_found_test()
 }
 
 pub fn singularize_regular_plural_test() {


### PR DESCRIPTION
## Summary
- Add unit tests for untested code paths across schema_parser, query_analyzer, model, and codegen/common modules
- Increases test count from 342 to 394 (+52 tests)

## Changes
- **schema_parser_test.gleam**: Add CREATE VIEW tests (basic select, alias, star, OR REPLACE, nonexistent table fallback)
- **query_analyzer_test.gleam**: Add error path tests (TableNotFound, ColumnNotFound, analysis_error_to_string for both variants)
- **model_test.gleam**: Add tests for parse_type_mapping error case, is_rich_type, scalar_type_to_decoder (SQLite bool), scalar_type_to_value_function (bytes across engines), enum helper functions (enum_type_name, enum_value_name, enum_to_string_fn, enum_from_string_fn)
- **codegen_test.gleam**: Add escape_string tests (backslash, double quote, newline, carriage return, tab, no special chars)
- **sqlode_test.gleam**: Add entry points for all new tests

Closes #152