### PR TITLE
refactor(lexer): introduce shared SQL lexer with engine-specific tokenization (Phase 1 of #203)

### DIFF
--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -1,0 +1,577 @@
+import gleam/list
+import gleam/string
+import sqlode/model
+
+/// A SQL token produced by the lexer.
+pub type Token {
+  /// SQL keyword (lowercased): SELECT, FROM, CREATE, etc.
+  Keyword(String)
+  /// Unquoted identifier: table_name, column_name
+  Ident(String)
+  /// Quoted identifier: "name", `name`, [name] (quotes stripped)
+  QuotedIdent(String)
+  /// String literal (quotes stripped): 'value', $$dollar$$
+  StringLit(String)
+  /// Numeric literal: 42, 3.14
+  NumberLit(String)
+  /// Parameter placeholder: $1, ?, :name, @name
+  Placeholder(String)
+  /// Operator: =, <>, ::, ->, ||, etc.
+  Operator(String)
+  LParen
+  RParen
+  Comma
+  Semicolon
+  Dot
+  Star
+}
+
+/// Tokenize a SQL string into a list of tokens.
+/// Comments are stripped. String literals and quoted identifiers are preserved
+/// as single tokens with their content.
+pub fn tokenize(sql: String, engine: model.Engine) -> List(Token) {
+  let graphemes = string.to_graphemes(sql)
+  do_tokenize(graphemes, engine, [])
+  |> list.reverse
+}
+
+fn do_tokenize(
+  input: List(String),
+  engine: model.Engine,
+  acc: List(Token),
+) -> List(Token) {
+  case input {
+    [] -> acc
+    [g, ..rest] ->
+      case g {
+        // Whitespace — skip
+        " " | "\t" | "\n" | "\r" -> do_tokenize(rest, engine, acc)
+
+        // Line comment: --
+        "-" ->
+          case rest {
+            ["-", ..after_dash] -> {
+              let remaining = skip_line_comment(after_dash)
+              do_tokenize(remaining, engine, acc)
+            }
+            _ -> {
+              let #(op, remaining) = read_operator([g, ..rest])
+              do_tokenize(remaining, engine, [Operator(op), ..acc])
+            }
+          }
+
+        // Block comment: /* ... */ or MySQL # comment
+        "/" ->
+          case rest {
+            ["*", ..after_star] -> {
+              let remaining = skip_block_comment(after_star)
+              do_tokenize(remaining, engine, acc)
+            }
+            _ -> do_tokenize(rest, engine, [Operator("/"), ..acc])
+          }
+
+        "#" ->
+          case engine {
+            model.MySQL -> {
+              let remaining = skip_line_comment(rest)
+              do_tokenize(remaining, engine, acc)
+            }
+            _ -> {
+              let #(op, remaining) = read_operator([g, ..rest])
+              do_tokenize(remaining, engine, [Operator(op), ..acc])
+            }
+          }
+
+        // Single-quoted string literal
+        "'" -> {
+          let #(content, remaining) = read_single_quoted_string(rest, [])
+          do_tokenize(remaining, engine, [StringLit(content), ..acc])
+        }
+
+        // Dollar-quoted string (PostgreSQL)
+        "$" ->
+          case engine {
+            model.PostgreSQL ->
+              case rest {
+                ["$", ..after_dollar] -> {
+                  let #(content, remaining) =
+                    read_dollar_quoted_string(after_dollar, [])
+                  do_tokenize(remaining, engine, [StringLit(content), ..acc])
+                }
+                _ -> {
+                  // Could be placeholder $1, $name
+                  let #(token, remaining) =
+                    read_placeholder_or_ident(["$", ..rest])
+                  do_tokenize(remaining, engine, [token, ..acc])
+                }
+              }
+            _ -> {
+              // SQLite $name placeholder
+              let #(token, remaining) = read_placeholder_or_ident(["$", ..rest])
+              do_tokenize(remaining, engine, [token, ..acc])
+            }
+          }
+
+        // Double-quoted identifier (PostgreSQL/SQLite) or string (MySQL)
+        "\"" ->
+          case engine {
+            model.MySQL -> {
+              let #(content, remaining) = read_quoted(rest, "\"", [])
+              do_tokenize(remaining, engine, [StringLit(content), ..acc])
+            }
+            _ -> {
+              let #(content, remaining) = read_quoted(rest, "\"", [])
+              do_tokenize(remaining, engine, [QuotedIdent(content), ..acc])
+            }
+          }
+
+        // Backtick-quoted identifier (MySQL)
+        "`" -> {
+          let #(content, remaining) = read_quoted(rest, "`", [])
+          do_tokenize(remaining, engine, [QuotedIdent(content), ..acc])
+        }
+
+        // Bracket-quoted identifier (SQLite)
+        "[" ->
+          case engine {
+            model.SQLite -> {
+              let #(content, remaining) = read_quoted(rest, "]", [])
+              do_tokenize(remaining, engine, [QuotedIdent(content), ..acc])
+            }
+            _ -> {
+              let #(op, remaining) = read_operator([g, ..rest])
+              do_tokenize(remaining, engine, [Operator(op), ..acc])
+            }
+          }
+
+        // Single-char tokens
+        "(" -> do_tokenize(rest, engine, [LParen, ..acc])
+        ")" -> do_tokenize(rest, engine, [RParen, ..acc])
+        "," -> do_tokenize(rest, engine, [Comma, ..acc])
+        ";" -> do_tokenize(rest, engine, [Semicolon, ..acc])
+        "*" -> do_tokenize(rest, engine, [Star, ..acc])
+
+        // Dot
+        "." ->
+          case rest {
+            [next, ..] ->
+              case is_digit(next) {
+                // .5 → numeric literal
+                True -> {
+                  let #(num, remaining) = read_number(rest, [g])
+                  do_tokenize(remaining, engine, [NumberLit(num), ..acc])
+                }
+                False -> do_tokenize(rest, engine, [Dot, ..acc])
+              }
+            _ -> do_tokenize(rest, engine, [Dot, ..acc])
+          }
+
+        // Placeholder: ?, :name, @name
+        "?" -> {
+          let #(ph, remaining) = read_placeholder_question(rest, [g])
+          do_tokenize(remaining, engine, [Placeholder(ph), ..acc])
+        }
+        ":" ->
+          case rest {
+            // PostgreSQL :: cast operator
+            [":", ..after_colon] ->
+              do_tokenize(after_colon, engine, [Operator("::"), ..acc])
+            [next, ..] ->
+              case is_alpha_or_underscore(next) {
+                True -> {
+                  let #(ph, remaining) = read_word(rest, [g])
+                  do_tokenize(remaining, engine, [Placeholder(ph), ..acc])
+                }
+                False -> do_tokenize(rest, engine, [Operator(":"), ..acc])
+              }
+            _ -> do_tokenize(rest, engine, [Operator(":"), ..acc])
+          }
+        "@" ->
+          case rest {
+            [next, ..] ->
+              case is_alpha_or_underscore(next) {
+                True -> {
+                  let #(ph, remaining) = read_word(rest, [g])
+                  do_tokenize(remaining, engine, [Placeholder(ph), ..acc])
+                }
+                False -> do_tokenize(rest, engine, [Operator("@"), ..acc])
+              }
+            _ -> do_tokenize(rest, engine, [Operator("@"), ..acc])
+          }
+
+        // Numbers
+        _ ->
+          case is_digit(g) {
+            True -> {
+              let #(num, remaining) = read_number(rest, [g])
+              do_tokenize(remaining, engine, [NumberLit(num), ..acc])
+            }
+            False ->
+              case is_alpha_or_underscore(g) {
+                True -> {
+                  let #(word, remaining) = read_word(rest, [g])
+                  let token = classify_word(word)
+                  do_tokenize(remaining, engine, [token, ..acc])
+                }
+                // Operators and other characters
+                False -> {
+                  let #(op, remaining) = read_operator([g, ..rest])
+                  do_tokenize(remaining, engine, [Operator(op), ..acc])
+                }
+              }
+          }
+      }
+  }
+}
+
+// --- Comment helpers ---
+
+fn skip_line_comment(input: List(String)) -> List(String) {
+  case input {
+    [] -> []
+    ["\n", ..rest] -> rest
+    [_, ..rest] -> skip_line_comment(rest)
+  }
+}
+
+fn skip_block_comment(input: List(String)) -> List(String) {
+  skip_block_comment_loop(input, 1)
+}
+
+fn skip_block_comment_loop(input: List(String), depth: Int) -> List(String) {
+  case input {
+    [] -> []
+    _ ->
+      case depth <= 0 {
+        True -> input
+        False ->
+          case input {
+            ["*", "/", ..rest] -> skip_block_comment_loop(rest, depth - 1)
+            ["/", "*", ..rest] -> skip_block_comment_loop(rest, depth + 1)
+            [_, ..rest] -> skip_block_comment_loop(rest, depth)
+            [] -> []
+          }
+      }
+  }
+}
+
+// --- String literal helpers ---
+
+fn read_single_quoted_string(
+  input: List(String),
+  acc: List(String),
+) -> #(String, List(String)) {
+  case input {
+    [] -> #(acc |> list.reverse |> string.concat, [])
+    ["'", "'", ..rest] ->
+      // Escaped quote '' → single '
+      read_single_quoted_string(rest, ["'", ..acc])
+    ["'", ..rest] ->
+      // End of string
+      #(acc |> list.reverse |> string.concat, rest)
+    [g, ..rest] -> read_single_quoted_string(rest, [g, ..acc])
+  }
+}
+
+fn read_dollar_quoted_string(
+  input: List(String),
+  acc: List(String),
+) -> #(String, List(String)) {
+  case input {
+    [] -> #(acc |> list.reverse |> string.concat, [])
+    ["$", "$", ..rest] ->
+      // End of $$...$$ string
+      #(acc |> list.reverse |> string.concat, rest)
+    [g, ..rest] -> read_dollar_quoted_string(rest, [g, ..acc])
+  }
+}
+
+fn read_quoted(
+  input: List(String),
+  closer: String,
+  acc: List(String),
+) -> #(String, List(String)) {
+  case input {
+    [] -> #(acc |> list.reverse |> string.concat, [])
+    [g, ..rest] ->
+      case g == closer {
+        True -> #(acc |> list.reverse |> string.concat, rest)
+        False -> read_quoted(rest, closer, [g, ..acc])
+      }
+  }
+}
+
+// --- Word/identifier helpers ---
+
+fn read_word(input: List(String), acc: List(String)) -> #(String, List(String)) {
+  case input {
+    [g, ..rest] ->
+      case is_alnum_or_underscore(g) {
+        True -> read_word(rest, [g, ..acc])
+        False -> #(acc |> list.reverse |> string.concat, input)
+      }
+    [] -> #(acc |> list.reverse |> string.concat, [])
+  }
+}
+
+fn classify_word(word: String) -> Token {
+  let lowered = string.lowercase(word)
+  case is_sql_keyword(lowered) {
+    True -> Keyword(lowered)
+    False -> Ident(word)
+  }
+}
+
+fn is_sql_keyword(word: String) -> Bool {
+  case word {
+    "select"
+    | "from"
+    | "where"
+    | "and"
+    | "or"
+    | "not"
+    | "in"
+    | "is"
+    | "null"
+    | "as"
+    | "on"
+    | "join"
+    | "inner"
+    | "left"
+    | "right"
+    | "full"
+    | "outer"
+    | "cross"
+    | "natural"
+    | "using"
+    | "order"
+    | "by"
+    | "group"
+    | "having"
+    | "limit"
+    | "offset"
+    | "union"
+    | "intersect"
+    | "except"
+    | "all"
+    | "distinct"
+    | "insert"
+    | "into"
+    | "values"
+    | "update"
+    | "set"
+    | "delete"
+    | "create"
+    | "table"
+    | "view"
+    | "type"
+    | "index"
+    | "alter"
+    | "drop"
+    | "if"
+    | "exists"
+    | "primary"
+    | "key"
+    | "foreign"
+    | "references"
+    | "unique"
+    | "check"
+    | "default"
+    | "constraint"
+    | "cascade"
+    | "restrict"
+    | "no"
+    | "action"
+    | "autoincrement"
+    | "serial"
+    | "bigserial"
+    | "smallserial"
+    | "returning"
+    | "case"
+    | "when"
+    | "then"
+    | "else"
+    | "end"
+    | "cast"
+    | "between"
+    | "like"
+    | "ilike"
+    | "with"
+    | "recursive"
+    | "temporary"
+    | "temp"
+    | "unlogged"
+    | "true"
+    | "false"
+    | "asc"
+    | "desc"
+    | "nulls"
+    | "first"
+    | "last"
+    | "over"
+    | "partition"
+    | "window"
+    | "row"
+    | "rows"
+    | "range"
+    | "preceding"
+    | "following"
+    | "current"
+    | "unbounded"
+    | "enum"
+    | "replace"
+    | "conflict"
+    | "do"
+    | "nothing"
+    | "begin"
+    | "commit"
+    | "rollback"
+    | "transaction"
+    | "for"
+    | "each"
+    | "trigger"
+    | "execute"
+    | "procedure"
+    | "function"
+    | "returns"
+    | "language"
+    | "volatile"
+    | "stable"
+    | "immutable"
+    | "security"
+    | "definer"
+    | "invoker"
+    | "grant"
+    | "revoke"
+    | "to"
+    | "schema"
+    | "database"
+    | "extension"
+    | "only"
+    | "lateral"
+    | "any"
+    | "some"
+    | "array"
+    | "of"
+    | "collate"
+    | "coalesce"
+    | "greatest"
+    | "least"
+    | "count"
+    | "sum"
+    | "avg"
+    | "min"
+    | "max"
+    | "row_number"
+    | "rank"
+    | "dense_rank"
+    | "ntile"
+    | "lag"
+    | "lead"
+    | "first_value"
+    | "last_value"
+    | "nth_value" -> True
+    _ -> False
+  }
+}
+
+// --- Number helpers ---
+
+fn read_number(
+  input: List(String),
+  acc: List(String),
+) -> #(String, List(String)) {
+  case input {
+    [g, ..rest] ->
+      case is_digit(g) || g == "." {
+        True -> read_number(rest, [g, ..acc])
+        False ->
+          case g == "e" || g == "E" {
+            True ->
+              case rest {
+                ["+", ..] | ["-", ..] ->
+                  read_number(list.drop(rest, 1), [
+                    case rest {
+                      [s, ..] -> s
+                      _ -> ""
+                    },
+                    g,
+                    ..acc
+                  ])
+                _ -> read_number(rest, [g, ..acc])
+              }
+            False -> #(acc |> list.reverse |> string.concat, input)
+          }
+      }
+    [] -> #(acc |> list.reverse |> string.concat, [])
+  }
+}
+
+// --- Placeholder helpers ---
+
+fn read_placeholder_or_ident(input: List(String)) -> #(Token, List(String)) {
+  case input {
+    ["$", ..rest] -> {
+      let #(word, remaining) = read_word(rest, ["$"])
+      #(Placeholder(word), remaining)
+    }
+    _ -> #(Operator("$"), input)
+  }
+}
+
+fn read_placeholder_question(
+  input: List(String),
+  acc: List(String),
+) -> #(String, List(String)) {
+  case input {
+    [g, ..rest] ->
+      case is_digit(g) {
+        True -> read_placeholder_question(rest, [g, ..acc])
+        False -> #(acc |> list.reverse |> string.concat, input)
+      }
+    [] -> #(acc |> list.reverse |> string.concat, [])
+  }
+}
+
+// --- Operator helpers ---
+
+fn read_operator(input: List(String)) -> #(String, List(String)) {
+  case input {
+    // Multi-char operators
+    ["<", ">", ..rest] -> #("<>", rest)
+    ["<", "=", ..rest] -> #("<=", rest)
+    [">", "=", ..rest] -> #(">=", rest)
+    ["!", "=", ..rest] -> #("!=", rest)
+    ["|", "|", ..rest] -> #("||", rest)
+    ["-", ">", ">", ..rest] -> #("->>", rest)
+    ["-", ">", ..rest] -> #("->", rest)
+    // Single-char operators
+    [g, ..rest] -> #(g, rest)
+    [] -> #("", [])
+  }
+}
+
+// --- Character classification ---
+
+fn is_digit(g: String) -> Bool {
+  case g {
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
+    _ -> False
+  }
+}
+
+fn is_alpha_or_underscore(g: String) -> Bool {
+  is_alpha(g) || g == "_"
+}
+
+fn is_alnum_or_underscore(g: String) -> Bool {
+  is_alpha(g) || is_digit(g) || g == "_"
+}
+
+fn is_alpha(g: String) -> Bool {
+  let cp = case string.to_utf_codepoints(g) {
+    [cp] -> string.utf_codepoint_to_int(cp)
+    _ -> 0
+  }
+  { cp >= 65 && cp <= 90 } || { cp >= 97 && cp <= 122 }
+}

--- a/test/lexer_test.gleam
+++ b/test/lexer_test.gleam
@@ -1,0 +1,372 @@
+import gleeunit
+import gleeunit/should
+import sqlode/lexer.{
+  Comma, Dot, Ident, Keyword, LParen, NumberLit, Operator, Placeholder,
+  QuotedIdent, RParen, Semicolon, Star, StringLit,
+}
+import sqlode/model
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// --- Basic token tests ---
+
+pub fn simple_select_test() {
+  lexer.tokenize("SELECT id, name FROM authors;", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    Ident("id"),
+    Comma,
+    Ident("name"),
+    Keyword("from"),
+    Ident("authors"),
+    Semicolon,
+  ])
+}
+
+pub fn select_star_test() {
+  lexer.tokenize("SELECT * FROM users", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    Star,
+    Keyword("from"),
+    Ident("users"),
+  ])
+}
+
+pub fn create_table_test() {
+  lexer.tokenize(
+    "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("create"),
+    Keyword("table"),
+    Ident("authors"),
+    LParen,
+    Ident("id"),
+    Keyword("bigserial"),
+    Keyword("primary"),
+    Keyword("key"),
+    Comma,
+    Ident("name"),
+    Ident("TEXT"),
+    Keyword("not"),
+    Keyword("null"),
+    RParen,
+    Semicolon,
+  ])
+}
+
+// --- String literal tests ---
+
+pub fn string_literal_test() {
+  lexer.tokenize("SELECT 'hello world'", model.PostgreSQL)
+  |> should.equal([Keyword("select"), StringLit("hello world")])
+}
+
+pub fn escaped_single_quote_test() {
+  lexer.tokenize("SELECT 'it''s'", model.PostgreSQL)
+  |> should.equal([Keyword("select"), StringLit("it's")])
+}
+
+pub fn dollar_quoted_string_postgresql_test() {
+  lexer.tokenize("SELECT $$hello 'world' -- not comment$$", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    StringLit("hello 'world' -- not comment"),
+  ])
+}
+
+// --- Comment tests ---
+
+pub fn line_comment_stripped_test() {
+  lexer.tokenize(
+    "SELECT id -- this is a comment\nFROM authors",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("select"),
+    Ident("id"),
+    Keyword("from"),
+    Ident("authors"),
+  ])
+}
+
+pub fn block_comment_stripped_test() {
+  lexer.tokenize("SELECT /* comment */ id FROM authors", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    Ident("id"),
+    Keyword("from"),
+    Ident("authors"),
+  ])
+}
+
+pub fn nested_block_comment_test() {
+  lexer.tokenize(
+    "SELECT /* outer /* inner */ still outer */ id FROM authors",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("select"),
+    Ident("id"),
+    Keyword("from"),
+    Ident("authors"),
+  ])
+}
+
+pub fn mysql_hash_comment_test() {
+  lexer.tokenize("SELECT id # comment\nFROM users", model.MySQL)
+  |> should.equal([
+    Keyword("select"),
+    Ident("id"),
+    Keyword("from"),
+    Ident("users"),
+  ])
+}
+
+// --- Quoted identifier tests ---
+
+pub fn double_quoted_identifier_postgresql_test() {
+  lexer.tokenize("SELECT \"user\" FROM \"my table\"", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    QuotedIdent("user"),
+    Keyword("from"),
+    QuotedIdent("my table"),
+  ])
+}
+
+pub fn backtick_identifier_mysql_test() {
+  lexer.tokenize("SELECT `order` FROM `my table`", model.MySQL)
+  |> should.equal([
+    Keyword("select"),
+    QuotedIdent("order"),
+    Keyword("from"),
+    QuotedIdent("my table"),
+  ])
+}
+
+pub fn bracket_identifier_sqlite_test() {
+  lexer.tokenize("SELECT [order] FROM [my table]", model.SQLite)
+  |> should.equal([
+    Keyword("select"),
+    QuotedIdent("order"),
+    Keyword("from"),
+    QuotedIdent("my table"),
+  ])
+}
+
+// --- Placeholder tests ---
+
+pub fn postgresql_placeholder_test() {
+  lexer.tokenize("WHERE id = $1 AND name = $2", model.PostgreSQL)
+  |> should.equal([
+    Keyword("where"),
+    Ident("id"),
+    Operator("="),
+    Placeholder("$1"),
+    Keyword("and"),
+    Ident("name"),
+    Operator("="),
+    Placeholder("$2"),
+  ])
+}
+
+pub fn mysql_placeholder_test() {
+  lexer.tokenize("WHERE id = ?", model.MySQL)
+  |> should.equal([
+    Keyword("where"),
+    Ident("id"),
+    Operator("="),
+    Placeholder("?"),
+  ])
+}
+
+pub fn sqlite_named_placeholder_test() {
+  lexer.tokenize("WHERE id = :user_id AND name = @name", model.SQLite)
+  |> should.equal([
+    Keyword("where"),
+    Ident("id"),
+    Operator("="),
+    Placeholder(":user_id"),
+    Keyword("and"),
+    Ident("name"),
+    Operator("="),
+    Placeholder("@name"),
+  ])
+}
+
+pub fn sqlite_numbered_placeholder_test() {
+  lexer.tokenize("WHERE id = ?1", model.SQLite)
+  |> should.equal([
+    Keyword("where"),
+    Ident("id"),
+    Operator("="),
+    Placeholder("?1"),
+  ])
+}
+
+// --- Operator tests ---
+
+pub fn postgresql_typecast_test() {
+  lexer.tokenize("$1::int", model.PostgreSQL)
+  |> should.equal([Placeholder("$1"), Operator("::"), Ident("int")])
+}
+
+pub fn comparison_operators_test() {
+  lexer.tokenize("a >= b AND c <> d", model.PostgreSQL)
+  |> should.equal([
+    Ident("a"),
+    Operator(">="),
+    Ident("b"),
+    Keyword("and"),
+    Ident("c"),
+    Operator("<>"),
+    Ident("d"),
+  ])
+}
+
+pub fn json_operators_test() {
+  lexer.tokenize("data->>'key'", model.PostgreSQL)
+  |> should.equal([
+    Ident("data"),
+    Operator("->>"),
+    StringLit("key"),
+  ])
+}
+
+// --- Number tests ---
+
+pub fn integer_literal_test() {
+  lexer.tokenize("SELECT 42", model.PostgreSQL)
+  |> should.equal([Keyword("select"), NumberLit("42")])
+}
+
+pub fn float_literal_test() {
+  lexer.tokenize("SELECT 3.14", model.PostgreSQL)
+  |> should.equal([Keyword("select"), NumberLit("3.14")])
+}
+
+// --- Schema-qualified identifier tests ---
+
+pub fn schema_qualified_table_test() {
+  lexer.tokenize("SELECT * FROM public.users", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    Star,
+    Keyword("from"),
+    Ident("public"),
+    Dot,
+    Ident("users"),
+  ])
+}
+
+// --- Complex SQL tests ---
+
+pub fn semicolon_in_string_literal_test() {
+  lexer.tokenize("INSERT INTO t VALUES ('a;b;c')", model.PostgreSQL)
+  |> should.equal([
+    Keyword("insert"),
+    Keyword("into"),
+    Ident("t"),
+    Keyword("values"),
+    LParen,
+    StringLit("a;b;c"),
+    RParen,
+  ])
+}
+
+pub fn comment_in_create_table_test() {
+  lexer.tokenize(
+    "CREATE TABLE t (\n  id INT, -- primary key\n  name TEXT\n);",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("create"),
+    Keyword("table"),
+    Ident("t"),
+    LParen,
+    Ident("id"),
+    Ident("INT"),
+    Comma,
+    Ident("name"),
+    Ident("TEXT"),
+    RParen,
+    Semicolon,
+  ])
+}
+
+pub fn subquery_tokens_test() {
+  lexer.tokenize(
+    "SELECT * FROM (SELECT id FROM users) AS sub",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("select"),
+    Star,
+    Keyword("from"),
+    LParen,
+    Keyword("select"),
+    Ident("id"),
+    Keyword("from"),
+    Ident("users"),
+    RParen,
+    Keyword("as"),
+    Ident("sub"),
+  ])
+}
+
+pub fn create_temporary_table_test() {
+  lexer.tokenize("CREATE TEMPORARY TABLE tmp (id INT)", model.PostgreSQL)
+  |> should.equal([
+    Keyword("create"),
+    Keyword("temporary"),
+    Keyword("table"),
+    Ident("tmp"),
+    LParen,
+    Ident("id"),
+    Ident("INT"),
+    RParen,
+  ])
+}
+
+pub fn enum_with_escaped_quotes_test() {
+  lexer.tokenize(
+    "CREATE TYPE status AS ENUM ('it''s', 'ok');",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("create"),
+    Keyword("type"),
+    Ident("status"),
+    Keyword("as"),
+    Keyword("enum"),
+    LParen,
+    StringLit("it's"),
+    Comma,
+    StringLit("ok"),
+    RParen,
+    Semicolon,
+  ])
+}
+
+pub fn mysql_double_quote_as_string_test() {
+  lexer.tokenize("SELECT \"hello\"", model.MySQL)
+  |> should.equal([Keyword("select"), StringLit("hello")])
+}
+
+pub fn table_alias_tokens_test() {
+  lexer.tokenize("SELECT u.name FROM users u", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    Ident("u"),
+    Dot,
+    Ident("name"),
+    Keyword("from"),
+    Ident("users"),
+    Ident("u"),
+  ])
+}


### PR DESCRIPTION
## Summary

Introduce a proper SQL lexer (`src/sqlode/lexer.gleam`) that tokenizes SQL strings into semantic token lists, handling all three supported engines (PostgreSQL, MySQL, SQLite). This is Phase 1 of the parser infrastructure overhaul (#203). The lexer is additive — existing regex-based parsing continues to work unchanged; migration will happen in subsequent PRs.

## Changes

- `src/sqlode/lexer.gleam`: New 580-line hand-written state machine lexer with:
  - **Token types**: `Keyword`, `Ident`, `QuotedIdent`, `StringLit`, `NumberLit`, `Placeholder`, `Operator`, `LParen`, `RParen`, `Comma`, `Semicolon`, `Dot`, `Star`
  - **Comment stripping**: `--` line comments, `/* */` block comments (with nesting support), MySQL `#` comments
  - **String literals**: Single-quoted with `''` escape, PostgreSQL `$$dollar$$` quoted strings
  - **Quoted identifiers**: PostgreSQL `"..."`, MySQL `` `...` ``, SQLite `[...]`
  - **Placeholders**: PostgreSQL `$N`, MySQL `?`, SQLite `?N`, `:name`, `@name`, `$name`
  - **Operators**: Multi-char operators (`::`, `<>`, `>=`, `<=`, `!=`, `||`, `->`, `->>`)
  - **Keyword classification**: 130+ SQL keywords recognized and lowercased
- `test/lexer_test.gleam`: 30 tests covering all token types, all three engines, edge cases (semicolons in strings, comments in DDL, nested block comments, escaped quotes, subquery structure, schema-qualified identifiers, table aliases)

## Design Decisions

- Hand-written state machine over parser combinator library (nibble) — simpler dependency story, better performance for the tokenization use case, and easier to debug
- Keywords are lowercased on output; identifiers preserve original case — downstream parsers can match keywords case-insensitively while preserving identifier casing
- Engine parameter controls dialect-specific behavior: `$$` strings (PostgreSQL only), `#` comments (MySQL only), `[...]` identifiers (SQLite only), `"..."` as string vs identifier (MySQL vs PostgreSQL/SQLite)
- Comments are stripped during lexing, not emitted as tokens — simplifies all downstream consumers

## Limitations

- PostgreSQL `E'...'` escape strings not yet supported (standard `'...'` with `''` escape is supported)
- Tagged dollar quotes (`$tag$...$tag$`) not yet supported (only `$$...$$`)
- This PR does not migrate any existing code to use the lexer — that is Phase 2-4 of #203

Relates to #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL lexer for tokenizing SQL statements across multiple database engines (PostgreSQL, MySQL, SQLite)
  * Supports parsing keywords, identifiers, string literals, numeric values, operators, comments, and parameter placeholders
  * Handles dialect-specific syntax variations including quoted identifiers and escape sequences

* **Tests**
  * Added comprehensive test suite covering lexer functionality across all SQL dialects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->