### PR TITLE
fix(runtime): handle empty slice by emitting NULL instead of invalid empty IN clause

### DIFF
--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -137,16 +137,21 @@ pub fn expand_slice_placeholders(
         let is_slice = list.find(slices, fn(s) { s.0 == orig_idx })
         case is_slice {
           Ok(#(_, len)) -> {
-            let expanded =
-              int.range(
-                from: next_new_idx,
-                to: next_new_idx + len,
-                with: [],
-                run: fn(items, i) { [prefix <> int.to_string(i), ..items] },
-              )
-              |> list.reverse
-              |> string.join(", ")
-            #(next_new_idx + len, [#(orig_idx, expanded), ..map])
+            case len {
+              0 -> #(next_new_idx, [#(orig_idx, "NULL"), ..map])
+              _ -> {
+                let expanded =
+                  int.range(
+                    from: next_new_idx,
+                    to: next_new_idx + len,
+                    with: [],
+                    run: fn(items, i) { [prefix <> int.to_string(i), ..items] },
+                  )
+                  |> list.reverse
+                  |> string.join(", ")
+                #(next_new_idx + len, [#(orig_idx, expanded), ..map])
+              }
+            }
           }
           Error(_) -> {
             #(next_new_idx + 1, [

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -326,6 +326,27 @@ pub fn expand_slice_placeholders_no_slices_test() {
   result |> should.equal("SELECT * FROM users WHERE id = $1")
 }
 
+pub fn expand_slice_placeholders_empty_slice_test() {
+  let sql = "SELECT * FROM users WHERE id IN ($1)"
+  let result = runtime.expand_slice_placeholders(sql, [#(1, 0)], 1, "$")
+  result |> should.equal("SELECT * FROM users WHERE id IN (NULL)")
+}
+
+pub fn expand_slice_placeholders_empty_slice_with_other_params_test() {
+  let sql = "SELECT * FROM users WHERE name = $1 AND id IN ($2) AND status = $3"
+  let result = runtime.expand_slice_placeholders(sql, [#(2, 0)], 3, "$")
+  result
+  |> should.equal(
+    "SELECT * FROM users WHERE name = $1 AND id IN (NULL) AND status = $2",
+  )
+}
+
+pub fn expand_slice_placeholders_empty_slice_sqlite_test() {
+  let sql = "SELECT * FROM users WHERE id IN (?1)"
+  let result = runtime.expand_slice_placeholders(sql, [#(1, 0)], 1, "?")
+  result |> should.equal("SELECT * FROM users WHERE id IN (NULL)")
+}
+
 // --- Table type and alias tests ---
 
 pub fn render_models_table_type_alias_for_exact_match_test() {


### PR DESCRIPTION
## Summary
- Fix `expand_slice_placeholders` to emit `NULL` for empty slices instead of generating invalid `IN ()` SQL
- Add three test cases covering empty slice edge cases for PostgreSQL and SQLite

## Changes
- `src/sqlode/runtime.gleam`: Add `len == 0` check in `expand_slice_placeholders` Phase 2 to emit `"NULL"` instead of an empty placeholder expansion
- `test/codegen_test.gleam`: Add tests for empty slice (single param), empty slice with renumbering, and empty slice with SQLite prefix

## Design Decisions
- Chose `IN (NULL)` over `WHERE FALSE` because it preserves the SQL structure and naturally returns zero rows (NULL never equals any value in SQL), matching common ORM behavior (e.g., sqlx, Diesel)
- Empty slice does not advance `next_new_idx` since no real placeholders are consumed

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty list parameters in SQL IN clauses, now correctly uses NULL instead of generating invalid placeholder ranges.

* **Tests**
  * Added test coverage for empty list parameter scenarios across different SQL placeholder formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->