### PR TITLE
test(generate): add tests for directory-based schema/query path expansion

### DIFF
--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1308,6 +1308,56 @@ pub fn mixed_file_and_directory_inputs_test() {
   cleanup_dir()
 }
 
+pub fn reject_empty_schema_directory_test() {
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/empty_dir"],
+      queries: ["test/fixtures/query.sql"],
+      gleam: model.GleamOutput(
+        out: dir_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Error(error) = generate.generate_config(cfg)
+
+  generate.error_to_string(error)
+  |> string.contains("no .sql files")
+  |> should.be_true
+}
+
+pub fn reject_empty_query_directory_test() {
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/empty_dir"],
+      gleam: model.GleamOutput(
+        out: dir_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Error(error) = generate.generate_config(cfg)
+
+  generate.error_to_string(error)
+  |> string.contains("no .sql files")
+  |> should.be_true
+}
+
 // --- Duplicate query name tests ---
 
 pub fn reject_duplicate_query_names_test() {


### PR DESCRIPTION
## Summary
- Add tests for the empty directory edge case in `expand_sql_paths`
- Verify that both schema and query directory paths produce clear errors when the directory contains no .sql files

## Changes
- `test/generate_test.gleam`: Add `reject_empty_schema_directory_test` and `reject_empty_query_directory_test`
- `test/fixtures/empty_dir/.gitkeep`: Empty directory fixture for testing

## Design Decisions
- Existing tests already cover the happy path (directory with .sql files, mixed file+directory inputs), so this PR focuses on the missing edge case coverage
- Uses `.gitkeep` to ensure the empty directory is tracked by git

Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases to validate error handling when required directories are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->