### PR TITLE
fix(model): replace sentinel empty strings with Option in type helper functions

### DIFF
--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import gleam/option
 import gleam/string
 import sqlode/codegen/common
 import sqlode/model
@@ -188,25 +189,26 @@ fn render_param_value(
       case param.nullable {
         True ->
           case unwrap {
-            "" ->
+            option.None ->
               "case "
               <> value_expr
               <> " { Some(value) -> "
               <> runtime_fn
               <> "(value) None -> runtime.null() }"
-            _ ->
+            option.Some(fn_name) ->
               "case "
               <> value_expr
               <> " { Some(value) -> "
               <> runtime_fn
               <> "("
-              <> unwrap
+              <> fn_name
               <> "(value)) None -> runtime.null() }"
           }
         False ->
           case unwrap {
-            "" -> runtime_fn <> "(" <> value_expr <> ")"
-            _ -> runtime_fn <> "(" <> unwrap <> "(" <> value_expr <> "))"
+            option.None -> runtime_fn <> "(" <> value_expr <> ")"
+            option.Some(fn_name) ->
+              runtime_fn <> "(" <> fn_name <> "(" <> value_expr <> "))"
           }
       }
     }
@@ -216,14 +218,14 @@ fn render_param_value(
 fn strong_unwrap_expr(
   scalar_type: model.ScalarType,
   type_mapping: model.TypeMapping,
-) -> String {
+) -> option.Option(String) {
   case type_mapping {
     model.StrongMapping ->
-      case model.is_rich_type(scalar_type) {
-        True -> "models." <> model.strong_type_unwrap_fn(scalar_type)
-        False -> ""
+      case model.strong_type_unwrap_fn(scalar_type) {
+        option.Some(fn_name) -> option.Some("models." <> fn_name)
+        option.None -> option.None
       }
-    _ -> ""
+    _ -> option.None
   }
 }
 
@@ -254,14 +256,15 @@ fn param_accessors_flattened(
           }
           _ ->
             case unwrap {
-              "" -> "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
-              _ ->
+              option.None ->
+                "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
+              option.Some(fn_name) ->
                 "list.map("
                 <> value_expr
                 <> ", fn(v) { "
                 <> runtime_fn
                 <> "("
-                <> unwrap
+                <> fn_name
                 <> "(v)) })"
             }
         }
@@ -286,29 +289,29 @@ fn param_accessors_flattened(
             case param.nullable {
               True ->
                 case unwrap {
-                  "" ->
+                  option.None ->
                     "[case "
                     <> value_expr
                     <> " { Some(value) -> "
                     <> runtime_fn
                     <> "(value) None -> runtime.null() }]"
-                  _ ->
+                  option.Some(fn_name) ->
                     "[case "
                     <> value_expr
                     <> " { Some(value) -> "
                     <> runtime_fn
                     <> "("
-                    <> unwrap
+                    <> fn_name
                     <> "(value)) None -> runtime.null() }]"
                 }
               False ->
                 case unwrap {
-                  "" -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
-                  _ ->
+                  option.None -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
+                  option.Some(fn_name) ->
                     "["
                     <> runtime_fn
                     <> "("
-                    <> unwrap
+                    <> fn_name
                     <> "("
                     <> value_expr
                     <> "))]"

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -324,15 +324,15 @@ pub fn is_rich_type(scalar_type: ScalarType) -> Bool {
 }
 
 /// Returns the unwrap function name for strong-typed semantic types.
-/// e.g. UuidType -> "sql_uuid_to_string"
-pub fn strong_type_unwrap_fn(scalar_type: ScalarType) -> String {
+/// e.g. UuidType -> Some("sql_uuid_to_string")
+pub fn strong_type_unwrap_fn(scalar_type: ScalarType) -> option.Option(String) {
   case scalar_type {
-    DateTimeType -> "sql_timestamp_to_string"
-    DateType -> "sql_date_to_string"
-    TimeType -> "sql_time_to_string"
-    UuidType -> "sql_uuid_to_string"
-    JsonType -> "sql_json_to_string"
-    _ -> ""
+    DateTimeType -> option.Some("sql_timestamp_to_string")
+    DateType -> option.Some("sql_date_to_string")
+    TimeType -> option.Some("sql_time_to_string")
+    UuidType -> option.Some("sql_uuid_to_string")
+    JsonType -> option.Some("sql_json_to_string")
+    _ -> option.None
   }
 }
 
@@ -346,7 +346,8 @@ pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
     DateTimeType | DateType | TimeType | UuidType | JsonType -> "runtime.string"
     EnumType(_) -> "runtime.string"
     CustomType(_, underlying) -> scalar_type_to_runtime_function(underlying)
-    ArrayType(_) -> ""
+    // ArrayType uses pog.array() in native adapter, not raw runtime encoding
+    ArrayType(element) -> scalar_type_to_runtime_function(element)
   }
 }
 

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -1,3 +1,4 @@
+import gleam/option
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -219,9 +220,13 @@ pub fn strong_type_uses_same_names_as_rich_test() {
 
 pub fn strong_type_unwrap_fn_test() {
   model.strong_type_unwrap_fn(model.UuidType)
-  |> should.equal("sql_uuid_to_string")
+  |> should.equal(option.Some("sql_uuid_to_string"))
   model.strong_type_unwrap_fn(model.JsonType)
-  |> should.equal("sql_json_to_string")
+  |> should.equal(option.Some("sql_json_to_string"))
+  model.strong_type_unwrap_fn(model.IntType)
+  |> should.equal(option.None)
+  model.strong_type_unwrap_fn(model.StringType)
+  |> should.equal(option.None)
 }
 
 // is_rich_type tests


### PR DESCRIPTION
## Summary

Replace sentinel empty string returns with proper `Option(String)` in `strong_type_unwrap_fn` and fix `scalar_type_to_runtime_function` for `ArrayType`. This follows Gleam idioms and prevents potential invalid code generation from empty string concatenation.

## Changes

- `src/sqlode/model.gleam`:
  - `strong_type_unwrap_fn` now returns `Option(String)` instead of `String` with `""` sentinel
  - `scalar_type_to_runtime_function` for `ArrayType` now delegates to element type instead of returning `""`
- `src/sqlode/codegen/params.gleam`:
  - `strong_unwrap_expr` returns `option.Option(String)` 
  - All call sites in `render_param_value` and `param_accessors_flattened` use `option.Some(fn_name)` / `option.None` instead of `"" -> ... _ -> ...`
- `test/model_test.gleam`:
  - Update `strong_type_unwrap_fn_test` to assert `Some("sql_uuid_to_string")` and `None` for non-rich types

## Design Decisions

- `ArrayType` in `scalar_type_to_runtime_function` now delegates to the element type (`ArrayType(IntType)` → `"runtime.int"`) instead of returning empty string. This is more correct since raw runtime encoding of array elements uses the element's runtime function.

Closes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code reliability by replacing sentinel string patterns with explicit Option types for type-safe unwrap function handling.
  * Enhanced array type conversion logic to properly delegate to native adapters rather than attempting raw encoding.
  * Strengthened type safety throughout code generation helpers with clearer intent representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->