### PR TITLE
fix(analyzer): adjust column nullability for LEFT, RIGHT, and FULL JOIN

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -12,6 +12,13 @@ type ExtractedColumn {
   ExtractedColumn(name: String, source_table: Option(String))
 }
 
+type JoinKind {
+  LeftJoin
+  RightJoin
+  FullJoin
+  OtherJoin
+}
+
 pub fn infer_result_columns(
   ctx: AnalyzerContext,
   query: model.ParsedQuery,
@@ -30,6 +37,7 @@ pub fn infer_result_columns(
       case extract_returning_columns(ctx, normalized) {
         Some(returning_cols) -> {
           let table_names = extract_table_names(ctx, normalized)
+          let nullable_tables = extract_nullable_tables(ctx, normalized)
           case table_names {
             [] -> Ok([])
             [primary, ..] ->
@@ -39,6 +47,7 @@ pub fn infer_result_columns(
                 catalog,
                 primary,
                 table_names,
+                nullable_tables,
               )
           }
         }
@@ -47,6 +56,7 @@ pub fn infer_result_columns(
             strip_cte(ctx, normalized)
             |> strip_compound
           let table_names = extract_table_names(ctx, main_sql)
+          let nullable_tables = extract_nullable_tables(ctx, main_sql)
 
           case table_names {
             [] -> Ok([])
@@ -58,6 +68,7 @@ pub fn infer_result_columns(
                 catalog,
                 primary,
                 table_names,
+                nullable_tables,
               )
             }
           }
@@ -139,13 +150,56 @@ fn extract_table_names(ctx: AnalyzerContext, sql: String) -> List(String) {
 }
 
 fn extract_join_tables(ctx: AnalyzerContext, sql: String) -> List(String) {
+  extract_join_info(ctx, sql)
+  |> list.map(fn(info) { info.0 })
+}
+
+fn extract_join_info(
+  ctx: AnalyzerContext,
+  sql: String,
+) -> List(#(String, JoinKind)) {
   regexp.scan(ctx.join_re, sql)
   |> list.filter_map(fn(match) {
     case match.submatches {
-      [Some(name)] -> Ok(name)
+      [Some(join_type), Some(name)] -> {
+        let kind = case string.lowercase(join_type) {
+          "left" -> LeftJoin
+          "right" -> RightJoin
+          "full" -> FullJoin
+          _ -> OtherJoin
+        }
+        Ok(#(name, kind))
+      }
+      [None, Some(name)] -> Ok(#(name, OtherJoin))
       _ -> Error(Nil)
     }
   })
+}
+
+fn extract_nullable_tables(ctx: AnalyzerContext, sql: String) -> List(String) {
+  let primary = context.primary_table_name(ctx, sql)
+  let joins = extract_join_info(ctx, sql)
+
+  let nullable_joined =
+    list.filter_map(joins, fn(j) {
+      case j.1 {
+        LeftJoin | FullJoin -> Ok(j.0)
+        _ -> Error(Nil)
+      }
+    })
+
+  let primary_nullable =
+    list.any(joins, fn(j) {
+      case j.1 {
+        RightJoin | FullJoin -> True
+        _ -> False
+      }
+    })
+
+  case primary_nullable, primary {
+    True, Some(name) -> [name, ..nullable_joined]
+    _, _ -> nullable_joined
+  }
 }
 
 fn extract_select_columns(
@@ -223,6 +277,7 @@ fn resolve_select_columns(
   catalog: model.Catalog,
   primary_table: String,
   all_tables: List(String),
+  nullable_tables: List(String),
 ) -> Result(List(model.ResultColumn), AnalysisError) {
   case columns {
     [ExtractedColumn(name: "*", ..)] ->
@@ -236,7 +291,8 @@ fn resolve_select_columns(
               model.ResultColumn(
                 name: col.name,
                 scalar_type: col.scalar_type,
-                nullable: col.nullable,
+                nullable: col.nullable
+                  || list.contains(nullable_tables, primary_table),
                 source_table: Some(primary_table),
               )
             }),
@@ -281,7 +337,8 @@ fn resolve_select_columns(
                       model.ResultColumn(
                         name: column.name,
                         scalar_type: column.scalar_type,
-                        nullable: column.nullable,
+                        nullable: column.nullable
+                          || list.contains(nullable_tables, table),
                         source_table: Some(table),
                       ),
                     ])
@@ -301,7 +358,8 @@ fn resolve_select_columns(
                       model.ResultColumn(
                         name: column.name,
                         scalar_type: column.scalar_type,
-                        nullable: column.nullable,
+                        nullable: column.nullable
+                          || list.contains(nullable_tables, found_table),
                         source_table: Some(found_table),
                       ),
                     ])

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -98,7 +98,9 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
   let assert Ok(returning_re) =
     regexp.from_string("returning\\s+(.+?)\\s*;?\\s*$")
   let assert Ok(join_re) =
-    regexp.from_string("join\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s")
+    regexp.from_string(
+      "(?:(left|right|full|inner|cross)\\s+(?:outer\\s+)?)?join\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s",
+    )
   let assert Ok(select_columns_re) =
     regexp.from_string("select\\s+(.+?)\\s+from\\s")
   let assert Ok(type_cast_re) =

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -594,6 +594,108 @@ pub fn analysis_error_to_string_unrecognized_cast_test() {
   string.contains(msg, "geometry") |> should.be_true()
 }
 
+pub fn left_join_makes_right_table_nullable_test() {
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: GetBookWithAuthor :one\nSELECT books.title, authors.name FROM books LEFT JOIN authors ON books.author_id = authors.id WHERE books.id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("lj.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  query.result_columns
+  |> should.equal([
+    model.ResultColumn(
+      name: "title",
+      scalar_type: model.StringType,
+      nullable: False,
+      source_table: Some("books"),
+    ),
+    model.ResultColumn(
+      name: "name",
+      scalar_type: model.StringType,
+      nullable: True,
+      source_table: Some("authors"),
+    ),
+  ])
+}
+
+pub fn right_join_makes_left_table_nullable_test() {
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: GetBookWithAuthor :one\nSELECT books.title, authors.name FROM books RIGHT JOIN authors ON books.author_id = authors.id;"
+  let assert Ok(queries) =
+    query_parser.parse_file("rj.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  query.result_columns
+  |> should.equal([
+    model.ResultColumn(
+      name: "title",
+      scalar_type: model.StringType,
+      nullable: True,
+      source_table: Some("books"),
+    ),
+    model.ResultColumn(
+      name: "name",
+      scalar_type: model.StringType,
+      nullable: False,
+      source_table: Some("authors"),
+    ),
+  ])
+}
+
+pub fn full_join_makes_both_tables_nullable_test() {
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: GetBookWithAuthor :one\nSELECT books.title, authors.name FROM books FULL JOIN authors ON books.author_id = authors.id;"
+  let assert Ok(queries) =
+    query_parser.parse_file("fj.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  query.result_columns
+  |> should.equal([
+    model.ResultColumn(
+      name: "title",
+      scalar_type: model.StringType,
+      nullable: True,
+      source_table: Some("books"),
+    ),
+    model.ResultColumn(
+      name: "name",
+      scalar_type: model.StringType,
+      nullable: True,
+      source_table: Some("authors"),
+    ),
+  ])
+}
+
 fn join_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/join_schema.sql")
   let assert Ok(catalog) =

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -109,6 +109,18 @@ pub fn join_result_columns_test() {
   query_analyzer_test.join_result_columns_test()
 }
 
+pub fn left_join_makes_right_table_nullable_test() {
+  query_analyzer_test.left_join_makes_right_table_nullable_test()
+}
+
+pub fn right_join_makes_left_table_nullable_test() {
+  query_analyzer_test.right_join_makes_left_table_nullable_test()
+}
+
+pub fn full_join_makes_both_tables_nullable_test() {
+  query_analyzer_test.full_join_makes_both_tables_nullable_test()
+}
+
 pub fn sqlc_embed_expands_table_columns_test() {
   query_analyzer_test.sqlc_embed_expands_table_columns_test()
 }


### PR DESCRIPTION
## Summary

- Parse JOIN type (LEFT/RIGHT/FULL/INNER/CROSS) and adjust result column nullability accordingly
- LEFT JOIN: right table columns become nullable
- RIGHT JOIN: left (primary) table columns become nullable
- FULL JOIN: both sides become nullable

## Changes

- **context.gleam**: Extended `join_re` regex to capture the optional join-type keyword (`LEFT`, `RIGHT`, `FULL`, `INNER`, `CROSS`) and handle `OUTER` keyword (e.g., `LEFT OUTER JOIN`)
- **column_inferencer.gleam**: Added `JoinKind` type, `extract_join_info` and `extract_nullable_tables` functions. `resolve_select_columns` now receives a `nullable_tables` list and applies `nullable: col.nullable || list.contains(nullable_tables, table)` when constructing `ResultColumn`
- **Tests**: Added `left_join_makes_right_table_nullable_test`, `right_join_makes_left_table_nullable_test`, and `full_join_makes_both_tables_nullable_test`

## Design Decisions

- `JoinKind` is a private type in `column_inferencer.gleam` since it's only needed internally for nullability computation
- Nullability is computed as a `List(String)` of table names that should force-nullable, which is simple to thread through `resolve_select_columns`

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL join type handling to correctly identify LEFT, RIGHT, FULL, INNER, and CROSS joins.
  * Fixed column nullability analysis to properly reflect join semantics—marking columns as nullable based on their join relationship.

* **Tests**
  * Added tests validating nullability behavior for LEFT, RIGHT, and FULL joins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->