### PR TITLE
fix(generate): validate duplicate query names and fail with a clear error

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -31,6 +31,7 @@ pub type GenerateError {
     query_paths: List(String),
     schema_paths: List(String),
   )
+  DuplicateQueryName(name: String, paths: List(String))
   UnsupportedAnnotation(query_name: String, command: String, detail: String)
   WriteError(writer.WriteError)
 }
@@ -286,6 +287,27 @@ fn load_queries(
     })
   })
   |> result.map(list.flatten)
+  |> result.try(validate_no_duplicate_query_names)
+}
+
+fn validate_no_duplicate_query_names(
+  queries: List(model.ParsedQuery),
+) -> Result(List(model.ParsedQuery), GenerateError) {
+  let grouped =
+    list.group(queries, fn(q) { q.name })
+    |> dict.to_list
+    |> list.filter(fn(entry) { list.length(entry.1) > 1 })
+
+  case grouped {
+    [] -> Ok(queries)
+    [#(name, dupes), ..] -> {
+      let paths =
+        dupes
+        |> list.map(fn(q) { q.source_path })
+        |> list.unique
+      Error(DuplicateQueryName(name:, paths:))
+    }
+  }
 }
 
 fn apply_type_overrides(
@@ -646,6 +668,11 @@ pub fn error_to_string(error: GenerateError) -> String {
               "\n  Hint: Queries were parsed but none produced output. Check that your schema defines the tables referenced in your queries"
           }
       }
+    DuplicateQueryName(name:, paths:) ->
+      "duplicate query name \""
+      <> name
+      <> "\" found in: "
+      <> string.join(paths, ", ")
     UnsupportedAnnotation(query_name:, command:, detail:) ->
       "Query " <> query_name <> " uses " <> command <> ": " <> detail
     WriteError(inner) -> writer.error_to_string(inner)

--- a/test/fixtures/duplicate_query.sql
+++ b/test/fixtures/duplicate_query.sql
@@ -1,0 +1,8 @@
+-- name: GetAuthor :one
+SELECT id, name FROM authors WHERE id = $1;
+
+-- name: ListAuthors :many
+SELECT id, name FROM authors;
+
+-- name: GetAuthor :one
+SELECT id, name FROM authors WHERE name = $1;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1307,3 +1307,30 @@ pub fn mixed_file_and_directory_inputs_test() {
 
   cleanup_dir()
 }
+
+// --- Duplicate query name tests ---
+
+pub fn reject_duplicate_query_names_test() {
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/duplicate_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Error(error) = generate.generate_config(cfg)
+
+  generate.error_to_string(error)
+  |> string.contains("duplicate query name \"GetAuthor\"")
+  |> should.be_true
+}


### PR DESCRIPTION
## Summary
- Add validation to detect duplicate query names across SQL files within the same SQL block
- Emit a clear error message naming the duplicate and listing the source files, instead of letting the Gleam compiler fail with a confusing duplicate function name error

## Changes
- `src/sqlode/generate.gleam`: Add `DuplicateQueryName` error variant and `validate_no_duplicate_query_names` function that runs after all queries are loaded but before analysis
- `test/generate_test.gleam`: Add test for duplicate query name rejection
- `test/fixtures/duplicate_query.sql`: Test fixture with duplicate `GetAuthor` annotations

## Design Decisions
- Validation is placed at the end of `load_queries` to catch duplicates early, before any analysis or code generation
- Only the first duplicate group is reported to keep the error message focused and actionable
- Source file paths are included in the error to help users locate the duplicates

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query validation now detects when the same query name is defined multiple times and reports all occurrences.

* **Tests**
  * Added test coverage for duplicate query name detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->