### PR TITLE
fix(codegen): reject unrecognized SQL types and uninferred parameter types

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -33,7 +33,13 @@ fn analyze_query(
   query: model.ParsedQuery,
 ) -> Result(model.AnalyzedQuery, AnalysisError) {
   let occurrences = placeholder.extract(ctx, engine, query.sql)
-  let params = build_params(ctx, engine, query, catalog, occurrences)
+  use params <- result.try(build_params(
+    ctx,
+    engine,
+    query,
+    catalog,
+    occurrences,
+  ))
   use result_columns <- result.try(column_inferencer.infer_result_columns(
     ctx,
     query,
@@ -49,7 +55,7 @@ fn build_params(
   query: model.ParsedQuery,
   catalog: model.Catalog,
   occurrences: List(placeholder.PlaceholderOccurrence),
-) -> List(model.QueryParam) {
+) -> Result(List(model.QueryParam), context.AnalysisError) {
   let inferences =
     list.append(
       param_inferencer.infer_insert_params(ctx, engine, query, catalog),
@@ -57,26 +63,40 @@ fn build_params(
     )
     |> list.append(param_inferencer.infer_in_params(ctx, engine, query, catalog))
 
-  let cast_dict = param_inferencer.extract_type_casts(ctx, engine, query.sql)
+  use cast_dict <- result.try(
+    param_inferencer.extract_type_casts(ctx, engine, query.sql)
+    |> result.map_error(fn(err) {
+      let #(index, cast_type) = err
+      context.UnrecognizedCastType(
+        query_name: query.name,
+        param_index: index,
+        cast_type:,
+      )
+    }),
+  )
   let macro_dict = build_macro_dict(query.macros)
   let inference_dict = build_inference_dict(inferences)
 
   placeholder.unique(occurrences)
-  |> list.map(fn(occurrence) {
+  |> list.try_map(fn(occurrence) {
     let macro_info =
       dict.get(macro_dict, occurrence.index) |> option.from_result
     let inferred =
       dict.get(inference_dict, occurrence.index) |> option.from_result
 
     let cast_type = dict.get(cast_dict, occurrence.index) |> option.from_result
-    let inferred_type = case inferred {
-      Some(column) -> column.scalar_type
+    use inferred_type <- result.try(case inferred {
+      Some(column) -> Ok(column.scalar_type)
       None ->
         case cast_type {
-          Some(st) -> st
-          None -> model.StringType
+          Some(st) -> Ok(st)
+          None ->
+            Error(context.ParameterTypeNotInferred(
+              query_name: query.name,
+              param_index: occurrence.index,
+            ))
         }
-    }
+    })
 
     let #(field_name, scalar_type, nullable, is_list) = case macro_info {
       Some(model.SqlcArg(name:, ..)) -> {
@@ -106,25 +126,17 @@ fn build_params(
             column.nullable,
             False,
           )
-          None -> #(
-            occurrence.default_name,
-            case cast_type {
-              Some(st) -> st
-              None -> model.StringType
-            },
-            False,
-            False,
-          )
+          None -> #(occurrence.default_name, inferred_type, False, False)
         }
     }
 
-    model.QueryParam(
+    Ok(model.QueryParam(
       index: occurrence.index,
       field_name:,
       scalar_type:,
       nullable:,
       is_list:,
-    )
+    ))
   })
 }
 

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/regexp
@@ -8,6 +9,8 @@ import sqlode/naming
 pub type AnalysisError {
   TableNotFound(query_name: String, table_name: String)
   ColumnNotFound(query_name: String, table_name: String, column_name: String)
+  ParameterTypeNotInferred(query_name: String, param_index: Int)
+  UnrecognizedCastType(query_name: String, param_index: Int, cast_type: String)
 }
 
 pub fn analysis_error_to_string(error: AnalysisError) -> String {
@@ -26,6 +29,21 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
       <> "\" not found in table \""
       <> table_name
       <> "\""
+    ParameterTypeNotInferred(query_name:, param_index:) ->
+      "Query \""
+      <> query_name
+      <> "\": could not infer type for parameter $"
+      <> int.to_string(param_index)
+      <> ". Use a type cast (e.g. $"
+      <> int.to_string(param_index)
+      <> "::int) to specify the type"
+    UnrecognizedCastType(query_name:, param_index:, cast_type:) ->
+      "Query \""
+      <> query_name
+      <> "\": unrecognized cast type \""
+      <> cast_type
+      <> "\" for parameter $"
+      <> int.to_string(param_index)
   }
 }
 
@@ -58,7 +76,7 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     )
   let assert Ok(equality_re) =
     regexp.from_string(
-      "([a-zA-Z_][a-zA-Z0-9_.]*)\\s*=\\s*(\\$[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
+      "([a-zA-Z_][a-zA-Z0-9_.]*)\\s*(?:<=|>=|!=|<>|=|<|>|\\blike\\b|\\bilike\\b)\\s*(\\$[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
     )
   let assert Ok(postgresql_placeholder_re) = regexp.from_string("(\\$[0-9]+)")
   let assert Ok(mysql_placeholder_re) = regexp.from_string("(\\?)")

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -198,12 +198,12 @@ pub fn extract_type_casts(
   ctx: AnalyzerContext,
   engine: model.Engine,
   sql: String,
-) -> dict.Dict(Int, model.ScalarType) {
+) -> Result(dict.Dict(Int, model.ScalarType), #(Int, String)) {
   case engine {
     model.PostgreSQL -> {
       let normalized = context.normalize_sql(ctx, sql)
       regexp.scan(ctx.type_cast_re, normalized)
-      |> list.filter_map(fn(match) {
+      |> list.try_fold(dict.new(), fn(d, match) {
         case match.submatches {
           [Some(ph)] -> {
             let cast_type = string.replace(match.content, ph <> "::", "")
@@ -212,35 +212,37 @@ pub fn extract_type_casts(
               |> string.replace("$", "")
               |> int.parse
             {
-              Ok(index) -> Ok(#(index, cast_type_to_scalar(cast_type)))
-              Error(_) -> Error(Nil)
+              Ok(index) ->
+                case cast_type_to_scalar(cast_type) {
+                  Ok(scalar_type) -> Ok(dict.insert(d, index, scalar_type))
+                  Error(Nil) -> Error(#(index, string.trim(cast_type)))
+                }
+              Error(_) -> Ok(d)
             }
           }
-          _ -> Error(Nil)
+          _ -> Ok(d)
         }
       })
-      |> list.fold(dict.new(), fn(d, entry) {
-        let #(index, scalar_type) = entry
-        dict.insert(d, index, scalar_type)
-      })
     }
-    _ -> dict.new()
+    _ -> Ok(dict.new())
   }
 }
 
-fn cast_type_to_scalar(type_name: String) -> model.ScalarType {
+fn cast_type_to_scalar(type_name: String) -> Result(model.ScalarType, Nil) {
   let lowered = string.lowercase(string.trim(type_name))
   case lowered {
     "int" | "integer" | "bigint" | "smallint" | "serial" | "bigserial" ->
-      model.IntType
-    "float" | "double" | "real" | "numeric" | "decimal" -> model.FloatType
-    "bool" | "boolean" -> model.BoolType
-    "bytea" | "blob" | "binary" -> model.BytesType
-    "uuid" -> model.UuidType
-    "json" | "jsonb" -> model.JsonType
-    "timestamp" | "datetime" -> model.DateTimeType
-    "date" -> model.DateType
-    "time" | "timetz" -> model.TimeType
-    _ -> model.StringType
+      Ok(model.IntType)
+    "float" | "double" | "real" | "numeric" | "decimal" -> Ok(model.FloatType)
+    "bool" | "boolean" -> Ok(model.BoolType)
+    "bytea" | "blob" | "binary" -> Ok(model.BytesType)
+    "uuid" -> Ok(model.UuidType)
+    "json" | "jsonb" -> Ok(model.JsonType)
+    "timestamp" | "datetime" -> Ok(model.DateTimeType)
+    "date" -> Ok(model.DateType)
+    "time" | "timetz" -> Ok(model.TimeType)
+    "text" | "varchar" | "char" | "character" | "string" | "clob" | "name" ->
+      Ok(model.StringType)
+    _ -> Error(Nil)
   }
 }

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -1,3 +1,4 @@
+import gleam/io
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -192,12 +193,19 @@ fn parse_create_view(
                   let normalized = naming.normalize_identifier(col_name)
                   case find_column_in_tables(tables, normalized) {
                     Some(col) -> Ok(model.Column(..col, name: normalized))
-                    None ->
+                    None -> {
+                      io.println_error(
+                        "Warning: view column \""
+                        <> normalized
+                        <> "\" could not be resolved from source tables"
+                        <> " — defaulting to String (nullable).",
+                      )
                       Ok(model.Column(
                         name: normalized,
                         scalar_type: model.StringType,
                         nullable: True,
                       ))
+                    }
                   }
                 })
 
@@ -323,10 +331,14 @@ fn parse_column(
                 False -> True
               }
 
-              let scalar_type = case find_enum(type_text, enums) {
-                Some(enum_name) -> model.EnumType(enum_name)
-                None -> infer_scalar_type(type_text)
-              }
+              use scalar_type <- result.try(case find_enum(type_text, enums) {
+                Some(enum_name) -> Ok(model.EnumType(enum_name))
+                None ->
+                  infer_scalar_type(type_text)
+                  |> result.map_error(fn(detail) {
+                    InvalidColumn(table: table_name, detail:)
+                  })
+              })
 
               Ok(Some(model.Column(name:, scalar_type:, nullable:)))
             }
@@ -415,7 +427,7 @@ fn take_type_tokens(tokens: List(String), acc: List(String)) -> List(String) {
   }
 }
 
-fn infer_scalar_type(type_text: String) -> model.ScalarType {
+fn infer_scalar_type(type_text: String) -> Result(model.ScalarType, String) {
   let lowered = string.lowercase(type_text)
 
   // Order matters: check more specific patterns before general ones
@@ -430,20 +442,22 @@ fn infer_scalar_type(type_text: String) -> model.ScalarType {
     #(["timestamp", "datetime"], model.DateTimeType),
     #(["date"], model.DateType),
     #(["timetz", "time"], model.TimeType),
+    #(["text", "char", "clob", "name", "string"], model.StringType),
   ]
 
   find_matching_type(lowered, type_rules)
+  |> result.replace_error("unrecognized SQL type \"" <> type_text <> "\"")
 }
 
 fn find_matching_type(
   lowered: String,
   rules: List(#(List(String), model.ScalarType)),
-) -> model.ScalarType {
+) -> Result(model.ScalarType, Nil) {
   case rules {
-    [] -> model.StringType
+    [] -> Error(Nil)
     [#(patterns, scalar_type), ..rest] ->
       case list.any(patterns, fn(p) { string.contains(lowered, p) }) {
-        True -> scalar_type
+        True -> Ok(scalar_type)
         False -> find_matching_type(lowered, rest)
       }
   }

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -539,6 +539,61 @@ pub fn analysis_error_to_string_column_not_found_test() {
   string.contains(msg, "users") |> should.be_true()
 }
 
+pub fn parameter_type_not_inferred_error_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql = "-- name: Bare :many\nSELECT $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("bare.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result |> should.be_error()
+}
+
+pub fn unrecognized_cast_type_error_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: BadCast :many\nSELECT id, name FROM authors WHERE id = $1::geometry;"
+  let assert Ok(queries) =
+    query_parser.parse_file("badcast.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result |> should.be_error()
+}
+
+pub fn analysis_error_to_string_parameter_not_inferred_test() {
+  let error =
+    context.ParameterTypeNotInferred(query_name: "Bare", param_index: 1)
+  let msg = query_analyzer.analysis_error_to_string(error)
+  string.contains(msg, "Bare") |> should.be_true()
+  string.contains(msg, "$1") |> should.be_true()
+}
+
+pub fn analysis_error_to_string_unrecognized_cast_test() {
+  let error =
+    context.UnrecognizedCastType(
+      query_name: "BadCast",
+      param_index: 1,
+      cast_type: "geometry",
+    )
+  let msg = query_analyzer.analysis_error_to_string(error)
+  string.contains(msg, "BadCast") |> should.be_true()
+  string.contains(msg, "geometry") |> should.be_true()
+}
+
 fn join_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/join_schema.sql")
   let assert Ok(catalog) =

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -237,3 +237,15 @@ pub fn error_to_string_invalid_column_test() {
   |> string.contains("users")
   |> should.be_true()
 }
+
+pub fn unrecognized_sql_type_returns_error_test() {
+  let content =
+    "CREATE TABLE geo (\n"
+    <> "  id BIGSERIAL PRIMARY KEY,\n"
+    <> "  shape GEOMETRY NOT NULL\n"
+    <> ");"
+  let assert Error(error) = schema_parser.parse_files([#("geo.sql", content)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "geo") |> should.be_true()
+  string.contains(msg, "GEOMETRY") |> should.be_true()
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -501,6 +501,26 @@ pub fn analysis_error_to_string_column_not_found_test() {
   query_analyzer_test.analysis_error_to_string_column_not_found_test()
 }
 
+pub fn parameter_type_not_inferred_error_test() {
+  query_analyzer_test.parameter_type_not_inferred_error_test()
+}
+
+pub fn unrecognized_cast_type_error_test() {
+  query_analyzer_test.unrecognized_cast_type_error_test()
+}
+
+pub fn analysis_error_to_string_parameter_not_inferred_test() {
+  query_analyzer_test.analysis_error_to_string_parameter_not_inferred_test()
+}
+
+pub fn analysis_error_to_string_unrecognized_cast_test() {
+  query_analyzer_test.analysis_error_to_string_unrecognized_cast_test()
+}
+
+pub fn unrecognized_sql_type_returns_error_test() {
+  schema_parser_test.unrecognized_sql_type_returns_error_test()
+}
+
 pub fn singularize_regular_plural_test() {
   naming_test.singularize_regular_plural_test()
 }


### PR DESCRIPTION
## Summary

- Replace silent `StringType` fallback with explicit errors for unrecognized SQL types, unrecognized cast types, and uninferred parameter types
- Extend comparison operator regex to support `LIKE`, `ILIKE`, `!=`, `<>`, `<`, `>`, `<=`, `>=` for parameter type inference
- Add warning for unresolvable view columns (computed expressions are legitimate use cases)

## Changes

- **schema_parser.gleam**: `infer_scalar_type` and `find_matching_type` now return `Result` types. Unrecognized SQL types produce an `InvalidColumn` error. String-like types (`text`, `char`, `clob`, `name`, `string`) are explicitly recognized to avoid false errors.
- **query_analyzer/context.gleam**: Add `ParameterTypeNotInferred` and `UnrecognizedCastType` variants to `AnalysisError` with descriptive error messages. Extend `equality_re` regex to match comparison operators beyond `=`.
- **query_analyzer/param_inferencer.gleam**: `cast_type_to_scalar` returns `Result(ScalarType, Nil)`. `extract_type_casts` returns `Result(Dict, #(Int, String))` propagating unrecognized cast errors.
- **query_analyzer.gleam**: `build_params` returns `Result(List(QueryParam), AnalysisError)`. Errors on unresolvable parameter types instead of defaulting to `StringType`.
- **schema_parser.gleam** (views): Emit `io.println_error` warning for view columns that cannot be resolved from source tables (kept as warning because computed expressions are legitimate).

## Design Decisions

- **Errors over fallbacks**: Unrecognized SQL types and uninferred parameters now produce errors rather than silently defaulting to `StringType`. This catches type mismatches early instead of generating code that compiles but fails at runtime.
- **View column warning**: View columns use a warning (not error) because computed expressions like `CAST(x AS type) AS alias` legitimately produce columns not found in source tables.
- **Extended comparison regex**: Added support for `LIKE`/`ILIKE` and other comparison operators in parameter type inference, which was necessary to avoid false `ParameterTypeNotInferred` errors for existing valid SQL patterns.

Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when resolving CREATE VIEW columns from source tables.
  * Enhanced error reporting for unrecognized SQL type casts and parameter type inference failures.

* **Improvements**
  * Expanded SQL operator recognition to include comparison operators and LIKE/ILIKE patterns.
  * Improved error handling for unrecognized SQL column types with clearer diagnostic messages.

* **Tests**
  * Added comprehensive test coverage for error scenarios in query analysis and schema parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->