### PR TITLE
feat(codegen): add strong type-mapping mode for compile-time semantic type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,15 +482,17 @@ gen:
 
 When `type_mapping: "rich"` is set, sqlode generates transparent type aliases in `models.gleam` that preserve the semantic meaning of database types:
 
-| SQL type | `string` (default) | `rich` |
-|----------|-------------------|--------|
-| TIMESTAMP / DATETIME | `String` | `SqlTimestamp` |
-| DATE | `String` | `SqlDate` |
-| TIME / TIMETZ | `String` | `SqlTime` |
-| UUID | `String` | `SqlUuid` |
-| JSON / JSONB | `String` | `SqlJson` |
+| SQL type | `string` (default) | `rich` | `strong` |
+|----------|-------------------|--------|----------|
+| TIMESTAMP / DATETIME | `String` | `SqlTimestamp` | `SqlTimestamp(String)` |
+| DATE | `String` | `SqlDate` | `SqlDate(String)` |
+| TIME / TIMETZ | `String` | `SqlTime` | `SqlTime(String)` |
+| UUID | `String` | `SqlUuid` | `SqlUuid(String)` |
+| JSON / JSONB | `String` | `SqlJson` | `SqlJson(String)` |
 
-These are transparent aliases over `String`, so encoding and decoding work unchanged. The benefit is type-level documentation: you can distinguish a `SqlUuid` field from a plain `String` in your code.
+**`rich`**: Transparent aliases over `String` — type-level documentation without compile-time enforcement.
+
+**`strong`**: Single-constructor wrapper types with unwrap helpers (e.g. `sql_uuid_to_string`). A `SqlUuid` and a plain `String` are distinct at compile time, preventing accidental misuse. Generated adapters automatically wrap decoded values and unwrap encoded values.
 
 ## CLI
 

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -162,6 +162,8 @@ fn render_adapter(
 
   let emit_exact_table_names = gleam.emit_exact_table_names
 
+  let type_mapping = gleam.type_mapping
+
   let functions =
     queries
     |> list.map(render_adapter_function(
@@ -171,6 +173,7 @@ fn render_adapter(
       config,
       emit_sql_as_comment,
       emit_exact_table_names,
+      type_mapping,
     ))
     |> string.join("\n\n")
 
@@ -184,6 +187,7 @@ fn render_adapter_function(
   config: AdapterConfig,
   emit_sql_as_comment: Bool,
   emit_exact_table_names: Bool,
+  type_mapping: model.TypeMapping,
 ) -> String {
   let fn_name = query.base.function_name
   let has_params = !list.is_empty(query.params)
@@ -204,6 +208,7 @@ fn render_adapter_function(
         table_matches,
         config,
         emit_exact_table_names,
+        type_mapping,
       )
     model.Many | model.BatchMany ->
       render_adapter_many(
@@ -214,6 +219,7 @@ fn render_adapter_function(
         table_matches,
         config,
         emit_exact_table_names,
+        type_mapping,
       )
     model.Exec | model.BatchExec | model.CopyFrom ->
       render_adapter_exec(naming_ctx, query, fn_name, has_params, config)
@@ -252,6 +258,7 @@ fn render_decoder(
   type_name: String,
   config: AdapterConfig,
   emit_exact_table_names: Bool,
+  type_mapping: model.TypeMapping,
 ) -> String {
   case query.result_columns {
     [] -> "decode.success(Nil)"
@@ -268,6 +275,7 @@ fn render_decoder(
                   scalar_type,
                   nullable,
                   config,
+                  type_mapping,
                 )
               #(idx + 1, list.append(lines, [line]))
             }
@@ -285,6 +293,7 @@ fn render_decoder(
                   idx,
                   config,
                   emit_exact_table_names,
+                  type_mapping,
                 )
               #(new_idx, list.append(lines, embed_lines))
             }
@@ -317,6 +326,7 @@ fn render_decoder(
 fn render_base_decoder(
   scalar_type: model.ScalarType,
   config: AdapterConfig,
+  type_mapping: model.TypeMapping,
 ) -> String {
   case scalar_type {
     model.EnumType(enum_name) ->
@@ -325,7 +335,21 @@ fn render_base_decoder(
       <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(s, \"valid "
       <> enum_name
       <> " value\") } })"
-    _ -> config.decoder_function(scalar_type)
+    _ ->
+      case
+        type_mapping == model.StrongMapping && model.is_rich_type(scalar_type)
+      {
+        True -> {
+          let constructor =
+            model.scalar_type_to_gleam_type(scalar_type, model.StrongMapping)
+          "decode.map("
+          <> config.decoder_function(scalar_type)
+          <> ", models."
+          <> constructor
+          <> ")"
+        }
+        False -> config.decoder_function(scalar_type)
+      }
   }
 }
 
@@ -342,9 +366,10 @@ fn render_field_decode_line(
   scalar_type: model.ScalarType,
   nullable: Bool,
   config: AdapterConfig,
+  type_mapping: model.TypeMapping,
 ) -> String {
   let full_decoder =
-    render_base_decoder(scalar_type, config)
+    render_base_decoder(scalar_type, config, type_mapping)
     |> wrap_nullable_decoder(nullable)
   "    use "
   <> field_name
@@ -363,6 +388,7 @@ fn render_embedded_column_lines(
   start_idx: Int,
   config: AdapterConfig,
   emit_exact_table_names: Bool,
+  type_mapping: model.TypeMapping,
 ) -> #(Int, List(String)) {
   let embed_field_name = naming.to_snake_case(naming_ctx, embed_name)
   let embed_type_name =
@@ -370,7 +396,7 @@ fn render_embedded_column_lines(
   let embed_lines =
     list.index_map(embed_cols, fn(embed_col, embed_idx) {
       let full_decoder =
-        render_base_decoder(embed_col.scalar_type, config)
+        render_base_decoder(embed_col.scalar_type, config, type_mapping)
         |> wrap_nullable_decoder(embed_col.nullable)
       "    use "
       <> naming.to_snake_case(naming_ctx, embed_col.name)
@@ -405,6 +431,7 @@ fn render_adapter_one(
   table_matches: Dict(String, String),
   config: AdapterConfig,
   emit_exact_table_names: Bool,
+  type_mapping: model.TypeMapping,
 ) -> String {
   render_adapter_query_result(
     naming_ctx,
@@ -416,6 +443,7 @@ fn render_adapter_one(
     emit_exact_table_names,
     "Option",
     config.render_one_result,
+    type_mapping,
   )
 }
 
@@ -427,6 +455,7 @@ fn render_adapter_many(
   table_matches: Dict(String, String),
   config: AdapterConfig,
   emit_exact_table_names: Bool,
+  type_mapping: model.TypeMapping,
 ) -> String {
   render_adapter_query_result(
     naming_ctx,
@@ -438,6 +467,7 @@ fn render_adapter_many(
     emit_exact_table_names,
     "List",
     config.render_many_result,
+    type_mapping,
   )
 }
 
@@ -451,6 +481,7 @@ fn render_adapter_query_result(
   emit_exact_table_names: Bool,
   return_type_wrapper: String,
   render_result: fn() -> List(String),
+  type_mapping: model.TypeMapping,
 ) -> String {
   let type_name = naming.to_pascal_case(naming_ctx, query.base.name) <> "Row"
   let constructor_name = case
@@ -468,6 +499,7 @@ fn render_adapter_query_result(
       constructor_name,
       config,
       emit_exact_table_names,
+      type_mapping,
     )
 
   string.join(

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -14,6 +14,7 @@ pub fn render(
 ) -> String {
   let semantic_aliases = case type_mapping {
     model.RichMapping -> render_semantic_type_aliases(catalog, queries)
+    model.StrongMapping -> render_strong_type_wrappers(catalog, queries)
     model.StringMapping -> ""
   }
 
@@ -149,6 +150,41 @@ fn render_semantic_type_aliases(
   all_types
   |> list.map(fn(alias_name) { "pub type " <> alias_name <> " =\n  String" })
   |> string.join("\n\n")
+}
+
+fn render_strong_type_wrappers(
+  catalog: model.Catalog,
+  queries: List(model.AnalyzedQuery),
+) -> String {
+  let all_types = collect_rich_types(catalog, queries)
+
+  all_types
+  |> list.map(fn(type_name) {
+    let unwrap_fn = strong_type_unwrap_fn_from_name(type_name)
+    "pub type "
+    <> type_name
+    <> " {\n  "
+    <> type_name
+    <> "(String)\n}\n\npub fn "
+    <> unwrap_fn
+    <> "(value: "
+    <> type_name
+    <> ") -> String {\n  let "
+    <> type_name
+    <> "(inner) = value\n  inner\n}"
+  })
+  |> string.join("\n\n")
+}
+
+fn strong_type_unwrap_fn_from_name(type_name: String) -> String {
+  case type_name {
+    "SqlTimestamp" -> "sql_timestamp_to_string"
+    "SqlDate" -> "sql_date_to_string"
+    "SqlTime" -> "sql_time_to_string"
+    "SqlUuid" -> "sql_uuid_to_string"
+    "SqlJson" -> "sql_json_to_string"
+    _ -> "unknown_to_string"
+  }
 }
 
 fn collect_rich_types(

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -14,6 +14,12 @@ pub fn render(
 
   let has_enums = common.queries_have_enum_params(queries)
 
+  let needs_models_for_strong =
+    type_mapping == model.StrongMapping
+    && list.any(queries, fn(q) {
+      list.any(q.params, fn(p) { model.is_rich_type(p.scalar_type) })
+    })
+
   let imports = case needs_option_import(queries) {
     True ->
       list.flatten([
@@ -25,7 +31,7 @@ pub fn render(
           "import gleam/option.{type Option, None, Some}",
           "import sqlode/runtime.{type Value}",
         ],
-        case has_enums {
+        case has_enums || needs_models_for_strong {
           True -> ["import " <> module_path <> "/models"]
           False -> []
         },
@@ -37,7 +43,7 @@ pub fn render(
           False -> []
         },
         ["import sqlode/runtime.{type Value}"],
-        case has_enums {
+        case has_enums || needs_models_for_strong {
           True -> ["import " <> module_path <> "/models"]
           False -> []
         },
@@ -96,9 +102,12 @@ fn render_params_declaration(
       let values_body = case has_slices {
         True ->
           "  list.flatten(["
-          <> string.join(param_accessors_flattened(params), ", ")
+          <> string.join(param_accessors_flattened(params, type_mapping), ", ")
           <> "])"
-        False -> "  [" <> string.join(param_accessors(params), ", ") <> "]"
+        False ->
+          "  ["
+          <> string.join(param_accessors(params, type_mapping), ", ")
+          <> "]"
       }
       string.join(
         [
@@ -144,12 +153,18 @@ fn param_fields(
   })
 }
 
-fn param_accessors(params: List(model.QueryParam)) -> List(String) {
+fn param_accessors(
+  params: List(model.QueryParam),
+  type_mapping: model.TypeMapping,
+) -> List(String) {
   params
-  |> list.map(render_param_value)
+  |> list.map(render_param_value(_, type_mapping))
 }
 
-fn render_param_value(param: model.QueryParam) -> String {
+fn render_param_value(
+  param: model.QueryParam,
+  type_mapping: model.TypeMapping,
+) -> String {
   let value_expr = "params." <> param.field_name
   let runtime_fn = model.scalar_type_to_runtime_function(param.scalar_type)
 
@@ -168,26 +183,61 @@ fn render_param_value(param: model.QueryParam) -> String {
         False -> runtime_fn <> "(" <> to_string_fn <> "(" <> value_expr <> "))"
       }
     }
-    _ ->
+    _ -> {
+      let unwrap = strong_unwrap_expr(param.scalar_type, type_mapping)
       case param.nullable {
         True ->
-          "case "
-          <> value_expr
-          <> " { Some(value) -> "
-          <> runtime_fn
-          <> "(value) None -> runtime.null() }"
-        False -> runtime_fn <> "(" <> value_expr <> ")"
+          case unwrap {
+            "" ->
+              "case "
+              <> value_expr
+              <> " { Some(value) -> "
+              <> runtime_fn
+              <> "(value) None -> runtime.null() }"
+            _ ->
+              "case "
+              <> value_expr
+              <> " { Some(value) -> "
+              <> runtime_fn
+              <> "("
+              <> unwrap
+              <> "(value)) None -> runtime.null() }"
+          }
+        False ->
+          case unwrap {
+            "" -> runtime_fn <> "(" <> value_expr <> ")"
+            _ -> runtime_fn <> "(" <> unwrap <> "(" <> value_expr <> "))"
+          }
       }
+    }
+  }
+}
+
+fn strong_unwrap_expr(
+  scalar_type: model.ScalarType,
+  type_mapping: model.TypeMapping,
+) -> String {
+  case type_mapping {
+    model.StrongMapping ->
+      case model.is_rich_type(scalar_type) {
+        True -> "models." <> model.strong_type_unwrap_fn(scalar_type)
+        False -> ""
+      }
+    _ -> ""
   }
 }
 
 /// Render param values for queries with slice params.
 /// Scalars are wrapped in singleton lists, slices are mapped.
-fn param_accessors_flattened(params: List(model.QueryParam)) -> List(String) {
+fn param_accessors_flattened(
+  params: List(model.QueryParam),
+  type_mapping: model.TypeMapping,
+) -> List(String) {
   params
   |> list.map(fn(param) {
     let value_expr = "params." <> param.field_name
     let runtime_fn = model.scalar_type_to_runtime_function(param.scalar_type)
+    let unwrap = strong_unwrap_expr(param.scalar_type, type_mapping)
 
     case param.is_list {
       True ->
@@ -202,7 +252,18 @@ fn param_accessors_flattened(params: List(model.QueryParam)) -> List(String) {
             <> to_str
             <> "(v)) })"
           }
-          _ -> "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
+          _ ->
+            case unwrap {
+              "" -> "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
+              _ ->
+                "list.map("
+                <> value_expr
+                <> ", fn(v) { "
+                <> runtime_fn
+                <> "("
+                <> unwrap
+                <> "(v)) })"
+            }
         }
       False ->
         case param.scalar_type {
@@ -224,12 +285,34 @@ fn param_accessors_flattened(params: List(model.QueryParam)) -> List(String) {
           _ ->
             case param.nullable {
               True ->
-                "[case "
-                <> value_expr
-                <> " { Some(value) -> "
-                <> runtime_fn
-                <> "(value) None -> runtime.null() }]"
-              False -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
+                case unwrap {
+                  "" ->
+                    "[case "
+                    <> value_expr
+                    <> " { Some(value) -> "
+                    <> runtime_fn
+                    <> "(value) None -> runtime.null() }]"
+                  _ ->
+                    "[case "
+                    <> value_expr
+                    <> " { Some(value) -> "
+                    <> runtime_fn
+                    <> "("
+                    <> unwrap
+                    <> "(value)) None -> runtime.null() }]"
+                }
+              False ->
+                case unwrap {
+                  "" -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
+                  _ ->
+                    "["
+                    <> runtime_fn
+                    <> "("
+                    <> unwrap
+                    <> "("
+                    <> value_expr
+                    <> "))]"
+                }
             }
         }
     }

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -33,13 +33,15 @@ pub type Runtime {
 pub type TypeMapping {
   StringMapping
   RichMapping
+  StrongMapping
 }
 
 pub fn parse_type_mapping(value: String) -> Result(TypeMapping, String) {
   case value {
     "string" -> Ok(StringMapping)
     "rich" -> Ok(RichMapping)
-    _ -> Error("must be one of: string, rich")
+    "strong" -> Ok(StrongMapping)
+    _ -> Error("must be one of: string, rich, strong")
   }
 }
 
@@ -47,6 +49,7 @@ pub fn type_mapping_to_string(mapping: TypeMapping) -> String {
   case mapping {
     StringMapping -> "string"
     RichMapping -> "rich"
+    StrongMapping -> "strong"
   }
 }
 
@@ -252,27 +255,27 @@ pub fn scalar_type_to_gleam_type(
     BytesType -> "BitArray"
     DateTimeType ->
       case type_mapping {
-        RichMapping -> "SqlTimestamp"
+        RichMapping | StrongMapping -> "SqlTimestamp"
         StringMapping -> "String"
       }
     DateType ->
       case type_mapping {
-        RichMapping -> "SqlDate"
+        RichMapping | StrongMapping -> "SqlDate"
         StringMapping -> "String"
       }
     TimeType ->
       case type_mapping {
-        RichMapping -> "SqlTime"
+        RichMapping | StrongMapping -> "SqlTime"
         StringMapping -> "String"
       }
     UuidType ->
       case type_mapping {
-        RichMapping -> "SqlUuid"
+        RichMapping | StrongMapping -> "SqlUuid"
         StringMapping -> "String"
       }
     JsonType ->
       case type_mapping {
-        RichMapping -> "SqlJson"
+        RichMapping | StrongMapping -> "SqlJson"
         StringMapping -> "String"
       }
     EnumType(name) -> enum_type_name(name)
@@ -285,6 +288,19 @@ pub fn is_rich_type(scalar_type: ScalarType) -> Bool {
   case scalar_type {
     DateTimeType | DateType | TimeType | UuidType | JsonType -> True
     _ -> False
+  }
+}
+
+/// Returns the unwrap function name for strong-typed semantic types.
+/// e.g. UuidType -> "sql_uuid_to_string"
+pub fn strong_type_unwrap_fn(scalar_type: ScalarType) -> String {
+  case scalar_type {
+    DateTimeType -> "sql_timestamp_to_string"
+    DateType -> "sql_date_to_string"
+    TimeType -> "sql_time_to_string"
+    UuidType -> "sql_uuid_to_string"
+    JsonType -> "sql_json_to_string"
+    _ -> ""
   }
 }
 

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -290,6 +290,53 @@ pub fn rich_type_mapping_emits_semantic_aliases_test() {
   cleanup()
 }
 
+pub fn strong_type_mapping_emits_wrapper_types_test() {
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/all_types_schema.sql"],
+      queries: ["test/fixtures/all_types_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StrongMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Should emit wrapper types, not aliases
+  string.contains(models, "pub type SqlUuid {\n  SqlUuid(String)\n}")
+  |> should.be_true()
+  string.contains(models, "pub type SqlTimestamp {\n  SqlTimestamp(String)\n}")
+  |> should.be_true()
+
+  // Should emit unwrap helper functions
+  string.contains(models, "pub fn sql_uuid_to_string(value: SqlUuid) -> String")
+  |> should.be_true()
+  string.contains(
+    models,
+    "pub fn sql_timestamp_to_string(value: SqlTimestamp) -> String",
+  )
+  |> should.be_true()
+
+  // Fields should use strong types
+  string.contains(models, "col_uuid: SqlUuid") |> should.be_true()
+  string.contains(models, "col_timestamp: SqlTimestamp") |> should.be_true()
+
+  // Params should unwrap strong types
+  let params = read_generated("params.gleam")
+  string.contains(params, "models.sql_uuid_to_string(") |> should.be_true()
+
+  cleanup()
+}
+
 pub fn string_type_mapping_does_not_emit_aliases_test() {
   cleanup()
   let block = base_block(model.empty_overrides())

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -199,10 +199,29 @@ pub fn parse_type_mapping_rich_test() {
   model.parse_type_mapping("rich") |> should.equal(Ok(model.RichMapping))
 }
 
+pub fn parse_type_mapping_strong_test() {
+  model.parse_type_mapping("strong") |> should.equal(Ok(model.StrongMapping))
+}
+
 pub fn parse_type_mapping_invalid_test() {
   let assert Error(msg) = model.parse_type_mapping("unknown")
   string.contains(msg, "string") |> should.be_true()
   string.contains(msg, "rich") |> should.be_true()
+  string.contains(msg, "strong") |> should.be_true()
+}
+
+pub fn strong_type_uses_same_names_as_rich_test() {
+  model.scalar_type_to_gleam_type(model.UuidType, model.StrongMapping)
+  |> should.equal("SqlUuid")
+  model.scalar_type_to_gleam_type(model.DateTimeType, model.StrongMapping)
+  |> should.equal("SqlTimestamp")
+}
+
+pub fn strong_type_unwrap_fn_test() {
+  model.strong_type_unwrap_fn(model.UuidType)
+  |> should.equal("sql_uuid_to_string")
+  model.strong_type_unwrap_fn(model.JsonType)
+  |> should.equal("sql_json_to_string")
 }
 
 // is_rich_type tests


### PR DESCRIPTION
## Summary

Add a new `type_mapping: "strong"` config option that generates single-constructor wrapper types for semantic SQL types (UUID, JSON, DATE, TIME, TIMESTAMP) instead of transparent aliases. This provides compile-time type safety — a `SqlUuid` and a plain `String` are distinct types that cannot be accidentally mixed.

## Changes

- `src/sqlode/model.gleam`: Add `StrongMapping` variant to `TypeMapping`, update `parse_type_mapping`/`type_mapping_to_string`, add `strong_type_unwrap_fn` helper
- `src/sqlode/codegen/models.gleam`: Generate wrapper types (`pub type SqlUuid { SqlUuid(String) }`) and unwrap helpers (`pub fn sql_uuid_to_string(...)`) for StrongMapping
- `src/sqlode/codegen/params.gleam`: Unwrap strong types before encoding (e.g. `runtime.string(models.sql_uuid_to_string(params.uuid))`)
- `src/sqlode/codegen/adapter.gleam`: Wrap decoded values with constructors (`decode.map(decode.string, models.SqlUuid)`) for StrongMapping; propagate `type_mapping` through decoder chain
- `README.md`: Document the new `strong` mode in the type mapping table
- `test/model_test.gleam`: Add parsing, name, and unwrap function tests for StrongMapping
- `test/generate_test.gleam`: Add full generation test verifying wrapper types, unwrap helpers, and param encoding

## Design Decisions

- Strong types use the same names as rich types (SqlUuid, SqlTimestamp, etc.) so switching between `rich` and `strong` only changes the type definition, not field names
- Wrapper types use single-constructor pattern (`SqlUuid(String)`) rather than opaque types, keeping them easy to construct and pattern-match
- Generated unwrap helpers follow `sql_<type>_to_string` naming convention for consistency with enum `_to_string`/`_from_string` functions
- Adapter decoders wrap via `decode.map(decode.string, models.SqlUuid)` which leverages Gleam's constructor-as-function syntax

Closes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "strong" type mapping mode that generates distinct opaque wrapper types with conversion functions for semantic database types including TIMESTAMP, DATE, TIME, UUID, and JSON values.

* **Documentation**
  * Updated semantic type mappings documentation describing the characteristics and behaviors of all three supported type mapping modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->