### PR TITLE
feat(model): support PostgreSQL array types

### DIFF
--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -200,6 +200,7 @@ pub type ScalarType {
   JsonType
   EnumType(name: String)
   CustomType(name: String, underlying: ScalarType)
+  ArrayType(element: ScalarType)
 }
 
 pub type EnumDef {
@@ -212,6 +213,15 @@ pub type EnumDef {
 /// Returns Error(Nil) for unrecognized types.
 pub fn parse_sql_type(type_text: String) -> Result(ScalarType, Nil) {
   let lowered = string.lowercase(type_text)
+  // Detect PostgreSQL array syntax: TYPE[] or TYPE ARRAY
+  let #(base_type_text, is_array) = case string.ends_with(lowered, "[]") {
+    True -> #(string.drop_end(lowered, 2), True)
+    False ->
+      case string.ends_with(lowered, " array") {
+        True -> #(string.drop_end(lowered, 6), True)
+        False -> #(lowered, False)
+      }
+  }
   // Order matters: check more specific patterns before general ones
   // (e.g. "timestamp"/"datetime" before "time"/"date", "jsonb" before "json")
   let type_rules = [
@@ -226,7 +236,14 @@ pub fn parse_sql_type(type_text: String) -> Result(ScalarType, Nil) {
     #(["timetz", "time"], TimeType),
     #(["text", "char", "clob", "name", "string"], StringType),
   ]
-  find_matching_type(lowered, type_rules)
+  case find_matching_type(base_type_text, type_rules) {
+    Ok(element_type) ->
+      case is_array {
+        True -> Ok(ArrayType(element_type))
+        False -> Ok(element_type)
+      }
+    Error(Nil) -> Error(Nil)
+  }
 }
 
 fn find_matching_type(
@@ -280,6 +297,8 @@ pub fn scalar_type_to_gleam_type(
       }
     EnumType(name) -> enum_type_name(name)
     CustomType(name, _) -> name
+    ArrayType(element) ->
+      "List(" <> scalar_type_to_gleam_type(element, type_mapping) <> ")"
   }
 }
 
@@ -314,6 +333,7 @@ pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
     DateTimeType | DateType | TimeType | UuidType | JsonType -> "runtime.string"
     EnumType(_) -> "runtime.string"
     CustomType(_, underlying) -> scalar_type_to_runtime_function(underlying)
+    ArrayType(_) -> ""
   }
 }
 
@@ -331,6 +351,7 @@ pub fn scalar_type_to_db_name(scalar_type: ScalarType) -> String {
     JsonType -> "json"
     EnumType(name) -> name
     CustomType(_, underlying) -> scalar_type_to_db_name(underlying)
+    ArrayType(element) -> scalar_type_to_db_name(element) <> "[]"
   }
 }
 
@@ -352,6 +373,8 @@ pub fn scalar_type_to_value_function(
       "text"
     CustomType(_, underlying) ->
       scalar_type_to_value_function(engine, underlying)
+    ArrayType(element) ->
+      "array(pog." <> scalar_type_to_value_function(engine, element) <> ")"
   }
 }
 
@@ -369,6 +392,8 @@ pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String
     DateTimeType | DateType | TimeType | UuidType | JsonType | EnumType(_) ->
       "decode.string"
     CustomType(_, underlying) -> scalar_type_to_decoder(engine, underlying)
+    ArrayType(element) ->
+      "decode.list(" <> scalar_type_to_decoder(engine, element) <> ")"
   }
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -825,6 +825,122 @@ fn readme_analyzed_queries() -> List(model.AnalyzedQuery) {
   result
 }
 
+// --- Array type tests ---
+
+pub fn array_schema_parsing_test() {
+  let catalog = array_test_catalog()
+  let assert [table] = catalog.tables
+  let cols = table.columns
+  // tags should be ArrayType(StringType)
+  let assert [_, _, tags_col, scores_col] = cols
+  tags_col.scalar_type |> should.equal(model.ArrayType(model.StringType))
+  scores_col.scalar_type |> should.equal(model.ArrayType(model.IntType))
+}
+
+pub fn render_models_with_array_columns_test() {
+  let naming_ctx = naming.new()
+  let catalog = array_test_catalog()
+  let analyzed = array_analyzed_queries()
+  let rendered =
+    codegen.render_models_module(
+      naming_ctx,
+      catalog,
+      analyzed,
+      dict.new(),
+      model.StringMapping,
+      False,
+    )
+
+  // Table type should have List fields for array columns (nullable since no NOT NULL)
+  string.contains(rendered, "tags: Option(List(String))")
+  |> should.be_true()
+  string.contains(rendered, "scores: Option(List(Int))")
+  |> should.be_true()
+}
+
+pub fn render_params_with_array_columns_test() {
+  let naming_ctx = naming.new()
+  let analyzed = array_analyzed_queries()
+  let rendered =
+    codegen.render_params_module(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+    )
+
+  // Params for CreateArticle should have array fields (nullable since no NOT NULL)
+  string.contains(rendered, "tags: Option(List(String))")
+  |> should.be_true()
+  string.contains(rendered, "scores: Option(List(Int))")
+  |> should.be_true()
+}
+
+pub fn render_pog_adapter_with_array_columns_test() {
+  let naming_ctx = naming.new()
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/array_schema.sql"],
+      queries: ["test/fixtures/array_query.sql"],
+      gleam: model.GleamOutput(
+        out: "src/db",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let analyzed = array_analyzed_queries()
+  let rendered =
+    codegen.render_adapter_module(naming_ctx, block, analyzed, dict.new())
+
+  // Decoder should use decode.list for array result columns
+  string.contains(rendered, "decode.list(decode.string)")
+  |> should.be_true()
+  string.contains(rendered, "decode.list(decode.int)")
+  |> should.be_true()
+
+  // Parameter encoding should use pog.array for array params
+  string.contains(rendered, "pog.array(pog.text)")
+  |> should.be_true()
+  string.contains(rendered, "pog.array(pog.int)")
+  |> should.be_true()
+}
+
+fn array_test_catalog() -> model.Catalog {
+  let assert Ok(schema_content) =
+    simplifile.read("test/fixtures/array_schema.sql")
+  let assert Ok(catalog) =
+    schema_parser.parse_files([
+      #("test/fixtures/array_schema.sql", schema_content),
+    ])
+  catalog
+}
+
+fn array_analyzed_queries() -> List(model.AnalyzedQuery) {
+  let naming_ctx = naming.new()
+  let catalog = array_test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/array_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/array_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(result) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result
+}
+
 pub fn out_to_module_path_strips_src_prefix_test() {
   common.out_to_module_path("src/db") |> should.equal("db")
   common.out_to_module_path("src/generated/db") |> should.equal("generated/db")

--- a/test/fixtures/array_query.sql
+++ b/test/fixtures/array_query.sql
@@ -1,0 +1,7 @@
+-- name: GetArticle :one
+SELECT id, title, tags, scores
+FROM articles
+WHERE id = $1;
+
+-- name: CreateArticle :exec
+INSERT INTO articles (title, tags, scores) VALUES ($1, $2, $3);

--- a/test/fixtures/array_schema.sql
+++ b/test/fixtures/array_schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE articles (
+  id BIGSERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  tags TEXT[],
+  scores INTEGER[]
+);

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -288,3 +288,69 @@ pub fn enum_to_string_fn_test() {
 pub fn enum_from_string_fn_test() {
   model.enum_from_string_fn("status") |> should.equal("status_from_string")
 }
+
+// array type tests
+
+pub fn parse_sql_type_array_text_test() {
+  model.parse_sql_type("TEXT[]")
+  |> should.equal(Ok(model.ArrayType(model.StringType)))
+}
+
+pub fn parse_sql_type_array_integer_test() {
+  model.parse_sql_type("INTEGER[]")
+  |> should.equal(Ok(model.ArrayType(model.IntType)))
+}
+
+pub fn parse_sql_type_array_boolean_test() {
+  model.parse_sql_type("BOOLEAN[]")
+  |> should.equal(Ok(model.ArrayType(model.BoolType)))
+}
+
+pub fn parse_sql_type_array_uuid_test() {
+  model.parse_sql_type("UUID[]")
+  |> should.equal(Ok(model.ArrayType(model.UuidType)))
+}
+
+pub fn scalar_type_to_gleam_type_array_test() {
+  model.scalar_type_to_gleam_type(
+    model.ArrayType(model.IntType),
+    model.StringMapping,
+  )
+  |> should.equal("List(Int)")
+
+  model.scalar_type_to_gleam_type(
+    model.ArrayType(model.StringType),
+    model.StringMapping,
+  )
+  |> should.equal("List(String)")
+}
+
+pub fn scalar_type_to_decoder_array_test() {
+  model.scalar_type_to_decoder(model.PostgreSQL, model.ArrayType(model.IntType))
+  |> should.equal("decode.list(decode.int)")
+
+  model.scalar_type_to_decoder(
+    model.PostgreSQL,
+    model.ArrayType(model.StringType),
+  )
+  |> should.equal("decode.list(decode.string)")
+}
+
+pub fn scalar_type_to_value_function_array_test() {
+  model.scalar_type_to_value_function(
+    model.PostgreSQL,
+    model.ArrayType(model.IntType),
+  )
+  |> should.equal("array(pog.int)")
+
+  model.scalar_type_to_value_function(
+    model.PostgreSQL,
+    model.ArrayType(model.StringType),
+  )
+  |> should.equal("array(pog.text)")
+}
+
+pub fn scalar_type_to_db_name_array_test() {
+  model.scalar_type_to_db_name(model.ArrayType(model.IntType))
+  |> should.equal("int[]")
+}


### PR DESCRIPTION
## Summary

Add support for PostgreSQL array types (`TEXT[]`, `INTEGER[]`, etc.) by introducing an `ArrayType(element)` variant to `ScalarType`. The schema parser recognizes `TYPE[]` and `TYPE ARRAY` syntax, and the codegen pipeline maps arrays to `List(T)` in Gleam with `pog.array()` for parameter encoding and `decode.list()` for result decoding.

## Changes

- `src/sqlode/model.gleam`: Add `ArrayType(element: ScalarType)` variant to `ScalarType`; update `parse_sql_type` to detect `[]` and `ARRAY` suffixes; add `ArrayType` cases to all type mapping functions (`scalar_type_to_gleam_type`, `scalar_type_to_decoder`, `scalar_type_to_value_function`, `scalar_type_to_db_name`, `scalar_type_to_runtime_function`)
- `test/fixtures/array_schema.sql`: New fixture with `TEXT[]` and `INTEGER[]` columns
- `test/fixtures/array_query.sql`: New fixture with SELECT and INSERT queries using array columns
- `test/model_test.gleam`: Add 6 tests for array type parsing, Gleam type mapping, decoder, value function, and db_name
- `test/codegen_test.gleam`: Add 4 tests for array schema parsing, models rendering, params rendering, and pog adapter rendering

## Design Decisions

- `ArrayType(element)` wraps any `ScalarType`, supporting nested types like `ArrayType(UuidType)` → `List(SqlUuid)` with rich/strong mapping
- pog adapter uses `pog.array(pog.int)` / `pog.array(pog.text)` for array parameter encoding, matching the pog library's native array API
- Decoder uses `decode.list(decode.int)` / `decode.list(decode.string)` for array result columns
- `scalar_type_to_runtime_function` returns empty string for `ArrayType` since arrays are not used in raw runtime value encoding (they use the pog adapter path)

## Limitations

- SQLite does not support native array types — array columns in SQLite schemas will parse but may produce incorrect runtime behavior
- `ARRAY[TYPE]` syntax with explicit element type in brackets (e.g., `ARRAY[TEXT]`) is not yet supported — only `TYPE[]` and `TYPE ARRAY` suffixes are recognized

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PostgreSQL array column types (TEXT[], INTEGER[], BOOLEAN[], UUID[]) are now fully supported in schemas and generate correct Gleam List types with appropriate decoders and encoders.

* **Tests**
  * Added comprehensive test coverage for array type parsing, schema handling, and adapter code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->