### PR TITLE
fix(docs): remove rejected 'package' key from README YAML examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ sql:
     engine: "postgresql"
     gen:
       gleam:
-        package: "db"
         out: "src/db"
         runtime: "raw"
 ```
@@ -194,7 +193,6 @@ MySQL adapter generation is not available. MySQL works with `runtime: "raw"` onl
 ```yaml
 gen:
   gleam:
-    package: "db"
     out: "src/db"
     runtime: "native"
 ```
@@ -427,7 +425,6 @@ sql:
     engine: "postgresql"
     gen:
       gleam:
-        package: "db"
         out: "src/db"
     overrides:
       types:
@@ -475,7 +472,6 @@ By default, sqlode maps UUID, JSON, DATE, TIME, and TIMESTAMP columns to `String
 ```yaml
 gen:
   gleam:
-    package: "db"
     out: "src/db"
     type_mapping: "rich"
 ```
@@ -528,7 +524,6 @@ sqlode follows sqlc conventions, so most SQL files work without changes. Key dif
    ```yaml
    gen:
      gleam:
-       package: "db"
        out: "src/db"
        runtime: "raw"   # or "native" for full adapter generation
    ```


### PR DESCRIPTION
## Summary

Remove the `package: "db"` key from all 5 YAML config examples in README.md. This key is not in the accepted keys list (`config.gleam` line 118-124) and causes an `UnsupportedFields` error when users copy examples directly from the README.

## Changes

- `README.md`: Remove `package: "db"` from all 5 YAML examples (lines 59, 197, 430, 478, 531)

## Design Decisions

Removed the key entirely rather than adding it to the accepted-but-ignored keys list, since `package` has no effect on code generation (imports are derived from `out` via `common.out_to_module_path`). This matches the `sqlode init` template which does not include `package`.

Closes #194