### PR TITLE
fix(cli): suppress version banner on generate command

### DIFF
--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -63,7 +63,6 @@ fn version_command() -> glint.Command(Nil) {
 }
 
 fn run_generate(config_path: String) -> Nil {
-  io.println("sqlode v" <> version.version)
   io.println("Loading config from: " <> config_path)
 
   case generate.run(config_path) {


### PR DESCRIPTION
## Summary
- Remove the unconditional version banner print from `run_generate` in `cli.gleam`
- Version output is now only available via the `version` subcommand, following standard CLI conventions

## Changes
- `src/sqlode/cli.gleam`: Remove `io.println("sqlode v" <> version.version)` from `run_generate`

## Design Decisions
- The `version` subcommand already exists and remains the canonical way to check the version
- No `--verbose` flag was added since the remaining "Loading config from:" message already provides sufficient progress feedback

Closes #252