### PR TITLE
fix(parser): mask sqlc.arg/narg/slice before expansion to ignore macros in literals

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -29,6 +29,7 @@ type ParserContext {
     postgresql_param_re: regexp.Regexp,
     sqlite_param_re: regexp.Regexp,
     sqlc_macro_re: regexp.Regexp,
+    masked_sqlc_macro_re: regexp.Regexp,
     at_name_re: regexp.Regexp,
   )
 }
@@ -43,6 +44,8 @@ fn new_parser_context(naming_ctx: naming.NamingContext) -> ParserContext {
     regexp.from_string(
       "sqlc\\.(arg|narg|slice)\\(('[^']*'|\"[^\"]*\"|[a-zA-Z_][a-zA-Z0-9_]*)\\)",
     )
+  let assert Ok(masked_sqlc_macro_re) =
+    regexp.from_string("sqlc\\.(arg|narg|slice)\\(([^)]+)\\)")
   let assert Ok(at_name_re) = regexp.from_string("@([A-Za-z_][A-Za-z0-9_]*)")
 
   ParserContext(
@@ -50,6 +53,7 @@ fn new_parser_context(naming_ctx: naming.NamingContext) -> ParserContext {
     postgresql_param_re:,
     sqlite_param_re:,
     sqlc_macro_re:,
+    masked_sqlc_macro_re:,
     at_name_re:,
   )
 }
@@ -156,10 +160,16 @@ fn finalize_pending(
         True -> Error(MissingSql(path:, line: start_line, name:))
         False -> {
           let masked = mask_sql(engine, sql)
-          let #(at_expanded, _at_masked, at_macros, next_idx) =
+          let #(at_expanded, at_masked, at_macros, next_idx) =
             expand_at_name_shorthands(ctx, engine, sql, masked)
           let #(expanded_sql, sqlc_macros) =
-            expand_sqlc_macros_from(ctx, engine, at_expanded, next_idx)
+            expand_sqlc_macros_from(
+              ctx,
+              engine,
+              at_expanded,
+              at_masked,
+              next_idx,
+            )
           let macros = list.append(at_macros, sqlc_macros)
           let final_masked = mask_sql(engine, expanded_sql)
           Ok([
@@ -368,29 +378,39 @@ fn expand_sqlc_macros_from(
   ctx: ParserContext,
   engine: model.Engine,
   sql: String,
+  masked: String,
   start_idx: Int,
 ) -> #(String, List(model.SqlcMacro)) {
-  let matches = regexp.scan(ctx.sqlc_macro_re, sql)
+  let matches = regexp.scan(ctx.masked_sqlc_macro_re, masked)
 
   case matches {
     [] -> #(sql, [])
     _ -> {
-      let #(expanded, macros, _) =
-        list.fold(matches, #(sql, [], start_idx), fn(acc, match) {
-          let #(current_sql, macro_acc, idx) = acc
+      let #(expanded, _expanded_masked, macros, _) =
+        list.fold(matches, #(sql, masked, [], start_idx), fn(acc, match) {
+          let #(current_sql, current_masked, macro_acc, idx) = acc
 
           case match.submatches {
-            [Some(kind), Some(raw_name)] -> {
-              let name = strip_quotes(raw_name)
+            [Some(kind), Some(captured_arg)] -> {
+              let name = case string.trim(captured_arg) {
+                "" ->
+                  extract_macro_arg(current_sql, current_masked, match.content)
+                trimmed -> strip_quotes(trimmed)
+              }
               let placeholder = engine_placeholder(engine, idx)
-              let new_sql =
-                replace_first_simple(current_sql, match.content, placeholder)
+              let #(new_sql, new_masked) =
+                replace_first_in_masked(
+                  current_sql,
+                  current_masked,
+                  match.content,
+                  placeholder,
+                )
               let sqlc_macro = case kind {
                 "narg" -> model.SqlcNarg(index: idx, name:)
                 "slice" -> model.SqlcSlice(index: idx, name:)
                 _ -> model.SqlcArg(index: idx, name:)
               }
-              #(new_sql, [sqlc_macro, ..macro_acc], idx + 1)
+              #(new_sql, new_masked, [sqlc_macro, ..macro_acc], idx + 1)
             }
             _ -> acc
           }
@@ -401,21 +421,31 @@ fn expand_sqlc_macros_from(
   }
 }
 
+fn extract_macro_arg(
+  sql: String,
+  masked: String,
+  masked_match: String,
+) -> String {
+  case string.split_once(masked, masked_match) {
+    Ok(#(before, _)) -> {
+      let pos = string.length(before)
+      let span = string.slice(sql, pos, string.length(masked_match))
+      case string.split_once(span, "(") {
+        Ok(#(_, after_paren)) -> {
+          let arg = string.drop_end(after_paren, 1)
+          strip_quotes(string.trim(arg))
+        }
+        Error(_) -> ""
+      }
+    }
+    Error(_) -> ""
+  }
+}
+
 fn strip_quotes(name: String) -> String {
   case string.first(name) {
     Ok("'") | Ok("\"") -> string.slice(name, 1, string.length(name) - 2)
     _ -> name
-  }
-}
-
-fn replace_first_simple(
-  in text: String,
-  each pattern: String,
-  with replacement: String,
-) -> String {
-  case string.split_once(text, pattern) {
-    Ok(#(before, after)) -> before <> replacement <> after
-    Error(_) -> text
   }
 }
 

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -596,6 +596,55 @@ pub fn sqlite_dollar_not_treated_as_dollar_quoted_test() {
   query.param_count |> should.equal(1)
 }
 
+pub fn sqlc_arg_in_string_literal_ignored_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: MacroInString :one\n"
+    <> "SELECT id FROM authors WHERE note = 'sqlc.arg(fake)' AND id = sqlc.arg(real_id);"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcArg(index: 1, name: "real_id")])
+  string.contains(query.sql, "'sqlc.arg(fake)'") |> should.be_true()
+}
+
+pub fn sqlc_narg_in_line_comment_ignored_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: MacroInComment :one\n"
+    <> "SELECT id FROM authors\n"
+    <> "-- WHERE name = sqlc.narg(ignored)\n"
+    <> "WHERE id = sqlc.arg(real_id);"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcArg(index: 1, name: "real_id")])
+}
+
+pub fn sqlc_slice_in_block_comment_ignored_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: MacroInBlock :many\n"
+    <> "SELECT id FROM authors\n"
+    <> "WHERE /* sqlc.slice(phantom) */ id IN (sqlc.slice(real_ids));"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+
+  query.param_count |> should.equal(1)
+  query.macros
+  |> should.equal([model.SqlcSlice(index: 1, name: "real_ids")])
+}
+
 pub fn error_to_string_coverage_test() {
   query_parser.error_to_string(query_parser.InvalidAnnotation(
     path: "test.sql",

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -593,3 +593,15 @@ pub fn tagged_dollar_quoted_string_postgresql_test() {
 pub fn nested_dollar_quoted_tags_postgresql_test() {
   lexer_test.nested_dollar_quoted_tags_postgresql_test()
 }
+
+pub fn sqlc_arg_in_string_literal_ignored_test() {
+  query_parser_test.sqlc_arg_in_string_literal_ignored_test()
+}
+
+pub fn sqlc_narg_in_line_comment_ignored_test() {
+  query_parser_test.sqlc_narg_in_line_comment_ignored_test()
+}
+
+pub fn sqlc_slice_in_block_comment_ignored_test() {
+  query_parser_test.sqlc_slice_in_block_comment_ignored_test()
+}


### PR DESCRIPTION
## Summary

- Scan the masked SQL (instead of raw SQL) when expanding `sqlc.arg`, `sqlc.narg`, and `sqlc.slice` macros, preventing phantom parameters from macro-like text inside string literals, comments, or dollar-quoted strings
- Remove unused `replace_first_simple` function (superseded by `replace_first_in_masked`)

## Changes

- **`src/sqlode/query_parser.gleam`**:
  - Add `masked_sqlc_macro_re` regex to `ParserContext` with permissive pattern `sqlc\.(arg|narg|slice)\(([^)]+)\)` that matches both unmasked and masked (spaces) macro arguments
  - Update `expand_sqlc_macros_from` to accept a `masked` parameter, scan masked SQL with the new regex, and use `replace_first_in_masked` for position-accurate replacement
  - Add `extract_macro_arg` helper to recover quoted argument names from the original SQL when the masked form has spaces (since `mask_sql` replaces the content of quoted macro arguments like `'name'` with spaces)
  - Pass `at_masked` (previously discarded) from `expand_at_name_shorthands` to `expand_sqlc_macros_from`
  - Remove dead `replace_first_simple` function
- **`test/query_parser_test.gleam`**: Add 3 tests covering macros inside single-quoted strings, line comments, and block comments
- **`test/sqlode_test.gleam`**: Register new test proxies

## Design Decisions

- A separate `masked_sqlc_macro_re` is needed because `mask_sql` replaces quoted macro arguments (e.g., `'name'` in `sqlc.arg('name')`) with spaces, making the original strict regex unable to match. The permissive regex `[^)]+` catches both forms.
- When the captured argument is all spaces (indicating a quoted original), `extract_macro_arg` uses position-based extraction from the original SQL to recover the real argument name.

Closes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL query parser to correctly ignore `sqlc.arg`, `sqlc.narg`, and `sqlc.slice` macros when they appear inside string literals, line comments, or block comments.

* **Tests**
  * Added test coverage for macro handling in string literals, line comments, and block comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->