### PR TITLE
fix(analyzer): expand SELECT * to include columns from all joined tables

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -118,25 +118,29 @@ fn resolve_select_columns(
   nullable_tables: List(String),
 ) -> Result(List(model.ResultColumn), AnalysisError) {
   case columns {
-    [ExtractedColumn(name: "*", ..)] ->
-      case
-        catalog.tables
-        |> list.find(fn(table) { table.name == primary_table })
-      {
-        Ok(table) ->
-          Ok(
-            list.map(table.columns, fn(col) {
-              model.ResultColumn(
-                name: col.name,
-                scalar_type: col.scalar_type,
-                nullable: col.nullable
-                  || list.contains(nullable_tables, primary_table),
-                source_table: Some(primary_table),
-              )
-            }),
-          )
-        Error(_) -> Error(TableNotFound(query_name:, table_name: primary_table))
+    [ExtractedColumn(name: "*", ..)] -> {
+      let result_columns =
+        all_tables
+        |> list.flat_map(fn(table_name) {
+          case list.find(catalog.tables, fn(t) { t.name == table_name }) {
+            Ok(table) ->
+              list.map(table.columns, fn(col) {
+                model.ResultColumn(
+                  name: col.name,
+                  scalar_type: col.scalar_type,
+                  nullable: col.nullable
+                    || list.contains(nullable_tables, table_name),
+                  source_table: Some(table_name),
+                )
+              })
+            Error(_) -> []
+          }
+        })
+      case result_columns {
+        [] -> Error(TableNotFound(query_name:, table_name: primary_table))
+        _ -> Ok(result_columns)
       }
+    }
     _ ->
       list.try_map(columns, fn(extracted) {
         let trimmed = string.trim(extracted.name)


### PR DESCRIPTION
## Summary

Fix `SELECT *` to expand columns from all tables in the query (primary + JOINed), not just the primary table. Previously, `SELECT * FROM posts JOIN authors ON ...` only returned `posts` columns, silently dropping `authors` columns.

## Changes

- `src/sqlode/query_analyzer/column_inferencer.gleam` lines 120-140: Replace single-table expansion with `all_tables` iteration using `list.flat_map`. Each table's columns are expanded with correct nullable flags based on `nullable_tables`.

## Design Decisions

- Tables that don't exist in the catalog are silently skipped (empty list) rather than causing an error — this is lenient for cases like table aliases or CTEs that aren't in the schema catalog
- If no columns are found at all (no tables matched), `TableNotFound` error is returned with the primary table name
- Column order follows table order in `all_tables` (primary first, then JOINed tables in order), matching sqlc behavior

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced wildcard column resolution to properly aggregate columns from all resolvable tables in a query, instead of only the primary table, improving accuracy of column identification in multi-table SQL queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->