### PR TITLE
fix(runtime): add SqlArray variant to Value type for raw-mode array parameter support

### DIFF
--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -13,6 +13,8 @@ pub fn render(
 ) -> String {
   let has_slices = common.queries_have_slices(queries)
 
+  let has_arrays = queries_have_array_params(queries)
+
   let has_enums = common.queries_have_enum_params(queries)
 
   let needs_models_for_strong =
@@ -24,7 +26,7 @@ pub fn render(
   let imports = case needs_option_import(queries) {
     True ->
       list.flatten([
-        case has_slices {
+        case has_slices || has_arrays {
           True -> ["import gleam/list"]
           False -> []
         },
@@ -39,7 +41,7 @@ pub fn render(
       ])
     False ->
       list.flatten([
-        case has_slices {
+        case has_slices || has_arrays {
           True -> ["import gleam/list"]
           False -> []
         },
@@ -64,6 +66,17 @@ pub fn render(
     ])
 
   string.join(lines, "\n")
+}
+
+fn queries_have_array_params(queries: List(model.AnalyzedQuery)) -> Bool {
+  list.any(queries, fn(q) {
+    list.any(q.params, fn(p) {
+      case p.scalar_type {
+        model.ArrayType(_) -> True
+        _ -> False
+      }
+    })
+  })
 }
 
 fn needs_option_import(queries: List(model.AnalyzedQuery)) -> Bool {
@@ -179,6 +192,20 @@ fn render_param_value(
         False -> runtime_fn <> "(" <> to_string_fn <> "(" <> value_expr <> "))"
       }
     }
+    model.ArrayType(element) -> {
+      let mapper = render_array_element_mapper(element, type_mapping)
+      let array_expr =
+        "runtime.array(list.map(" <> value_expr <> ", " <> mapper <> "))"
+      case param.nullable {
+        True ->
+          "runtime.nullable("
+          <> value_expr
+          <> ", fn(v) { runtime.array(list.map(v, "
+          <> mapper
+          <> ")) })"
+        False -> array_expr
+      }
+    }
     _ -> {
       let unwrap = strong_unwrap_expr(param.scalar_type, type_mapping)
       case param.nullable {
@@ -212,6 +239,27 @@ fn strong_unwrap_expr(
         option.None -> option.None
       }
     _ -> option.None
+  }
+}
+
+fn render_array_element_mapper(
+  element: model.ScalarType,
+  type_mapping: model.TypeMapping,
+) -> String {
+  let runtime_fn = model.scalar_type_to_runtime_function(element)
+  case element {
+    model.EnumType(name) -> {
+      let to_str = "models." <> model.enum_to_string_fn(name)
+      "fn(v) { " <> runtime_fn <> "(" <> to_str <> "(v)) }"
+    }
+    _ -> {
+      let unwrap = strong_unwrap_expr(element, type_mapping)
+      case unwrap {
+        option.None -> runtime_fn
+        option.Some(fn_name) ->
+          "fn(v) { " <> runtime_fn <> "(" <> fn_name <> "(v)) }"
+      }
+    }
   }
 }
 
@@ -266,6 +314,23 @@ fn param_accessors_flattened(
               }
               False ->
                 "[" <> runtime_fn <> "(" <> to_str <> "(" <> value_expr <> "))]"
+            }
+          }
+          model.ArrayType(element) -> {
+            let mapper = render_array_element_mapper(element, type_mapping)
+            case param.nullable {
+              True ->
+                "[runtime.nullable("
+                <> value_expr
+                <> ", fn(v) { runtime.array(list.map(v, "
+                <> mapper
+                <> ")) })]"
+              False ->
+                "[runtime.array(list.map("
+                <> value_expr
+                <> ", "
+                <> mapper
+                <> "))]"
             }
           }
           _ ->

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -23,6 +23,7 @@ pub type Value {
   SqlFloat(Float)
   SqlBool(Bool)
   SqlBytes(BitArray)
+  SqlArray(List(Value))
 }
 
 /// A typed raw query descriptor that bundles SQL metadata with its parameter
@@ -85,6 +86,10 @@ pub fn bool(value: Bool) -> Value {
 
 pub fn bytes(value: BitArray) -> Value {
   SqlBytes(value)
+}
+
+pub fn array(values: List(Value)) -> Value {
+  SqlArray(values)
 }
 
 pub fn nullable(value: option.Option(a), encode: fn(a) -> Value) -> Value {

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -897,6 +897,30 @@ pub fn render_params_with_array_columns_test() {
   |> should.be_true()
 }
 
+pub fn render_params_array_encoding_raw_runtime_test() {
+  let naming_ctx = naming.new()
+  let analyzed = array_analyzed_queries()
+  let rendered =
+    codegen.render_params_module(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+    )
+
+  // Raw-mode array params should encode using runtime.array + list.map
+  string.contains(rendered, "runtime.array(list.map(")
+  |> should.be_true()
+
+  // Nullable array params should use runtime.nullable wrapping runtime.array
+  string.contains(rendered, "runtime.nullable(")
+  |> should.be_true()
+
+  // Should import gleam/list for array mapping
+  string.contains(rendered, "import gleam/list")
+  |> should.be_true()
+}
+
 pub fn render_pog_adapter_with_array_columns_test() {
   let naming_ctx = naming.new()
   let block =

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -32,6 +32,29 @@ pub fn bytes_value_test() {
   runtime.bytes(<<1, 2, 3>>) |> should.equal(runtime.SqlBytes(<<1, 2, 3>>))
 }
 
+pub fn array_value_test() {
+  runtime.array([runtime.string("a"), runtime.string("b")])
+  |> should.equal(
+    runtime.SqlArray([runtime.SqlString("a"), runtime.SqlString("b")]),
+  )
+}
+
+pub fn array_empty_test() {
+  runtime.array([])
+  |> should.equal(runtime.SqlArray([]))
+}
+
+pub fn array_nested_types_test() {
+  runtime.array([runtime.int(1), runtime.int(2), runtime.int(3)])
+  |> should.equal(
+    runtime.SqlArray([
+      runtime.SqlInt(1),
+      runtime.SqlInt(2),
+      runtime.SqlInt(3),
+    ]),
+  )
+}
+
 pub fn prepare_no_slices_test() {
   let query =
     runtime.RawQuery(


### PR DESCRIPTION
## Summary
- Add `SqlArray(List(Value))` variant to the runtime `Value` type, enabling raw-mode queries to represent PostgreSQL array parameters
- Update params codegen to generate `runtime.array(list.map(...))` encoding for `ArrayType` parameters
- Handle nullable arrays, enum element arrays, and strong-type element arrays in both standard and flattened param rendering

## Changes
- `src/sqlode/runtime.gleam`: Add `SqlArray(List(Value))` variant and `array()` constructor function
- `src/sqlode/codegen/params.gleam`: Add `ArrayType` branch in `render_param_value` and `param_accessors_flattened`, add `render_array_element_mapper` helper, update `gleam/list` import detection for array params
- `test/runtime_test.gleam`: Add tests for array constructor (non-empty, empty, mixed types)
- `test/codegen_test.gleam`: Add test verifying raw-mode array param encoding generates correct `runtime.array(list.map(...))` pattern

## Design Decisions
- The `array()` constructor takes `List(Value)` (pre-encoded values), keeping the encoding responsibility in generated code via `list.map` with the element's runtime function
- `scalar_type_to_runtime_function(ArrayType(element))` in model.gleam is unchanged — it correctly returns the element's runtime function, which params codegen uses inside the `list.map` call
- Native adapter code (pog/sqlight) is unaffected — it already handles arrays via driver-specific functions like `pog.array()`

Closes #236