### PR TITLE
fix(schema-parser): skip unresolved view columns instead of silent StringType fallback

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -314,13 +314,9 @@ fn parse_create_view(
                         "Warning: view column \""
                         <> normalized
                         <> "\" could not be resolved from source tables"
-                        <> " — defaulting to String (nullable).",
+                        <> " — skipping column.",
                       )
-                      Ok(model.Column(
-                        name: normalized,
-                        scalar_type: model.StringType,
-                        nullable: True,
-                      ))
+                      Error(Nil)
                     }
                   }
                 })

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -162,9 +162,10 @@ pub fn view_with_cast_expression_test() {
   let assert Ok(catalog) =
     schema_parser.parse_files([#("cast_view.sql", content)])
 
-  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
-  let col_names = list.map(view.columns, fn(c) { c.name })
-  col_names |> should.equal(["col_a", "col_b"])
+  // Aliased expression columns (col_a, col_b) cannot be resolved from source
+  // tables, so they are skipped with a warning. The view is omitted if empty.
+  let view_found = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  view_found |> should.be_error()
 }
 
 pub fn view_basic_select_test() {
@@ -190,7 +191,9 @@ pub fn view_with_alias_test() {
   let assert Ok(view) =
     list.find(catalog.tables, fn(tbl) { tbl.name == "user_names" })
   let col_names = list.map(view.columns, fn(c) { c.name })
-  col_names |> should.equal(["id", "display_name"])
+  // "display_name" alias cannot be resolved from source tables, so it is
+  // skipped. Only "id" (which matches a real column) is retained.
+  col_names |> should.equal(["id"])
 }
 
 pub fn view_star_test() {
@@ -221,12 +224,10 @@ pub fn view_nonexistent_table_test() {
   let assert Ok(catalog) =
     schema_parser.parse_files([#("noexist.sql", content)])
 
-  // View referencing nonexistent table still creates view with fallback types
-  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
-  let assert [col] = view.columns
-  col.name |> should.equal("id")
-  col.scalar_type |> should.equal(model.StringType)
-  col.nullable |> should.equal(True)
+  // View referencing nonexistent table: all columns are unresolvable and
+  // skipped, so the view itself is omitted (no columns → no table entry).
+  let view_found = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  view_found |> should.be_error()
 }
 
 pub fn error_to_string_invalid_column_test() {


### PR DESCRIPTION
## Summary

Change the schema parser to skip unresolved view columns with a warning instead of silently defaulting them to `StringType(nullable=True)`. This aligns with the project policy established in PR #179 of preferring early errors over silent fallback.

## Changes

- `src/sqlode/schema_parser.gleam`: In `parse_create_view`, change unresolved column handling from `Ok(model.Column(...StringType...))` to `Error(Nil)`, which causes `filter_map` to exclude the column. Warning message updated from "defaulting to String (nullable)" to "skipping column".
- `test/schema_parser_test.gleam`: Update 3 tests to match new behavior:
  - `view_with_cast_expression_test`: Aliased expression columns are skipped, view is omitted if empty
  - `view_with_alias_test`: Only columns matching real table columns are retained
  - `view_nonexistent_table_test`: All columns unresolvable, view is omitted entirely

## Design Decisions

- Skipping (not erroring) is the right balance: views with expression columns are common and shouldn't block generation. The warning clearly tells users which columns were dropped.
- Views with zero resolved columns produce no table entry (existing `case columns { [] -> None }` handles this).

Closes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved view schema parsing behavior when column references cannot be resolved from source tables. Unresolved columns are now omitted from the resulting view schema rather than being represented with a default inferred type, providing more accurate and consistent schema representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->