### PR TITLE
fix(analyzer): validate compound query branches have matching column counts

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -6,7 +6,8 @@ import gleam/string
 import sqlode/lexer
 import sqlode/model
 import sqlode/query_analyzer/context.{
-  type AnalysisError, type AnalyzerContext, ColumnNotFound, TableNotFound,
+  type AnalysisError, type AnalyzerContext, ColumnNotFound,
+  CompoundColumnCountMismatch, TableNotFound,
 }
 
 type ExtractedColumn {
@@ -54,6 +55,10 @@ pub fn infer_result_columns(
         }
         None -> {
           let main_tokens = tok_strip_cte(tokens)
+          use _ <- result.try(validate_compound_column_counts(
+            query.name,
+            main_tokens,
+          ))
           let main_tokens2 = tok_strip_compound(main_tokens)
           let table_names = tok_extract_table_names(main_tokens2)
           let nullable_tables =
@@ -553,6 +558,95 @@ fn tok_strip_compound_loop(
       }
     }
     [token, ..rest] -> tok_strip_compound_loop(rest, depth, [token, ..acc])
+  }
+}
+
+/// Validate that all compound query branches have the same column count.
+fn validate_compound_column_counts(
+  query_name: String,
+  tokens: List(lexer.Token),
+) -> Result(Nil, AnalysisError) {
+  let branches = tok_split_compound_branches(tokens)
+  case branches {
+    [] | [_] -> Ok(Nil)
+    [first, ..rest] -> {
+      let first_count = count_branch_columns(first)
+      list.try_each(rest, fn(branch) {
+        let branch_count = count_branch_columns(branch)
+        case branch_count == first_count {
+          True -> Ok(Nil)
+          False ->
+            Error(CompoundColumnCountMismatch(
+              query_name:,
+              first_count:,
+              branch_count:,
+            ))
+        }
+      })
+    }
+  }
+}
+
+fn count_branch_columns(branch: List(lexer.Token)) -> Int {
+  case tok_find_select_to_from(branch) {
+    Some(col_tokens) -> list.length(tok_split_on_commas(col_tokens))
+    None -> 0
+  }
+}
+
+/// Split tokens on top-level compound operators (UNION, INTERSECT, EXCEPT).
+fn tok_split_compound_branches(
+  tokens: List(lexer.Token),
+) -> List(List(lexer.Token)) {
+  tok_split_compound_branches_loop(tokens, 0, [], [])
+}
+
+fn tok_split_compound_branches_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  current: List(lexer.Token),
+  acc: List(List(lexer.Token)),
+) -> List(List(lexer.Token)) {
+  case tokens {
+    [] ->
+      case current {
+        [] -> list.reverse(acc)
+        _ -> list.reverse([list.reverse(current), ..acc])
+      }
+    [lexer.LParen, ..rest] ->
+      tok_split_compound_branches_loop(
+        rest,
+        depth + 1,
+        [lexer.LParen, ..current],
+        acc,
+      )
+    [lexer.RParen, ..rest] ->
+      tok_split_compound_branches_loop(
+        rest,
+        depth - 1,
+        [lexer.RParen, ..current],
+        acc,
+      )
+    [lexer.Keyword(kw), ..rest] if depth == 0 ->
+      case kw == "union" || kw == "intersect" || kw == "except" {
+        True -> {
+          let rest2 = case rest {
+            [lexer.Keyword("all"), ..r] -> r
+            _ -> rest
+          }
+          let branch = list.reverse(current)
+          tok_split_compound_branches_loop(rest2, 0, [], [branch, ..acc])
+        }
+        False ->
+          tok_split_compound_branches_loop(
+            rest,
+            depth,
+            [lexer.Keyword(kw), ..current],
+            acc,
+          )
+      }
+    [token, ..rest] ->
+      tok_split_compound_branches_loop(rest, depth, [token, ..current], acc)
   }
 }
 

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -11,6 +11,11 @@ pub type AnalysisError {
   ColumnNotFound(query_name: String, table_name: String, column_name: String)
   ParameterTypeNotInferred(query_name: String, param_index: Int)
   UnrecognizedCastType(query_name: String, param_index: Int, cast_type: String)
+  CompoundColumnCountMismatch(
+    query_name: String,
+    first_count: Int,
+    branch_count: Int,
+  )
 }
 
 pub fn analysis_error_to_string(error: AnalysisError) -> String {
@@ -44,6 +49,13 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
       <> cast_type
       <> "\" for parameter $"
       <> int.to_string(param_index)
+    CompoundColumnCountMismatch(query_name:, first_count:, branch_count:) ->
+      "Query \""
+      <> query_name
+      <> "\": compound query branch has "
+      <> int.to_string(branch_count)
+      <> " columns, but the first branch has "
+      <> int.to_string(first_count)
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -453,6 +453,72 @@ pub fn cte_select_from_real_table_test() {
   name_col.name |> should.equal("name")
 }
 
+pub fn compound_query_column_count_mismatch_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let content =
+    "-- name: BadUnion :many\n"
+    <> "SELECT id, name FROM authors\n"
+    <> "UNION\n"
+    <> "SELECT id FROM authors;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("union.sql", model.PostgreSQL, naming_ctx, content)
+  let assert Error(err) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let msg = query_analyzer.analysis_error_to_string(err)
+  msg |> string.contains("2") |> should.be_true()
+  msg |> string.contains("1") |> should.be_true()
+  msg |> string.contains("BadUnion") |> should.be_true()
+}
+
+pub fn compound_query_valid_union_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let content =
+    "-- name: GoodUnion :many\n"
+    <> "SELECT id, name FROM authors\n"
+    <> "UNION ALL\n"
+    <> "SELECT id, name FROM authors;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("union.sql", model.PostgreSQL, naming_ctx, content)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  list.length(query.result_columns) |> should.equal(2)
+}
+
+pub fn compound_query_except_mismatch_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let content =
+    "-- name: BadExcept :many\n"
+    <> "SELECT id, name FROM authors\n"
+    <> "EXCEPT\n"
+    <> "SELECT id, name, bio FROM authors;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("except.sql", model.PostgreSQL, naming_ctx, content)
+  let assert Error(_) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+}
+
 fn test_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/schema.sql")
   let assert Ok(catalog) =

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -605,3 +605,15 @@ pub fn sqlc_narg_in_line_comment_ignored_test() {
 pub fn sqlc_slice_in_block_comment_ignored_test() {
   query_parser_test.sqlc_slice_in_block_comment_ignored_test()
 }
+
+pub fn compound_query_column_count_mismatch_test() {
+  query_analyzer_test.compound_query_column_count_mismatch_test()
+}
+
+pub fn compound_query_valid_union_test() {
+  query_analyzer_test.compound_query_valid_union_test()
+}
+
+pub fn compound_query_except_mismatch_test() {
+  query_analyzer_test.compound_query_except_mismatch_test()
+}


### PR DESCRIPTION
## Summary

- Validate that all branches of compound queries (UNION/INTERSECT/EXCEPT) have the same number of columns before generating row types
- Reject queries with mismatched column counts with a precise diagnostic instead of silently inferring from only the first branch

## Changes

- **`src/sqlode/query_analyzer/context.gleam`**: Add `CompoundColumnCountMismatch(query_name, first_count, branch_count)` variant to `AnalysisError` with descriptive error message
- **`src/sqlode/query_analyzer/column_inferencer.gleam`**:
  - Add `validate_compound_column_counts` that splits tokens on top-level compound operators and compares column counts across branches
  - Add `tok_split_compound_branches` / `tok_split_compound_branches_loop` to split token stream on UNION/INTERSECT/EXCEPT (handling ALL keyword and parenthesis depth)
  - Add `count_branch_columns` helper using existing `tok_find_select_to_from` and `tok_split_on_commas`
  - Call validation in `infer_result_columns` before `tok_strip_compound`
- **`test/query_analyzer_test.gleam`**: Add 3 tests for UNION mismatch, valid UNION ALL, and EXCEPT mismatch

## Design Decisions

- Validation runs before `tok_strip_compound` to access all branches; after validation passes, the existing logic continues to infer columns from the first branch only
- Column count comparison uses the token-based column extraction (SELECT to FROM), consistent with the rest of the inferencer
- UNION ALL is handled by skipping the optional ALL keyword during branch splitting

Closes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for compound queries (UNION, INTERSECT, EXCEPT) to ensure all branches have matching column counts.
  * Improved error messages to clearly report column count mismatches in compound queries.

* **Tests**
  * Added comprehensive test coverage for compound query validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->