### PR TITLE
refactor(analyzer): migrate param inferencer to lexer-based multi-table support (Phase 4 of #203)

### DIFF
--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -1,9 +1,10 @@
 import gleam/dict
 import gleam/int
 import gleam/list
-import gleam/option.{None, Some}
+import gleam/option.{type Option, None, Some}
 import gleam/regexp
 import gleam/string
+import sqlode/lexer
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer/context.{type AnalyzerContext}
@@ -94,15 +95,17 @@ pub fn infer_equality_params(
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
   let normalized = context.normalize_sql(ctx, query.sql)
-  let table_name = context.primary_table_name(ctx, normalized)
+  let tokens = lexer.tokenize(query.sql, engine)
+  let all_tables = tok_extract_table_names(tokens)
 
-  case table_name {
-    None -> []
-    Some(name) ->
+  case all_tables {
+    [] -> []
+    [primary, ..] ->
       scan_equality_matches(
         engine,
         catalog,
-        name,
+        primary,
+        all_tables,
         regexp.scan(ctx.equality_re, normalized),
         1,
         [],
@@ -114,7 +117,8 @@ pub fn infer_equality_params(
 fn scan_equality_matches(
   engine: model.Engine,
   catalog: model.Catalog,
-  table_name: String,
+  primary_table: String,
+  all_tables: List(String),
   matches: List(regexp.Match),
   occurrence: Int,
   acc: List(#(Int, model.Column)),
@@ -123,21 +127,41 @@ fn scan_equality_matches(
     [] -> acc
     [match, ..rest] ->
       case match.submatches {
-        [Some(column_name), Some(token)] -> {
+        [Some(column_ref), Some(token)] -> {
+          // Handle table.column qualified references
+          let #(search_table, col_name) = case
+            string.split_once(column_ref, ".")
+          {
+            Ok(#(table_prefix, column)) -> #(
+              Some(string.trim(table_prefix)),
+              string.trim(column),
+            )
+            Error(_) -> #(None, column_ref)
+          }
+          let normalized_col = naming.normalize_identifier(col_name)
+
           let acc = case
             placeholder.placeholder_index_for_token(engine, token, occurrence)
           {
-            Some(index) ->
-              case
-                context.find_column(
-                  catalog,
-                  table_name,
-                  naming.normalize_identifier(column_name),
-                )
-              {
-                Some(column) -> [#(index, column), ..acc]
-                None -> acc
+            Some(index) -> {
+              let found = case search_table {
+                Some(table) ->
+                  context.find_column(catalog, table, normalized_col)
+                None ->
+                  find_column_in_tables(catalog, all_tables, normalized_col)
               }
+              case found {
+                Some(column) -> [#(index, column), ..acc]
+                None ->
+                  // Fallback: try primary table
+                  case
+                    context.find_column(catalog, primary_table, normalized_col)
+                  {
+                    Some(column) -> [#(index, column), ..acc]
+                    None -> acc
+                  }
+              }
+            }
             None -> acc
           }
 
@@ -151,7 +175,8 @@ fn scan_equality_matches(
           scan_equality_matches(
             engine,
             catalog,
-            table_name,
+            primary_table,
+            all_tables,
             rest,
             next_occurrence,
             acc,
@@ -161,7 +186,8 @@ fn scan_equality_matches(
           scan_equality_matches(
             engine,
             catalog,
-            table_name,
+            primary_table,
+            all_tables,
             rest,
             occurrence,
             acc,
@@ -177,15 +203,17 @@ pub fn infer_in_params(
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
   let normalized = context.normalize_sql(ctx, query.sql)
-  let table_name = context.primary_table_name(ctx, normalized)
+  let tokens = lexer.tokenize(query.sql, engine)
+  let all_tables = tok_extract_table_names(tokens)
 
-  case table_name {
-    None -> []
-    Some(name) ->
+  case all_tables {
+    [] -> []
+    [primary, ..] ->
       scan_equality_matches(
         engine,
         catalog,
-        name,
+        primary,
+        all_tables,
         regexp.scan(ctx.in_clause_re, normalized),
         1,
         [],
@@ -230,4 +258,88 @@ pub fn extract_type_casts(
 
 fn cast_type_to_scalar(type_name: String) -> Result(model.ScalarType, Nil) {
   model.parse_sql_type(string.trim(type_name))
+}
+
+// --- Token-based helpers ---
+
+/// Search all tables for a column by name.
+fn find_column_in_tables(
+  catalog: model.Catalog,
+  table_names: List(String),
+  column_name: String,
+) -> Option(model.Column) {
+  list.find_map(table_names, fn(name) {
+    case context.find_column(catalog, name, column_name) {
+      Some(col) -> Ok(col)
+      None -> Error(Nil)
+    }
+  })
+  |> option.from_result
+}
+
+/// Extract table names from tokens (FROM/JOIN/INTO/UPDATE).
+fn tok_extract_table_names(tokens: List(lexer.Token)) -> List(String) {
+  tok_table_names_loop(tokens, [])
+  |> list.unique
+}
+
+fn tok_table_names_loop(
+  tokens: List(lexer.Token),
+  acc: List(String),
+) -> List(String) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
+      let remaining = tok_skip_parens(rest, 1)
+      tok_table_names_loop(remaining, acc)
+    }
+    [lexer.Keyword(kw), ..rest]
+      if kw == "from" || kw == "into" || kw == "update"
+    -> {
+      let #(name, remaining) = tok_read_table_name(rest)
+      case name {
+        Some(n) -> tok_table_names_loop(remaining, [n, ..acc])
+        None -> tok_table_names_loop(rest, acc)
+      }
+    }
+    [lexer.Keyword("join"), ..rest] -> {
+      let #(name, remaining) = tok_read_table_name(rest)
+      case name {
+        Some(n) -> tok_table_names_loop(remaining, [n, ..acc])
+        None -> tok_table_names_loop(rest, acc)
+      }
+    }
+    [_, ..rest] -> tok_table_names_loop(rest, acc)
+  }
+}
+
+fn tok_read_table_name(
+  tokens: List(lexer.Token),
+) -> #(Option(String), List(lexer.Token)) {
+  case tokens {
+    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), ..rest] -> #(
+      Some(string.lowercase(name)),
+      rest,
+    )
+    [lexer.Ident(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    [lexer.QuotedIdent(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    [lexer.LParen, ..rest] -> {
+      let remaining = tok_skip_parens(rest, 1)
+      #(None, remaining)
+    }
+    _ -> #(None, tokens)
+  }
+}
+
+fn tok_skip_parens(tokens: List(lexer.Token), depth: Int) -> List(lexer.Token) {
+  case depth <= 0 {
+    True -> tokens
+    False ->
+      case tokens {
+        [] -> []
+        [lexer.LParen, ..rest] -> tok_skip_parens(rest, depth + 1)
+        [lexer.RParen, ..rest] -> tok_skip_parens(rest, depth - 1)
+        [_, ..rest] -> tok_skip_parens(rest, depth)
+      }
+  }
 }


### PR DESCRIPTION
## Summary

Migrate the parameter inferencer from single-table regex-based extraction to lexer-based multi-table resolution. This fixes #191 where parameter type inference failed for JOIN table columns in WHERE clauses.

## Changes

- `src/sqlode/query_analyzer/param_inferencer.gleam`:
  - `infer_equality_params`: Use `tok_extract_table_names` (lexer-based) to get all tables including JOINed ones, replacing `context.primary_table_name` which only returned the first table
  - `infer_in_params`: Same multi-table improvement
  - `scan_equality_matches`: Now takes `all_tables` parameter and supports `table.column` qualified references — splits on `.` to extract table prefix, searches that table first, then falls back to all tables
  - Add `find_column_in_tables` helper to search across all tables for a column
  - Add `tok_extract_table_names`, `tok_table_names_loop`, `tok_read_table_name`, `tok_skip_parens` token-based helpers (same pattern as column_inferencer)

## What This Fixes

- **#191**: `WHERE authors.name = $2` in a JOIN query now correctly resolves `$2` type from the `authors` table, not just the primary table
- `table.column` qualified references are recognized and searched in the correct table
- Unqualified column references are searched across all tables (primary + JOINed)
- Subqueries in FROM (`FROM (SELECT ...)`) are correctly skipped during table extraction

## Design Decisions

- Token-based table extraction is duplicated from column_inferencer rather than shared. Both modules need the same logic but extracting a shared module would add coupling. This can be consolidated in a future refactoring pass.
- `extract_type_casts` and `infer_insert_params` still use regex — they don't have the multi-table problem (INSERT targets a single table, type casts are table-independent)

Relates to #203
Fixes #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL parameter inference for queries with qualified column references (e.g., `table.column`).
  * Enhanced parameter detection accuracy in complex multi-table queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->