### PR TITLE
feat(model): add missing PostgreSQL types (INTERVAL, MONEY, CITEXT, network, geometric, FTS)

### DIFF
--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -224,16 +224,29 @@ pub fn parse_sql_type(type_text: String) -> Result(ScalarType, Nil) {
   }
   // Order matters: check more specific patterns before general ones
   // (e.g. "timestamp"/"datetime" before "time"/"date", "jsonb" before "json")
+  // Order matters: more specific patterns must come before general ones.
+  // "interval" before "int" (interval contains "int" as substring).
+  // "point" before "int" (point contains "int" as substring).
+  // "timestamp"/"datetime" before "time"/"date".
+  // "jsonb" before "json".
   let type_rules = [
-    #(["int", "serial"], IntType),
-    #(["double", "real", "float", "numeric", "decimal"], FloatType),
+    #(["double", "real", "float", "numeric", "decimal", "money"], FloatType),
     #(["bool"], BoolType),
     #(["bytea", "blob", "binary"], BytesType),
     #(["uuid"], UuidType),
     #(["jsonb", "json"], JsonType),
     #(["timestamp", "datetime"], DateTimeType),
     #(["date"], DateType),
-    #(["timetz", "time"], TimeType),
+    #(["timetz", "interval"], TimeType),
+    #(
+      [
+        "citext", "inet", "cidr", "macaddr", "tsvector", "tsquery", "point",
+        "line", "lseg", "box", "path", "polygon", "circle", "xml", "bit",
+      ],
+      StringType,
+    ),
+    #(["int", "serial"], IntType),
+    #(["time"], TimeType),
     #(["text", "char", "clob", "name", "string"], StringType),
   ]
   case find_matching_type(base_type_text, type_rules) {

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -354,3 +354,57 @@ pub fn scalar_type_to_db_name_array_test() {
   model.scalar_type_to_db_name(model.ArrayType(model.IntType))
   |> should.equal("int[]")
 }
+
+// PostgreSQL-specific type tests
+
+pub fn parse_sql_type_interval_test() {
+  model.parse_sql_type("INTERVAL")
+  |> should.equal(Ok(model.TimeType))
+}
+
+pub fn parse_sql_type_money_test() {
+  model.parse_sql_type("MONEY")
+  |> should.equal(Ok(model.FloatType))
+}
+
+pub fn parse_sql_type_citext_test() {
+  model.parse_sql_type("CITEXT")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_inet_test() {
+  model.parse_sql_type("INET")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_cidr_test() {
+  model.parse_sql_type("CIDR")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_macaddr_test() {
+  model.parse_sql_type("MACADDR")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_tsvector_test() {
+  model.parse_sql_type("TSVECTOR")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_point_test() {
+  model.parse_sql_type("POINT")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_xml_test() {
+  model.parse_sql_type("XML")
+  |> should.equal(Ok(model.StringType))
+}
+
+pub fn parse_sql_type_bit_test() {
+  model.parse_sql_type("BIT")
+  |> should.equal(Ok(model.StringType))
+  model.parse_sql_type("BIT VARYING")
+  |> should.equal(Ok(model.StringType))
+}


### PR DESCRIPTION
## Summary

Add recognition for commonly used PostgreSQL types that previously caused "unrecognized SQL type" errors, blocking code generation for schemas using these types.

## Changes

- `src/sqlode/model.gleam`: Expand `type_rules` in `parse_sql_type` with new type mappings:
  - `MONEY` → `FloatType`
  - `INTERVAL` → `TimeType`
  - `CITEXT`, `XML`, `BIT`, `BIT VARYING` → `StringType`
  - Network types: `INET`, `CIDR`, `MACADDR` → `StringType`
  - Full-text search: `TSVECTOR`, `TSQUERY` → `StringType`
  - Geometric types: `POINT`, `LINE`, `LSEG`, `BOX`, `PATH`, `POLYGON`, `CIRCLE` → `StringType`
  - Reorder type rules to prevent substring conflicts (`INTERVAL` before `INT`, `POINT` before `INT`, `TIMETZ` before `TIME`)
- `test/model_test.gleam`: Add 10 tests for new type mappings

## Design Decisions

- Types without direct Gleam equivalents map to `StringType` (network addresses, geometric types, FTS types) — this ensures schemas parse without error while providing a usable Gleam type
- `MONEY` maps to `FloatType` rather than `StringType` since it represents a numeric value
- `INTERVAL` maps to `TimeType` since it represents a time duration (serialized as string by pog/sqlight)
- Rule ordering is critical: patterns containing `int` as substring (`interval`, `point`) must be checked before the `int` rule

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional PostgreSQL data types including `MONEY`, `CITEXT`, `INET`, `CIDR`, `MACADDR`, `TSVECTOR`, `POINT`, `XML`, `BIT`, and `BIT VARYING`.
  * Improved type classification for `INTERVAL` and time-related types.

* **Tests**
  * Added comprehensive test coverage for newly supported PostgreSQL type mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->