### PR TITLE
fix(parser): recognize tagged PostgreSQL dollar-quoted strings during placeholder masking

### DIFF
--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -92,13 +92,13 @@ fn do_tokenize(
         "$" ->
           case engine {
             model.PostgreSQL ->
-              case rest {
-                ["$", ..after_dollar] -> {
+              case try_dollar_tag_lex(rest) {
+                Ok(#(tag, after_tag)) -> {
                   let #(content, remaining) =
-                    read_dollar_quoted_string(after_dollar, [])
+                    read_dollar_quoted_string(after_tag, tag, [])
                   do_tokenize(remaining, engine, [StringLit(content), ..acc])
                 }
-                _ -> {
+                Error(_) -> {
                   // Could be placeholder $1, $name
                   let #(token, remaining) =
                     read_placeholder_or_ident(["$", ..rest])
@@ -275,14 +275,76 @@ fn read_single_quoted_string(
 
 fn read_dollar_quoted_string(
   input: List(String),
+  tag: String,
   acc: List(String),
 ) -> #(String, List(String)) {
   case input {
     [] -> #(acc |> list.reverse |> string.concat, [])
-    ["$", "$", ..rest] ->
-      // End of $$...$$ string
-      #(acc |> list.reverse |> string.concat, rest)
-    [g, ..rest] -> read_dollar_quoted_string(rest, [g, ..acc])
+    ["$", ..rest] ->
+      case try_match_closing_dollar_tag_lex(rest, tag) {
+        Ok(remaining) -> #(acc |> list.reverse |> string.concat, remaining)
+        Error(_) -> read_dollar_quoted_string(rest, tag, ["$", ..acc])
+      }
+    [g, ..rest] -> read_dollar_quoted_string(rest, tag, [g, ..acc])
+  }
+}
+
+fn try_dollar_tag_lex(
+  chars: List(String),
+) -> Result(#(String, List(String)), Nil) {
+  case chars {
+    ["$", ..rest] -> Ok(#("", rest))
+    [c, ..rest] ->
+      case is_alpha_or_underscore(c) {
+        True -> read_dollar_tag_chars_lex(rest, [c])
+        False -> Error(Nil)
+      }
+    [] -> Error(Nil)
+  }
+}
+
+fn read_dollar_tag_chars_lex(
+  chars: List(String),
+  acc: List(String),
+) -> Result(#(String, List(String)), Nil) {
+  case chars {
+    [] -> Error(Nil)
+    ["$", ..rest] -> {
+      let tag = acc |> list.reverse |> string.concat
+      Ok(#(tag, rest))
+    }
+    [c, ..rest] ->
+      case is_alnum_or_underscore(c) {
+        True -> read_dollar_tag_chars_lex(rest, [c, ..acc])
+        False -> Error(Nil)
+      }
+  }
+}
+
+fn try_match_closing_dollar_tag_lex(
+  chars: List(String),
+  tag: String,
+) -> Result(List(String), Nil) {
+  let tag_chars = string.to_graphemes(tag)
+  match_tag_then_dollar_lex(chars, tag_chars)
+}
+
+fn match_tag_then_dollar_lex(
+  chars: List(String),
+  tag_chars: List(String),
+) -> Result(List(String), Nil) {
+  case tag_chars {
+    [] ->
+      case chars {
+        ["$", ..rest] -> Ok(rest)
+        _ -> Error(Nil)
+      }
+    [expected, ..tag_rest] ->
+      case chars {
+        [actual, ..chars_rest] if actual == expected ->
+          match_tag_then_dollar_lex(chars_rest, tag_rest)
+        _ -> Error(Nil)
+      }
   }
 }
 

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -155,13 +155,13 @@ fn finalize_pending(
       case sql == "" {
         True -> Error(MissingSql(path:, line: start_line, name:))
         False -> {
-          let masked = mask_sql(sql)
+          let masked = mask_sql(engine, sql)
           let #(at_expanded, _at_masked, at_macros, next_idx) =
             expand_at_name_shorthands(ctx, engine, sql, masked)
           let #(expanded_sql, sqlc_macros) =
             expand_sqlc_macros_from(ctx, engine, at_expanded, next_idx)
           let macros = list.append(at_macros, sqlc_macros)
-          let final_masked = mask_sql(expanded_sql)
+          let final_masked = mask_sql(engine, expanded_sql)
           Ok([
             model.ParsedQuery(
               name:,
@@ -455,16 +455,18 @@ type MaskState {
   MaskDoubleQuote
   MaskLineComment
   MaskBlockComment
+  MaskDollarQuoted(tag: String)
 }
 
-fn mask_sql(sql: String) -> String {
+fn mask_sql(engine: model.Engine, sql: String) -> String {
   let chars = string.to_graphemes(sql)
-  do_mask(chars, MaskNormal, [])
+  do_mask(engine, chars, MaskNormal, [])
   |> list.reverse
   |> string.join("")
 }
 
 fn do_mask(
+  engine: model.Engine,
   chars: List(String),
   state: MaskState,
   acc: List(String),
@@ -473,38 +475,154 @@ fn do_mask(
     MaskNormal ->
       case chars {
         [] -> acc
-        ["'", ..rest] -> do_mask(rest, MaskSingleQuote, [" ", ..acc])
-        ["\"", ..rest] -> do_mask(rest, MaskDoubleQuote, [" ", ..acc])
-        ["-", "-", ..rest] -> do_mask(rest, MaskLineComment, [" ", " ", ..acc])
-        ["/", "*", ..rest] -> do_mask(rest, MaskBlockComment, [" ", " ", ..acc])
-        [c, ..rest] -> do_mask(rest, MaskNormal, [c, ..acc])
+        ["'", ..rest] -> do_mask(engine, rest, MaskSingleQuote, [" ", ..acc])
+        ["\"", ..rest] -> do_mask(engine, rest, MaskDoubleQuote, [" ", ..acc])
+        ["-", "-", ..rest] ->
+          do_mask(engine, rest, MaskLineComment, [" ", " ", ..acc])
+        ["/", "*", ..rest] ->
+          do_mask(engine, rest, MaskBlockComment, [" ", " ", ..acc])
+        ["$", ..rest] ->
+          case engine {
+            model.PostgreSQL ->
+              case try_dollar_tag(rest) {
+                Ok(#(tag, after_tag)) -> {
+                  let spaces = list.repeat(" ", string.length(tag) + 2)
+                  do_mask(
+                    engine,
+                    after_tag,
+                    MaskDollarQuoted(tag),
+                    list.append(spaces, acc),
+                  )
+                }
+                Error(_) -> do_mask(engine, rest, MaskNormal, ["$", ..acc])
+              }
+            _ -> do_mask(engine, rest, MaskNormal, ["$", ..acc])
+          }
+        [c, ..rest] -> do_mask(engine, rest, MaskNormal, [c, ..acc])
       }
     MaskSingleQuote ->
       case chars {
         [] -> acc
-        ["'", "'", ..rest] -> do_mask(rest, MaskSingleQuote, [" ", " ", ..acc])
-        ["'", ..rest] -> do_mask(rest, MaskNormal, [" ", ..acc])
-        [_, ..rest] -> do_mask(rest, MaskSingleQuote, [" ", ..acc])
+        ["'", "'", ..rest] ->
+          do_mask(engine, rest, MaskSingleQuote, [" ", " ", ..acc])
+        ["'", ..rest] -> do_mask(engine, rest, MaskNormal, [" ", ..acc])
+        [_, ..rest] -> do_mask(engine, rest, MaskSingleQuote, [" ", ..acc])
       }
     MaskDoubleQuote ->
       case chars {
         [] -> acc
         ["\"", "\"", ..rest] ->
-          do_mask(rest, MaskDoubleQuote, [" ", " ", ..acc])
-        ["\"", ..rest] -> do_mask(rest, MaskNormal, [" ", ..acc])
-        [_, ..rest] -> do_mask(rest, MaskDoubleQuote, [" ", ..acc])
+          do_mask(engine, rest, MaskDoubleQuote, [" ", " ", ..acc])
+        ["\"", ..rest] -> do_mask(engine, rest, MaskNormal, [" ", ..acc])
+        [_, ..rest] -> do_mask(engine, rest, MaskDoubleQuote, [" ", ..acc])
       }
     MaskLineComment ->
       case chars {
         [] -> acc
-        ["\n", ..rest] -> do_mask(rest, MaskNormal, ["\n", ..acc])
-        [_, ..rest] -> do_mask(rest, MaskLineComment, [" ", ..acc])
+        ["\n", ..rest] -> do_mask(engine, rest, MaskNormal, ["\n", ..acc])
+        [_, ..rest] -> do_mask(engine, rest, MaskLineComment, [" ", ..acc])
       }
     MaskBlockComment ->
       case chars {
         [] -> acc
-        ["*", "/", ..rest] -> do_mask(rest, MaskNormal, [" ", " ", ..acc])
-        [_, ..rest] -> do_mask(rest, MaskBlockComment, [" ", ..acc])
+        ["*", "/", ..rest] ->
+          do_mask(engine, rest, MaskNormal, [" ", " ", ..acc])
+        [_, ..rest] -> do_mask(engine, rest, MaskBlockComment, [" ", ..acc])
       }
+    MaskDollarQuoted(tag) ->
+      case chars {
+        [] -> acc
+        ["$", ..rest] ->
+          case try_match_closing_dollar_tag(rest, tag) {
+            Ok(remaining) -> {
+              let spaces = list.repeat(" ", string.length(tag) + 2)
+              do_mask(engine, remaining, MaskNormal, list.append(spaces, acc))
+            }
+            Error(_) ->
+              do_mask(engine, rest, MaskDollarQuoted(tag), [" ", ..acc])
+          }
+        [_, ..rest] ->
+          do_mask(engine, rest, MaskDollarQuoted(tag), [" ", ..acc])
+      }
+  }
+}
+
+fn try_dollar_tag(chars: List(String)) -> Result(#(String, List(String)), Nil) {
+  case chars {
+    ["$", ..rest] -> Ok(#("", rest))
+    [c, ..rest] ->
+      case is_mask_alpha_or_underscore(c) {
+        True -> read_dollar_tag_chars(rest, [c])
+        False -> Error(Nil)
+      }
+    [] -> Error(Nil)
+  }
+}
+
+fn read_dollar_tag_chars(
+  chars: List(String),
+  acc: List(String),
+) -> Result(#(String, List(String)), Nil) {
+  case chars {
+    [] -> Error(Nil)
+    ["$", ..rest] -> {
+      let tag = acc |> list.reverse |> string.concat
+      Ok(#(tag, rest))
+    }
+    [c, ..rest] ->
+      case is_mask_alnum_or_underscore(c) {
+        True -> read_dollar_tag_chars(rest, [c, ..acc])
+        False -> Error(Nil)
+      }
+  }
+}
+
+fn try_match_closing_dollar_tag(
+  chars: List(String),
+  tag: String,
+) -> Result(List(String), Nil) {
+  let tag_chars = string.to_graphemes(tag)
+  match_tag_then_dollar(chars, tag_chars)
+}
+
+fn match_tag_then_dollar(
+  chars: List(String),
+  tag_chars: List(String),
+) -> Result(List(String), Nil) {
+  case tag_chars {
+    [] ->
+      case chars {
+        ["$", ..rest] -> Ok(rest)
+        _ -> Error(Nil)
+      }
+    [expected, ..tag_rest] ->
+      case chars {
+        [actual, ..chars_rest] if actual == expected ->
+          match_tag_then_dollar(chars_rest, tag_rest)
+        _ -> Error(Nil)
+      }
+  }
+}
+
+fn is_mask_alpha_or_underscore(c: String) -> Bool {
+  is_mask_alpha(c) || c == "_"
+}
+
+fn is_mask_alnum_or_underscore(c: String) -> Bool {
+  is_mask_alpha(c) || is_mask_digit(c) || c == "_"
+}
+
+fn is_mask_alpha(c: String) -> Bool {
+  let cp = case string.to_utf_codepoints(c) {
+    [cp] -> string.utf_codepoint_to_int(cp)
+    _ -> 0
+  }
+  { cp >= 65 && cp <= 90 } || { cp >= 97 && cp <= 122 }
+}
+
+fn is_mask_digit(c: String) -> Bool {
+  case c {
+    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
+    _ -> False
   }
 }

--- a/test/lexer_test.gleam
+++ b/test/lexer_test.gleam
@@ -79,6 +79,27 @@ pub fn dollar_quoted_string_postgresql_test() {
   ])
 }
 
+pub fn tagged_dollar_quoted_string_postgresql_test() {
+  lexer.tokenize("SELECT $tag$hello $1 world$tag$, id", model.PostgreSQL)
+  |> should.equal([
+    Keyword("select"),
+    StringLit("hello $1 world"),
+    Comma,
+    Ident("id"),
+  ])
+}
+
+pub fn nested_dollar_quoted_tags_postgresql_test() {
+  lexer.tokenize(
+    "SELECT $outer$contains $$inner$$ text$outer$",
+    model.PostgreSQL,
+  )
+  |> should.equal([
+    Keyword("select"),
+    StringLit("contains $$inner$$ text"),
+  ])
+}
+
 // --- Comment tests ---
 
 pub fn line_comment_stripped_test() {

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -545,6 +545,57 @@ pub fn sqlite_repeated_numbered_placeholder_dedup_test() {
   query.param_count |> should.equal(1)
 }
 
+pub fn postgresql_plain_dollar_quoted_string_masks_placeholder_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: DollarPlain :one\n"
+    <> "SELECT $$literal $1 inside$$, id FROM authors WHERE id = $1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+}
+
+pub fn postgresql_tagged_dollar_quoted_string_masks_placeholder_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: DollarTag :one\n"
+    <> "SELECT $tag$literal $1 inside$tag$, id FROM authors WHERE id = $2;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(2)
+}
+
+pub fn postgresql_dollar_quoted_does_not_affect_real_params_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: DollarMixed :one\n"
+    <> "SELECT $fn$body with $1 and $2$fn$, id FROM authors WHERE id = $1 AND name = $2;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(2)
+}
+
+pub fn sqlite_dollar_not_treated_as_dollar_quoted_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: SqliteDollar :one\n" <> "SELECT id FROM authors WHERE id = $id;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+}
+
 pub fn error_to_string_coverage_test() {
   query_parser.error_to_string(query_parser.InvalidAnnotation(
     path: "test.sql",

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -2,6 +2,7 @@ import codegen_test
 import config_test
 import generate_test
 import gleeunit
+import lexer_test
 import model_test
 import naming_test
 import query_analyzer_test
@@ -567,4 +568,28 @@ pub fn sqlite_bare_question_marks_not_deduped_test() {
 
 pub fn sqlite_repeated_numbered_placeholder_dedup_test() {
   query_parser_test.sqlite_repeated_numbered_placeholder_dedup_test()
+}
+
+pub fn postgresql_plain_dollar_quoted_string_masks_placeholder_test() {
+  query_parser_test.postgresql_plain_dollar_quoted_string_masks_placeholder_test()
+}
+
+pub fn postgresql_tagged_dollar_quoted_string_masks_placeholder_test() {
+  query_parser_test.postgresql_tagged_dollar_quoted_string_masks_placeholder_test()
+}
+
+pub fn postgresql_dollar_quoted_does_not_affect_real_params_test() {
+  query_parser_test.postgresql_dollar_quoted_does_not_affect_real_params_test()
+}
+
+pub fn sqlite_dollar_not_treated_as_dollar_quoted_test() {
+  query_parser_test.sqlite_dollar_not_treated_as_dollar_quoted_test()
+}
+
+pub fn tagged_dollar_quoted_string_postgresql_test() {
+  lexer_test.tagged_dollar_quoted_string_postgresql_test()
+}
+
+pub fn nested_dollar_quoted_tags_postgresql_test() {
+  lexer_test.nested_dollar_quoted_tags_postgresql_test()
 }


### PR DESCRIPTION
## Summary

- Add support for tagged PostgreSQL dollar-quoted strings (`$tag$...$tag$`) in both the SQL masking layer and the lexer
- Prevent phantom parameters from being detected inside dollar-quoted string literals
- Only PostgreSQL is affected; SQLite and MySQL code paths remain unchanged

## Changes

- **`src/sqlode/query_parser.gleam`**: Add `MaskDollarQuoted(tag)` state to `do_mask`. When a `$` is encountered in PostgreSQL mode, detect whether it starts a dollar-quoted string (`$$` or `$tag$`) via `try_dollar_tag`. Content inside dollar-quoted strings is replaced with spaces like other string literals. Add `engine` parameter to `mask_sql`/`do_mask` so dollar-quoting detection is PostgreSQL-only.
- **`src/sqlode/lexer.gleam`**: Extend `read_dollar_quoted_string` to accept a `tag` parameter and match `$tag$` closing delimiters instead of only `$$`. Add `try_dollar_tag_lex` to detect tagged dollar quotes at the tokenization entry point.
- **`test/query_parser_test.gleam`**: Add 4 tests covering: plain `$$` masking, tagged `$tag$` masking, mixed dollar-quoted + real params, and SQLite `$name` not treated as dollar-quoting.
- **`test/lexer_test.gleam`**: Add 2 tests covering: tagged dollar-quoted tokenization and nested tag handling (`$outer$..$$inner$$...$outer$`).

## Design Decisions

- Dollar-quoting detection is gated behind `model.PostgreSQL` engine check to avoid misinterpreting SQLite `$name` placeholders
- Tag validation follows PostgreSQL rules: must start with letter/underscore, followed by alphanumeric/underscore characters
- The closing delimiter matching uses a character-by-character comparison to avoid regex overhead in the hot masking loop

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PostgreSQL dollar-quoted string support with proper tag-aware tokenization
  * Fixed query parameter counting to exclude placeholders inside dollar-quoted string literals
  * Ensured SQLite mode correctly distinguishes dollar-quoted strings from dollar-prefixed identifiers

* **Tests**
  * Added comprehensive test coverage for PostgreSQL tagged dollar-quoted strings and placeholder masking scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->