### PR TITLE
fix(analyzer): infer CASE expression type from first THEN branch

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -308,7 +308,7 @@ fn infer_expression_type_dispatch(
         }
         Error(_) -> #(model.StringType, True)
       }
-    Some(InferCase) -> #(model.StringType, True)
+    Some(InferCase) -> infer_case_type(lowered, catalog, table_names)
     Some(InferStringLiteral) -> #(model.StringType, False)
     None ->
       case is_integer_literal(lowered) {
@@ -406,6 +406,43 @@ fn extract_first_csv_arg(
     [")", ..rest] -> extract_first_csv_arg(rest, depth - 1, [")", ..acc])
     [",", ..] if depth == 0 -> acc |> list.reverse |> string.concat
     [c, ..rest] -> extract_first_csv_arg(rest, depth, [c, ..acc])
+  }
+}
+
+/// Infer type from CASE expression by examining the first THEN branch.
+fn infer_case_type(
+  lowered: String,
+  catalog: model.Catalog,
+  table_names: List(String),
+) -> #(model.ScalarType, Bool) {
+  // Extract the first THEN value from "case when ... then <value> ..."
+  case string.split_once(lowered, " then ") {
+    Ok(#(_, after_then)) -> {
+      // The value extends until WHEN, ELSE, or END
+      let value_text =
+        after_then
+        |> split_before_keyword([" when ", " else ", " end"])
+        |> string.trim
+      case value_text {
+        "" -> #(model.StringType, True)
+        _ ->
+          infer_expression_type_dispatch(value_text, catalog, table_names)
+          |> fn(result) { #(result.0, True) }
+      }
+    }
+    Error(_) -> #(model.StringType, True)
+  }
+}
+
+/// Split string before the first occurrence of any keyword.
+fn split_before_keyword(s: String, keywords: List(String)) -> String {
+  case keywords {
+    [] -> s
+    [kw, ..rest] ->
+      case string.split_once(s, kw) {
+        Ok(#(before, _)) -> split_before_keyword(before, rest)
+        Error(_) -> split_before_keyword(s, rest)
+      }
   }
 }
 


### PR DESCRIPTION
## Summary

Fix CASE expression type inference to examine the first THEN branch value instead of always defaulting to `StringType`. `CASE WHEN x THEN 1 ELSE 0 END` now correctly infers `IntType`.

## Changes

- `src/sqlode/query_analyzer/column_inferencer.gleam`:
  - Replace `Some(InferCase) -> #(model.StringType, True)` with `infer_case_type(lowered, catalog, table_names)`
  - Add `infer_case_type` — extracts the first THEN value and recursively calls `infer_expression_type_dispatch` on it
  - Add `split_before_keyword` — splits text before the first occurrence of WHEN/ELSE/END keywords to isolate the THEN value
  - CASE results are always nullable (True) since conditional expressions can produce different types per branch

## Examples

| Expression | Before | After |
|-----------|--------|-------|
| `CASE WHEN x THEN 1 ELSE 0 END` | `StringType` | `IntType` |
| `CASE WHEN x THEN 'a' ELSE 'b' END` | `StringType` | `StringType` |
| `CASE WHEN x THEN true ELSE false END` | `StringType` | `BoolType` |
| `CASE WHEN x THEN count(*) ELSE 0 END` | `StringType` | `IntType` |

Closes #193