### PR TITLE
feat(analyzer): support expression-based SELECT columns

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -9,7 +9,11 @@ import sqlode/query_analyzer/context.{
 }
 
 type ExtractedColumn {
-  ExtractedColumn(name: String, source_table: Option(String))
+  ExtractedColumn(
+    name: String,
+    source_table: Option(String),
+    expression: Option(String),
+  )
 }
 
 type JoinKind {
@@ -124,11 +128,17 @@ fn extract_returning_columns(
       case match.submatches {
         [Some(columns_text)] -> {
           let cols = case string.trim(columns_text) == "*" {
-            True -> [ExtractedColumn(name: "*", source_table: None)]
+            True -> [
+              ExtractedColumn(name: "*", source_table: None, expression: None),
+            ]
             False ->
               context.split_csv(columns_text)
               |> list.map(fn(c) {
-                ExtractedColumn(name: string.trim(c), source_table: None)
+                ExtractedColumn(
+                  name: string.trim(c),
+                  source_table: None,
+                  expression: None,
+                )
               })
           }
           Some(cols)
@@ -211,26 +221,33 @@ fn extract_select_columns(
       case match.submatches {
         [Some(columns_text)] -> {
           case string.trim(columns_text) == "*" {
-            True -> [ExtractedColumn(name: "*", source_table: None)]
+            True -> [
+              ExtractedColumn(name: "*", source_table: None, expression: None),
+            ]
             False ->
               columns_text
               |> context.split_csv
               |> list.map(fn(col) {
                 let trimmed = string.trim(col)
                 case string.starts_with(trimmed, "sqlc.embed(") {
-                  True -> ExtractedColumn(name: trimmed, source_table: None)
+                  True ->
+                    ExtractedColumn(
+                      name: trimmed,
+                      source_table: None,
+                      expression: None,
+                    )
                   False ->
-                    case string.contains(trimmed, " as ") {
-                      True -> {
-                        let assert Ok(#(expr, alias)) =
-                          string.split_once(trimmed, " as ")
-                        let table = extract_table_qualifier(string.trim(expr))
+                    case split_last_as(trimmed) {
+                      Some(#(expr_part, alias_part)) -> {
+                        let expr_trimmed = string.trim(expr_part)
+                        let table = extract_table_qualifier(expr_trimmed)
                         ExtractedColumn(
-                          name: string.trim(alias),
+                          name: string.trim(alias_part),
                           source_table: table,
+                          expression: Some(expr_trimmed),
                         )
                       }
-                      False ->
+                      None ->
                         case string.contains(trimmed, ".") {
                           True -> {
                             let parts = string.split(trimmed, ".")
@@ -242,10 +259,18 @@ fn extract_select_columns(
                               Ok(last) -> string.trim(last)
                               Error(_) -> trimmed
                             }
-                            ExtractedColumn(name:, source_table: table)
+                            ExtractedColumn(
+                              name:,
+                              source_table: table,
+                              expression: None,
+                            )
                           }
                           False ->
-                            ExtractedColumn(name: trimmed, source_table: None)
+                            ExtractedColumn(
+                              name: trimmed,
+                              source_table: None,
+                              expression: None,
+                            )
                         }
                     }
                 }
@@ -255,6 +280,58 @@ fn extract_select_columns(
         _ -> []
       }
     [] -> []
+  }
+}
+
+/// Split on the last top-level " as " (outside parentheses).
+/// This avoids splitting on AS inside CAST(... AS type).
+fn split_last_as(s: String) -> Option(#(String, String)) {
+  let lowered = string.lowercase(s)
+  split_last_as_loop(lowered, s, 0, 0, -1)
+}
+
+fn split_last_as_loop(
+  lowered: String,
+  original: String,
+  idx: Int,
+  depth: Int,
+  last_pos: Int,
+) -> Option(#(String, String)) {
+  case string.pop_grapheme(lowered) {
+    Error(_) ->
+      case last_pos >= 0 {
+        True ->
+          Some(#(
+            string.slice(original, 0, last_pos),
+            string.slice(original, last_pos + 4, string.length(original)),
+          ))
+        False -> None
+      }
+    Ok(#(g, rest)) ->
+      case g {
+        "(" -> split_last_as_loop(rest, original, idx + 1, depth + 1, last_pos)
+        ")" -> {
+          let new_depth = case depth > 0 {
+            True -> depth - 1
+            False -> 0
+          }
+          split_last_as_loop(rest, original, idx + 1, new_depth, last_pos)
+        }
+        " " ->
+          case depth == 0 && string.starts_with(rest, "as ") {
+            True ->
+              split_last_as_loop(
+                string.drop_start(rest, 3),
+                original,
+                idx + 4,
+                depth,
+                idx,
+              )
+            False ->
+              split_last_as_loop(rest, original, idx + 1, depth, last_pos)
+          }
+        _ -> split_last_as_loop(rest, original, idx + 1, depth, last_pos)
+      }
   }
 }
 
@@ -343,11 +420,26 @@ fn resolve_select_columns(
                       ),
                     ])
                   None ->
-                    Error(ColumnNotFound(
-                      query_name:,
-                      table_name: table,
-                      column_name: normalized_name,
-                    ))
+                    case extracted.expression {
+                      Some(expr) -> {
+                        let #(scalar_type, nullable) =
+                          infer_expression_type(expr, catalog, all_tables)
+                        Ok([
+                          model.ResultColumn(
+                            name: normalized_name,
+                            scalar_type:,
+                            nullable:,
+                            source_table: None,
+                          ),
+                        ])
+                      }
+                      None ->
+                        Error(ColumnNotFound(
+                          query_name:,
+                          table_name: table,
+                          column_name: normalized_name,
+                        ))
+                    }
                 }
               None ->
                 case
@@ -364,11 +456,26 @@ fn resolve_select_columns(
                       ),
                     ])
                   None ->
-                    Error(ColumnNotFound(
-                      query_name:,
-                      table_name: primary_table,
-                      column_name: normalized_name,
-                    ))
+                    case extracted.expression {
+                      Some(expr) -> {
+                        let #(scalar_type, nullable) =
+                          infer_expression_type(expr, catalog, all_tables)
+                        Ok([
+                          model.ResultColumn(
+                            name: normalized_name,
+                            scalar_type:,
+                            nullable:,
+                            source_table: None,
+                          ),
+                        ])
+                      }
+                      None ->
+                        Error(ColumnNotFound(
+                          query_name:,
+                          table_name: primary_table,
+                          column_name: normalized_name,
+                        ))
+                    }
                 }
             }
           }
@@ -376,6 +483,158 @@ fn resolve_select_columns(
       })
       |> result.map(list.flatten)
   }
+}
+
+fn infer_expression_type(
+  expr: String,
+  catalog: model.Catalog,
+  table_names: List(String),
+) -> #(model.ScalarType, Bool) {
+  let lowered = string.lowercase(string.trim(expr))
+  infer_expression_type_dispatch(lowered, catalog, table_names)
+}
+
+fn infer_expression_type_dispatch(
+  lowered: String,
+  catalog: model.Catalog,
+  table_names: List(String),
+) -> #(model.ScalarType, Bool) {
+  let prefixes = [
+    #("count(", InferCount),
+    #("sum(", InferSum),
+    #("avg(", InferAvg),
+    #("min(", InferMinMax),
+    #("max(", InferMinMax),
+    #("row_number(", InferRowNumber),
+    #("rank(", InferRowNumber),
+    #("dense_rank(", InferRowNumber),
+    #("coalesce(", InferCoalesce),
+    #("cast(", InferCast),
+    #("case ", InferCase),
+    #("'", InferStringLiteral),
+  ]
+  case find_matching_prefix(lowered, prefixes) {
+    Some(InferCount) -> #(model.IntType, False)
+    Some(InferSum) -> {
+      let inner_type = infer_aggregate_inner_type(lowered, catalog, table_names)
+      #(inner_type, True)
+    }
+    Some(InferAvg) -> #(model.FloatType, True)
+    Some(InferMinMax) -> {
+      let inner_type = infer_aggregate_inner_type(lowered, catalog, table_names)
+      #(inner_type, True)
+    }
+    Some(InferRowNumber) -> #(model.IntType, False)
+    Some(InferCoalesce) -> {
+      let inner = extract_function_arg(lowered)
+      case resolve_column_type(string.trim(inner), catalog, table_names) {
+        Some(t) -> #(t, False)
+        None -> #(model.StringType, False)
+      }
+    }
+    Some(InferCast) ->
+      case string.split_once(lowered, " as ") {
+        Ok(#(_, type_part)) -> {
+          let type_text = type_part |> string.replace(")", "") |> string.trim
+          case model.parse_sql_type(type_text) {
+            Ok(scalar_type) -> #(scalar_type, True)
+            Error(_) -> #(model.StringType, True)
+          }
+        }
+        Error(_) -> #(model.StringType, True)
+      }
+    Some(InferCase) -> #(model.StringType, True)
+    Some(InferStringLiteral) -> #(model.StringType, False)
+    None ->
+      case is_integer_literal(lowered) {
+        True -> #(model.IntType, False)
+        False ->
+          case lowered == "true" || lowered == "false" {
+            True -> #(model.BoolType, False)
+            False -> #(model.StringType, True)
+          }
+      }
+  }
+}
+
+type ExprKind {
+  InferCount
+  InferSum
+  InferAvg
+  InferMinMax
+  InferRowNumber
+  InferCoalesce
+  InferCast
+  InferCase
+  InferStringLiteral
+}
+
+fn find_matching_prefix(
+  lowered: String,
+  rules: List(#(String, ExprKind)),
+) -> Option(ExprKind) {
+  case rules {
+    [] -> None
+    [#(prefix, kind), ..rest] ->
+      case string.starts_with(lowered, prefix) {
+        True -> Some(kind)
+        False -> find_matching_prefix(lowered, rest)
+      }
+  }
+}
+
+fn infer_aggregate_inner_type(
+  func_expr: String,
+  catalog: model.Catalog,
+  table_names: List(String),
+) -> model.ScalarType {
+  let inner = extract_function_arg(func_expr)
+  case resolve_column_type(string.trim(inner), catalog, table_names) {
+    Some(t) -> t
+    None -> model.IntType
+  }
+}
+
+fn extract_function_arg(func_expr: String) -> String {
+  case string.split_once(func_expr, "(") {
+    Ok(#(_, rest)) ->
+      case string.split_once(rest, ")") {
+        Ok(#(arg, _)) -> {
+          // For multi-arg functions, take the first arg
+          case string.split_once(arg, ",") {
+            Ok(#(first, _)) -> string.trim(first)
+            Error(_) -> string.trim(arg)
+          }
+        }
+        Error(_) -> rest
+      }
+    Error(_) -> func_expr
+  }
+}
+
+fn resolve_column_type(
+  name: String,
+  catalog: model.Catalog,
+  table_names: List(String),
+) -> Option(model.ScalarType) {
+  // Try table.column format
+  let col_name = case string.split_once(name, ".") {
+    Ok(#(_, col)) -> string.trim(col)
+    Error(_) -> name
+  }
+  case find_column_in_tables(catalog, table_names, col_name) {
+    Some(#(_, column)) -> Some(column.scalar_type)
+    None -> None
+  }
+}
+
+fn is_integer_literal(s: String) -> Bool {
+  !string.is_empty(s)
+  && string.to_utf_codepoints(s)
+  |> list.all(fn(cp) {
+    let value = string.utf_codepoint_to_int(cp)
+    value >= 48 && value <= 57
+  })
 }
 
 fn find_column_in_tables(

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -183,8 +183,47 @@ pub fn find_column(
 }
 
 pub fn split_csv(text: String) -> List(String) {
-  text
-  |> string.split(",")
+  split_csv_paren_aware(text, 0, [], [])
   |> list.map(string.trim)
   |> list.filter(fn(entry) { entry != "" })
+}
+
+fn split_csv_paren_aware(
+  remaining: String,
+  depth: Int,
+  current_rev: List(String),
+  acc: List(String),
+) -> List(String) {
+  case string.pop_grapheme(remaining) {
+    Error(_) -> {
+      let current = current_rev |> list.reverse |> string.concat |> string.trim
+      case current {
+        "" -> list.reverse(acc)
+        _ -> list.reverse([current, ..acc])
+      }
+    }
+    Ok(#(grapheme, rest)) ->
+      case grapheme {
+        "(" ->
+          split_csv_paren_aware(rest, depth + 1, [grapheme, ..current_rev], acc)
+        ")" -> {
+          let new_depth = case depth > 0 {
+            True -> depth - 1
+            False -> 0
+          }
+          split_csv_paren_aware(rest, new_depth, [grapheme, ..current_rev], acc)
+        }
+        "," ->
+          case depth == 0 {
+            True -> {
+              let current =
+                current_rev |> list.reverse |> string.concat |> string.trim
+              split_csv_paren_aware(rest, depth, [], [current, ..acc])
+            }
+            False ->
+              split_csv_paren_aware(rest, depth, [grapheme, ..current_rev], acc)
+          }
+        _ -> split_csv_paren_aware(rest, depth, [grapheme, ..current_rev], acc)
+      }
+  }
 }

--- a/test/fixtures/expression_query.sql
+++ b/test/fixtures/expression_query.sql
@@ -1,0 +1,19 @@
+-- name: CountAuthors :one
+SELECT COUNT(*) AS total
+FROM authors;
+
+-- name: SumAndAvg :one
+SELECT SUM(id) AS id_sum, AVG(id) AS id_avg
+FROM authors;
+
+-- name: CoalesceNullable :many
+SELECT id, COALESCE(bio, 'N/A') AS bio_text
+FROM authors;
+
+-- name: CastColumn :many
+SELECT id, CAST(name AS TEXT) AS name_text
+FROM authors;
+
+-- name: LiteralSelect :one
+SELECT 1 AS one, 'hello' AS greeting
+FROM authors;

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -703,3 +703,162 @@ fn join_catalog() -> model.Catalog {
 
   catalog
 }
+
+// --- Expression-based column tests ---
+
+pub fn count_expression_infers_int_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/expression_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/expression_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  // CountAuthors: COUNT(*) AS total → Int, not nullable
+  let assert [count_query, ..] = analyzed
+  let assert [total_col] = count_query.result_columns
+  let assert model.ResultColumn(name: "total", scalar_type: model.IntType, ..) =
+    total_col
+}
+
+pub fn sum_avg_expression_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/expression_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/expression_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  // SumAndAvg: SUM(id) AS id_sum → Int(nullable), AVG(id) AS id_avg → Float(nullable)
+  let assert [_, sum_avg_query, ..] = analyzed
+  let assert [sum_col, avg_col] = sum_avg_query.result_columns
+  let assert model.ResultColumn(
+    name: "id_sum",
+    scalar_type: model.IntType,
+    nullable: True,
+    ..,
+  ) = sum_col
+  let assert model.ResultColumn(
+    name: "id_avg",
+    scalar_type: model.FloatType,
+    nullable: True,
+    ..,
+  ) = avg_col
+}
+
+pub fn coalesce_expression_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/expression_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/expression_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  // CoalesceNullable: COALESCE(bio, 'N/A') AS bio_text → String, not nullable
+  let assert [_, _, coalesce_query, ..] = analyzed
+  let assert [_, bio_col] = coalesce_query.result_columns
+  let assert model.ResultColumn(
+    name: "bio_text",
+    scalar_type: model.StringType,
+    nullable: False,
+    ..,
+  ) = bio_col
+}
+
+pub fn cast_expression_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/expression_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/expression_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  // CastColumn: CAST(name AS TEXT) AS name_text → String
+  let assert [_, _, _, cast_query, ..] = analyzed
+  let assert [_, name_col] = cast_query.result_columns
+  let assert model.ResultColumn(
+    name: "name_text",
+    scalar_type: model.StringType,
+    ..,
+  ) = name_col
+}
+
+pub fn literal_expression_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let assert Ok(content) = simplifile.read("test/fixtures/expression_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/expression_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  // LiteralSelect: 1 AS one → Int, 'hello' AS greeting → String
+  let assert [_, _, _, _, literal_query] = analyzed
+  let assert [one_col, greeting_col] = literal_query.result_columns
+  let assert model.ResultColumn(
+    name: "one",
+    scalar_type: model.IntType,
+    nullable: False,
+    ..,
+  ) = one_col
+  let assert model.ResultColumn(
+    name: "greeting",
+    scalar_type: model.StringType,
+    nullable: False,
+    ..,
+  ) = greeting_col
+}


### PR DESCRIPTION
## Summary

Add expression-based SELECT column support to the column inferencer. Previously, any non-catalog column (COUNT(*), CASE, COALESCE, CAST, literals) caused a hard `ColumnNotFound` error. Now the inferencer detects expressions and infers their types from SQL patterns, falling back gracefully to `StringType(nullable=True)` for unrecognized expressions.

## Changes

- `src/sqlode/query_analyzer/column_inferencer.gleam`:
  - Add `expression: Option(String)` field to `ExtractedColumn` to preserve the original SQL expression
  - Replace `string.split_once(" as ")` with `split_last_as` that splits on the last top-level ` AS ` (outside parentheses), fixing CAST(... AS type) alias extraction
  - Add expression type inference engine (`infer_expression_type_dispatch`) supporting:
    - `COUNT(*)` / `COUNT(expr)` → `IntType, not nullable`
    - `SUM(expr)` → element type from catalog, nullable
    - `AVG(expr)` → `FloatType, nullable`
    - `MIN(expr)` / `MAX(expr)` → element type from catalog, nullable
    - `ROW_NUMBER()` / `RANK()` / `DENSE_RANK()` → `IntType, not nullable`
    - `COALESCE(a, b)` → type of first arg from catalog, not nullable
    - `CAST(expr AS type)` → parsed SQL type
    - Integer literals → `IntType, not nullable`
    - String literals → `StringType, not nullable`
    - Boolean literals → `BoolType, not nullable`
    - `CASE WHEN ... END` → `StringType, nullable`
    - Unknown expressions → `StringType, nullable`
  - Fall back to expression inference when catalog lookup fails, instead of returning `ColumnNotFound`
- `src/sqlode/query_analyzer/context.gleam`: Replace naive `string.split(",")` in `split_csv` with parenthesis-aware splitter that correctly handles `COALESCE(a, b)`, `CAST(x AS y)`, etc.
- `test/fixtures/expression_query.sql`: New fixture with COUNT, SUM, AVG, COALESCE, CAST, and literal queries
- `test/query_analyzer_test.gleam`: Add 5 tests covering COUNT, SUM/AVG, COALESCE, CAST, and literal expression inference

## Design Decisions

- Expression type inference uses prefix matching on lowercased expressions rather than full SQL parsing — this is pragmatic and covers the most common patterns without adding a full expression parser
- `split_last_as` splits on the last top-level ` AS ` to correctly handle `CAST(name AS TEXT) AS alias` where the inner `AS` is part of the CAST syntax
- Parenthesis-aware CSV splitting in `split_csv` prevents `COALESCE(a, b)` from being split into separate columns
- Aggregate inner types are resolved via catalog lookup when possible (e.g., `SUM(id)` infers `IntType` from the `id` column)

## Limitations

- Window functions with complex OVER clauses are detected by prefix only (`ROW_NUMBER(`, `RANK(`, `DENSE_RANK(`)
- CASE expressions default to `StringType` — type inference from THEN/ELSE branches is not implemented
- Nested expressions (e.g., `COUNT(DISTINCT col)`) work for COUNT but the DISTINCT keyword is not specially handled for other aggregates
- Subquery expressions are not supported (they fall back to `StringType, nullable`)

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SQL expression parsing to infer types for complex SELECT expressions, including aggregate functions (COUNT, SUM, AVG), conditional logic (COALESCE, CASE), and type casting (CAST).
  * Improved comma handling in nested SQL constructs through parenthesis-aware parsing.

* **Tests**
  * Added comprehensive test coverage for expression type inference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->