### PR TITLE
fix(codegen): add runtime.nullable helper to simplify generated code for Option parameters

### DIFF
--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -172,38 +172,24 @@ fn render_param_value(
   case param.scalar_type {
     model.EnumType(name) -> {
       let to_string_fn = "models." <> model.enum_to_string_fn(name)
+      let encode_fn =
+        "fn(v) { " <> runtime_fn <> "(" <> to_string_fn <> "(v)) }"
       case param.nullable {
-        True ->
-          "case "
-          <> value_expr
-          <> " { Some(value) -> "
-          <> runtime_fn
-          <> "("
-          <> to_string_fn
-          <> "(value)) None -> runtime.null() }"
+        True -> "runtime.nullable(" <> value_expr <> ", " <> encode_fn <> ")"
         False -> runtime_fn <> "(" <> to_string_fn <> "(" <> value_expr <> "))"
       }
     }
     _ -> {
       let unwrap = strong_unwrap_expr(param.scalar_type, type_mapping)
       case param.nullable {
-        True ->
-          case unwrap {
-            option.None ->
-              "case "
-              <> value_expr
-              <> " { Some(value) -> "
-              <> runtime_fn
-              <> "(value) None -> runtime.null() }"
+        True -> {
+          let encode_fn = case unwrap {
+            option.None -> runtime_fn
             option.Some(fn_name) ->
-              "case "
-              <> value_expr
-              <> " { Some(value) -> "
-              <> runtime_fn
-              <> "("
-              <> fn_name
-              <> "(value)) None -> runtime.null() }"
+              "fn(v) { " <> runtime_fn <> "(" <> fn_name <> "(v)) }"
           }
+          "runtime.nullable(" <> value_expr <> ", " <> encode_fn <> ")"
+        }
         False ->
           case unwrap {
             option.None -> runtime_fn <> "(" <> value_expr <> ")"
@@ -273,37 +259,25 @@ fn param_accessors_flattened(
           model.EnumType(name) -> {
             let to_str = "models." <> model.enum_to_string_fn(name)
             case param.nullable {
-              True ->
-                "[case "
-                <> value_expr
-                <> " { Some(value) -> "
-                <> runtime_fn
-                <> "("
-                <> to_str
-                <> "(value)) None -> runtime.null() }]"
+              True -> {
+                let encode_fn =
+                  "fn(v) { " <> runtime_fn <> "(" <> to_str <> "(v)) }"
+                "[runtime.nullable(" <> value_expr <> ", " <> encode_fn <> ")]"
+              }
               False ->
                 "[" <> runtime_fn <> "(" <> to_str <> "(" <> value_expr <> "))]"
             }
           }
           _ ->
             case param.nullable {
-              True ->
-                case unwrap {
-                  option.None ->
-                    "[case "
-                    <> value_expr
-                    <> " { Some(value) -> "
-                    <> runtime_fn
-                    <> "(value) None -> runtime.null() }]"
+              True -> {
+                let encode_fn = case unwrap {
+                  option.None -> runtime_fn
                   option.Some(fn_name) ->
-                    "[case "
-                    <> value_expr
-                    <> " { Some(value) -> "
-                    <> runtime_fn
-                    <> "("
-                    <> fn_name
-                    <> "(value)) None -> runtime.null() }]"
+                    "fn(v) { " <> runtime_fn <> "(" <> fn_name <> "(v)) }"
                 }
+                "[runtime.nullable(" <> value_expr <> ", " <> encode_fn <> ")]"
+              }
               False ->
                 case unwrap {
                   option.None -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -1,5 +1,6 @@
 import gleam/int
 import gleam/list
+import gleam/option
 import gleam/string
 
 pub type QueryCommand {
@@ -84,6 +85,13 @@ pub fn bool(value: Bool) -> Value {
 
 pub fn bytes(value: BitArray) -> Value {
   SqlBytes(value)
+}
+
+pub fn nullable(value: option.Option(a), encode: fn(a) -> Value) -> Value {
+  case value {
+    option.Some(v) -> encode(v)
+    option.None -> SqlNull
+  }
 }
 
 /// Expand slice placeholders in a SQL string.


### PR DESCRIPTION
## Summary
- Add `runtime.nullable(value, encode)` helper that replaces verbose inline `case` expressions for nullable parameters
- Simplify codegen in `params.gleam` by eliminating 8 separate nullable case-expression generation sites

## Changes
- `src/sqlode/runtime.gleam`: Add `nullable(value: Option(a), encode: fn(a) -> Value) -> Value` function
- `src/sqlode/codegen/params.gleam`: Replace all inline nullable case-expression generation in `render_param_value` and `param_accessors_flattened` with calls to `runtime.nullable`

## Design Decisions
- The helper uses `Option(a)` and a generic encoder function, supporting all nullable variants (plain, enum, strong-typed) with a single function
- For simple cases (e.g., `runtime.int`), the encoder is passed directly; for composed cases (enum + to_string, or strong-type unwrap), an anonymous function wraps the composition
- Generated code changes from `case params.bio { Some(value) -> runtime.string(value) None -> runtime.null() }` to `runtime.nullable(params.bio, runtime.string)`, improving readability

Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal nullable parameter encoding logic by introducing a reusable helper function, reducing code duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->