### PR TITLE
perf(runtime): replace O(n^2) list.append with prepend-and-reverse in expand_slice_placeholders

### DIFF
--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -134,10 +134,9 @@ pub fn expand_slice_placeholders(
                 from: next_new_idx,
                 to: next_new_idx + len,
                 with: [],
-                run: fn(items, i) {
-                  list.append(items, [prefix <> int.to_string(i)])
-                },
+                run: fn(items, i) { [prefix <> int.to_string(i), ..items] },
               )
+              |> list.reverse
               |> string.join(", ")
             #(next_new_idx + len, [#(orig_idx, expanded), ..map])
           }


### PR DESCRIPTION
## Summary
- Replace `list.append(items, [element])` with cons-prepend `[element, ..items]` followed by `list.reverse` in `expand_slice_placeholders`
- This eliminates O(n²) behavior when expanding large IN-clause slice placeholders, reducing it to O(n)

## Changes
- `src/sqlode/runtime.gleam`: Changed the inner `int.range` accumulator in Phase 2 of `expand_slice_placeholders` from `list.append(items, [prefix <> int.to_string(i)])` (O(n) per call, O(n²) total) to `[prefix <> int.to_string(i), ..items]` with a final `list.reverse` (O(1) per call, O(n) total)

## Design Decisions
- Used the idiomatic Gleam prepend-and-reverse pattern rather than introducing new dependencies
- Kept the existing `int.range` fold structure to minimize diff and preserve readability

Closes #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL placeholder generation to ensure correct ordering in query expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->