### PR TITLE
chore(gleam.toml): add links and documentation fields for hex.pm

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -4,6 +4,11 @@ target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }
+links = [
+  { title = "Homepage", href = "https://github.com/nao1215/sqlode" },
+  { title = "Documentation", href = "https://hexdocs.pm/sqlode" },
+  { title = "Changelog", href = "https://github.com/nao1215/sqlode/blob/main/CHANGELOG.md" },
+]
 
 [dependencies]
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"


### PR DESCRIPTION
## Summary
- Add `links` array to `gleam.toml` with Homepage, Documentation, and Changelog entries
- These fields are displayed on hex.pm package pages, improving discoverability

## Changes
- `gleam.toml`: Add `links` field using the Gleam-standard array-of-tables format (matching `gleam_stdlib`'s format)

Closes #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added convenient links to project homepage, documentation, and changelog for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->