### PR TITLE
feat!: replace sqlc.* query macros with sqlode.* syntax and drop compatibility aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ ORDER BY name;
 
 -- name: CreateAuthor :exec
 INSERT INTO authors (name, bio)
-VALUES (sqlc.arg(author_name), sqlc.narg(bio));
+VALUES (sqlode.arg(author_name), sqlode.narg(bio));
 ```
 
 ### Generate
@@ -167,7 +167,7 @@ let values = q.encode(params.GetAuthorParams(id: 1))
 // q.sql, q.command, and values are now tied together
 ```
 
-For queries using `sqlc.slice()`, use `runtime.prepare` to expand slice placeholders and encode parameters in one call:
+For queries using `sqlode.slice()`, use `runtime.prepare` to expand slice placeholders and encode parameters in one call:
 
 ```gleam
 let q = queries.get_authors_by_ids()
@@ -323,21 +323,21 @@ pub fn main() {
 | `:batchexec` | Batch variant of `:exec` |
 | `:copyfrom` | Bulk insert |
 
-## sqlc macros
+## Query macros
 
 | Macro | Description |
 |---|---|
-| `sqlc.arg(name)` | Names a parameter |
-| `sqlc.narg(name)` | Names a nullable parameter |
-| `sqlc.slice(name)` | Expands to a list parameter for IN clauses |
-| `sqlc.embed(table)` | Embeds all columns of a table into the result |
+| `sqlode.arg(name)` | Names a parameter |
+| `sqlode.narg(name)` | Names a nullable parameter |
+| `sqlode.slice(name)` | Expands to a list parameter for IN clauses |
+| `sqlode.embed(table)` | Embeds all columns of a table into the result |
 
-### sqlc.slice example
+### sqlode.slice example
 
 ```sql
 -- name: GetAuthorsByIds :many
 SELECT id, name FROM authors
-WHERE id IN (sqlc.slice(ids));
+WHERE id IN (sqlode.slice(ids));
 ```
 
 Generates a parameter with type `List(Int)`:
@@ -348,11 +348,11 @@ pub type GetAuthorsByIdsParams {
 }
 ```
 
-### sqlc.embed example
+### sqlode.embed example
 
 ```sql
 -- name: GetBookWithAuthor :one
-SELECT sqlc.embed(authors), books.title
+SELECT sqlode.embed(authors), books.title
 FROM books
 JOIN authors ON books.author_id = authors.id
 WHERE books.id = $1;
@@ -581,7 +581,7 @@ sqlode follows sqlc conventions, so most SQL files work without changes. Key dif
        runtime: "raw"   # or "native" for full adapter generation
    ```
 
-3. Your existing `.sql` schema and query files should work as-is. sqlode supports `sqlc.arg()`, `sqlc.narg()`, `sqlc.slice()`, `sqlc.embed()`, and `@name` shorthand.
+3. Replace `sqlc.arg(...)`, `sqlc.narg(...)`, `sqlc.slice(...)`, and `sqlc.embed(...)` with `sqlode.arg(...)`, `sqlode.narg(...)`, `sqlode.slice(...)`, and `sqlode.embed(...)` in your `.sql` query files. The `@name` shorthand remains unchanged.
 
 4. Run `sqlode generate` (or `gleam run -m sqlode -- generate`).
 

--- a/integration_test/sqlite_advanced_test.sh
+++ b/integration_test/sqlite_advanced_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Integration test: advanced SQLite patterns covering expression columns
-# (COUNT, COALESCE), LEFT JOIN with null results, and sqlc.embed.
+# (COUNT, COALESCE), LEFT JOIN with null results, and sqlode.embed.
 
 set -eu
 
@@ -197,8 +197,8 @@ pub fn left_join_with_valid_author_test() {
   Nil
 }
 
-// Note: sqlc.embed() runtime test is skipped because the generated SQL
-// retains the sqlc.embed(...) macro text which is not valid SQL.
+// Note: sqlode.embed() runtime test is skipped because the generated SQL
+// retains the sqlode.embed(...) macro text which is not valid SQL.
 // The embed codegen (nested type generation + decoder) is verified
 // at the unit test level in codegen_test.gleam.
 GLEAM

--- a/integration_test/sqlite_extended_test.sh
+++ b/integration_test/sqlite_extended_test.sh
@@ -153,7 +153,7 @@ pub fn update_author_bio_execrows_test() {
   Nil
 }
 
-// ---- Test sqlc.narg (nullable parameter) ----
+// ---- Test sqlode.narg (nullable parameter) ----
 pub fn update_bio_nullable_with_value_test() {
   let db = setup_db()
 
@@ -202,7 +202,7 @@ pub fn update_bio_nullable_to_null_test() {
   Nil
 }
 
-// ---- Test sqlc.slice (WHERE IN with list param) ----
+// ---- Test sqlode.slice (WHERE IN with list param) ----
 pub fn get_authors_by_ids_slice_test() {
   let db = setup_db()
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -169,10 +169,10 @@ pub fn query_command_to_variant(command: QueryCommand) -> String {
   }
 }
 
-pub type SqlcMacro {
-  SqlcArg(index: Int, name: String)
-  SqlcNarg(index: Int, name: String)
-  SqlcSlice(index: Int, name: String)
+pub type Macro {
+  MacroArg(index: Int, name: String)
+  MacroNarg(index: Int, name: String)
+  MacroSlice(index: Int, name: String)
 }
 
 pub type ParsedQuery {
@@ -183,7 +183,7 @@ pub type ParsedQuery {
     sql: String,
     source_path: String,
     param_count: Int,
-    macros: List(SqlcMacro),
+    macros: List(Macro),
   )
 }
 

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -100,20 +100,20 @@ fn build_params(
     })
 
     let #(field_name, scalar_type, nullable, is_list) = case macro_info {
-      Some(model.SqlcArg(name:, ..)) -> {
+      Some(model.MacroArg(name:, ..)) -> {
         let n = case inferred {
           Some(column) -> column.nullable
           None -> False
         }
         #(naming.to_snake_case(ctx.naming, name), inferred_type, n, False)
       }
-      Some(model.SqlcNarg(name:, ..)) -> #(
+      Some(model.MacroNarg(name:, ..)) -> #(
         naming.to_snake_case(ctx.naming, name),
         inferred_type,
         True,
         False,
       )
-      Some(model.SqlcSlice(name:, ..)) -> #(
+      Some(model.MacroSlice(name:, ..)) -> #(
         naming.to_snake_case(ctx.naming, name),
         inferred_type,
         False,
@@ -141,17 +141,15 @@ fn build_params(
   })
 }
 
-fn macro_index(m: model.SqlcMacro) -> Int {
+fn macro_index(m: model.Macro) -> Int {
   case m {
-    model.SqlcArg(index: i, ..) -> i
-    model.SqlcNarg(index: i, ..) -> i
-    model.SqlcSlice(index: i, ..) -> i
+    model.MacroArg(index: i, ..) -> i
+    model.MacroNarg(index: i, ..) -> i
+    model.MacroSlice(index: i, ..) -> i
   }
 }
 
-fn build_macro_dict(
-  macros: List(model.SqlcMacro),
-) -> dict.Dict(Int, model.SqlcMacro) {
+fn build_macro_dict(macros: List(model.Macro)) -> dict.Dict(Int, model.Macro) {
   list.fold(macros, dict.new(), fn(d, m) { dict.insert(d, macro_index(m), m) })
 }
 

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -149,11 +149,11 @@ fn resolve_select_columns(
     _ ->
       list.try_map(columns, fn(extracted) {
         let trimmed = string.trim(extracted.name)
-        case string.starts_with(trimmed, "sqlc.embed(") {
+        case string.starts_with(trimmed, "sqlode.embed(") {
           True -> {
             let embed_name =
               trimmed
-              |> string.replace("sqlc.embed(", "")
+              |> string.replace("sqlode.embed(", "")
               |> string.replace(")", "")
               |> string.trim
               |> string.lowercase
@@ -870,15 +870,16 @@ fn tok_split_commas_loop(
 
 /// Parse a column item from tokens into ExtractedColumn.
 fn tok_parse_column_item(tokens: List(lexer.Token)) -> ExtractedColumn {
-  // Check for sqlc.embed(table) pattern: Ident("sqlc") Dot Ident("embed") LParen ...
+  // Check for sqlode.embed(table) pattern: Ident("sqlode") Dot Ident("embed") LParen ...
   case tokens {
     [lexer.Ident(name), lexer.Dot, lexer.Ident(fn_name), lexer.LParen, ..] -> {
       case
-        string.lowercase(name) == "sqlc" && string.lowercase(fn_name) == "embed"
+        string.lowercase(name) == "sqlode"
+        && string.lowercase(fn_name) == "embed"
       {
         True -> {
-          // Reconstruct as "sqlc.embed(table_name)" without extra spaces
-          let text = tok_reconstruct_sqlc_call(tokens)
+          // Reconstruct as "sqlode.embed(table_name)" without extra spaces
+          let text = tok_reconstruct_macro_call(tokens)
           ExtractedColumn(name: text, source_table: None, expression: None)
         }
         False -> tok_parse_regular_column(tokens)
@@ -888,8 +889,8 @@ fn tok_parse_column_item(tokens: List(lexer.Token)) -> ExtractedColumn {
   }
 }
 
-/// Reconstruct sqlc.embed(table) or sqlc.arg(name) without extra spaces.
-fn tok_reconstruct_sqlc_call(tokens: List(lexer.Token)) -> String {
+/// Reconstruct sqlode.embed(table) call without extra spaces.
+fn tok_reconstruct_macro_call(tokens: List(lexer.Token)) -> String {
   tokens
   |> list.map(fn(t) {
     case t {

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -28,8 +28,8 @@ type ParserContext {
     naming: naming.NamingContext,
     postgresql_param_re: regexp.Regexp,
     sqlite_param_re: regexp.Regexp,
-    sqlc_macro_re: regexp.Regexp,
-    masked_sqlc_macro_re: regexp.Regexp,
+    macro_re: regexp.Regexp,
+    masked_macro_re: regexp.Regexp,
     at_name_re: regexp.Regexp,
   )
 }
@@ -40,20 +40,20 @@ fn new_parser_context(naming_ctx: naming.NamingContext) -> ParserContext {
     regexp.from_string(
       "(\\?[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
     )
-  let assert Ok(sqlc_macro_re) =
+  let assert Ok(macro_re) =
     regexp.from_string(
-      "sqlc\\.(arg|narg|slice)\\(('[^']*'|\"[^\"]*\"|[a-zA-Z_][a-zA-Z0-9_]*)\\)",
+      "sqlode\\.(arg|narg|slice)\\(('[^']*'|\"[^\"]*\"|[a-zA-Z_][a-zA-Z0-9_]*)\\)",
     )
-  let assert Ok(masked_sqlc_macro_re) =
-    regexp.from_string("sqlc\\.(arg|narg|slice)\\(([^)]+)\\)")
+  let assert Ok(masked_macro_re) =
+    regexp.from_string("sqlode\\.(arg|narg|slice)\\(([^)]+)\\)")
   let assert Ok(at_name_re) = regexp.from_string("@([A-Za-z_][A-Za-z0-9_]*)")
 
   ParserContext(
     naming: naming_ctx,
     postgresql_param_re:,
     sqlite_param_re:,
-    sqlc_macro_re:,
-    masked_sqlc_macro_re:,
+    macro_re:,
+    masked_macro_re:,
     at_name_re:,
   )
 }
@@ -162,15 +162,9 @@ fn finalize_pending(
           let masked = mask_sql(engine, sql)
           let #(at_expanded, at_masked, at_macros, next_idx) =
             expand_at_name_shorthands(ctx, engine, sql, masked)
-          let #(expanded_sql, sqlc_macros) =
-            expand_sqlc_macros_from(
-              ctx,
-              engine,
-              at_expanded,
-              at_masked,
-              next_idx,
-            )
-          let macros = list.append(at_macros, sqlc_macros)
+          let #(expanded_sql, expanded_macros) =
+            expand_macros(ctx, engine, at_expanded, at_masked, next_idx)
+          let macros = list.append(at_macros, expanded_macros)
           let final_masked = mask_sql(engine, expanded_sql)
           Ok([
             model.ParsedQuery(
@@ -312,7 +306,7 @@ fn expand_at_name_shorthands(
   engine: model.Engine,
   sql: String,
   masked: String,
-) -> #(String, String, List(model.SqlcMacro), Int) {
+) -> #(String, String, List(model.Macro), Int) {
   case engine {
     model.MySQL -> #(sql, masked, [], 1)
     _ -> {
@@ -357,7 +351,7 @@ fn expand_at_name_shorthands(
                         #(
                           new_sql,
                           new_masked,
-                          [model.SqlcArg(index: idx, name:), ..macro_acc],
+                          [model.MacroArg(index: idx, name:), ..macro_acc],
                           idx + 1,
                           new_seen,
                         )
@@ -374,14 +368,14 @@ fn expand_at_name_shorthands(
   }
 }
 
-fn expand_sqlc_macros_from(
+fn expand_macros(
   ctx: ParserContext,
   engine: model.Engine,
   sql: String,
   masked: String,
   start_idx: Int,
-) -> #(String, List(model.SqlcMacro)) {
-  let matches = regexp.scan(ctx.masked_sqlc_macro_re, masked)
+) -> #(String, List(model.Macro)) {
+  let matches = regexp.scan(ctx.masked_macro_re, masked)
 
   case matches {
     [] -> #(sql, [])
@@ -405,12 +399,12 @@ fn expand_sqlc_macros_from(
                   match.content,
                   placeholder,
                 )
-              let sqlc_macro = case kind {
-                "narg" -> model.SqlcNarg(index: idx, name:)
-                "slice" -> model.SqlcSlice(index: idx, name:)
-                _ -> model.SqlcArg(index: idx, name:)
+              let macro_entry = case kind {
+                "narg" -> model.MacroNarg(index: idx, name:)
+                "slice" -> model.MacroSlice(index: idx, name:)
+                _ -> model.MacroArg(index: idx, name:)
               }
-              #(new_sql, new_masked, [sqlc_macro, ..macro_acc], idx + 1)
+              #(new_sql, new_masked, [macro_entry, ..macro_acc], idx + 1)
             }
             _ -> acc
           }

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -101,7 +101,7 @@ pub fn nullable(value: option.Option(a), encode: fn(a) -> Value) -> Value {
 
 /// Expand slice placeholders in a SQL string.
 ///
-/// When a query uses `sqlc.slice(ids)`, the parser emits a single placeholder
+/// When a query uses `sqlode.slice(ids)`, the parser emits a single placeholder
 /// (e.g. `$1` or `?1`).  At runtime the placeholder must be expanded to match
 /// the actual list length, and every subsequent placeholder must be renumbered.
 ///

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -438,7 +438,7 @@ fn analyzed_slice_queries(engine: model.Engine) -> List(model.AnalyzedQuery) {
   let assert Ok(catalog) =
     schema_parser.parse_files([#("test/fixtures/schema.sql", schema_content)])
   let sql =
-    "-- name: GetByIds :many\nSELECT id, name FROM authors WHERE id IN (sqlc.slice(ids));"
+    "-- name: GetByIds :many\nSELECT id, name FROM authors WHERE id IN (sqlode.slice(ids));"
   let assert Ok(queries) =
     query_parser.parse_file("slice.sql", engine, naming_ctx, sql)
   let assert Ok(result) =
@@ -714,7 +714,7 @@ pub fn readme_params_snapshot_test() {
   string.contains(rendered, "bio: Option(String)")
   |> should.be_true()
 
-  // README sqlc.slice: pub type GetAuthorsByIdsParams { GetAuthorsByIdsParams(ids: List(Int)) }
+  // README sqlode.slice: pub type GetAuthorsByIdsParams { GetAuthorsByIdsParams(ids: List(Int)) }
   string.contains(rendered, "pub type GetAuthorsByIdsParams {")
   |> should.be_true()
   string.contains(rendered, "ids: List(Int)")
@@ -754,7 +754,7 @@ pub fn readme_models_snapshot_test() {
   string.contains(rendered, "pub type ListAuthorsRow {")
   |> should.be_true()
 
-  // README sqlc.embed: pub type GetBookWithAuthorRow {
+  // README sqlode.embed: pub type GetBookWithAuthorRow {
   //   GetBookWithAuthorRow(authors: Author, title: String) }
   string.contains(rendered, "pub type GetBookWithAuthorRow {")
   |> should.be_true()

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -144,7 +144,7 @@ pub fn sqlite_at_named_placeholder_test() {
     list.find(analyzed, fn(q) { q.base.name == "GetAuthorByEmail" })
   get_by_email.base.param_count |> should.equal(1)
   let assert [param] = get_by_email.params
-  // @author_name shorthand is equivalent to sqlc.arg(author_name)
+  // @author_name shorthand is equivalent to sqlode.arg(author_name)
   param.field_name |> should.equal("author_name")
   param.scalar_type |> should.equal(model.StringType)
 }

--- a/test/fixtures/enum_query.sql
+++ b/test/fixtures/enum_query.sql
@@ -2,4 +2,4 @@
 SELECT id, name, status FROM users WHERE id = $1;
 
 -- name: ListUsersByStatuses :many
-SELECT id, name, status FROM users WHERE status IN (sqlc.slice(statuses));
+SELECT id, name, status FROM users WHERE status IN (sqlode.slice(statuses));

--- a/test/fixtures/macro_edge_cases.sql
+++ b/test/fixtures/macro_edge_cases.sql
@@ -1,14 +1,14 @@
 -- name: SearchByNameOrBio :many
 SELECT id, name, bio
 FROM authors
-WHERE name = sqlc.arg(search_term) OR bio LIKE sqlc.arg(search_term);
+WHERE name = sqlode.arg(search_term) OR bio LIKE sqlode.arg(search_term);
 
 -- name: InsertWithMixedMacros :exec
 INSERT INTO authors (name, bio)
-VALUES (sqlc.arg(author_name), sqlc.narg(author_bio));
+VALUES (sqlode.arg(author_name), sqlode.narg(author_bio));
 
 -- name: GetByMultipleIds :many
-SELECT id, name FROM authors WHERE id IN (sqlc.slice(ids));
+SELECT id, name FROM authors WHERE id IN (sqlode.slice(ids));
 
 -- name: UpdateWithNarg :exec
-UPDATE authors SET name = sqlc.arg(new_name), bio = sqlc.narg(new_bio) WHERE id = sqlc.arg(author_id);
+UPDATE authors SET name = sqlode.arg(new_name), bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);

--- a/test/fixtures/macro_query.sql
+++ b/test/fixtures/macro_query.sql
@@ -1,9 +1,9 @@
 -- name: GetAuthorByName :one
 SELECT id, name, bio
 FROM authors
-WHERE name = sqlc.arg(author_name);
+WHERE name = sqlode.arg(author_name);
 
 -- name: UpdateBio :exec
 UPDATE authors
-SET bio = sqlc.narg(new_bio)
-WHERE id = sqlc.arg(author_id);
+SET bio = sqlode.narg(new_bio)
+WHERE id = sqlode.arg(author_id);

--- a/test/fixtures/readme_query.sql
+++ b/test/fixtures/readme_query.sql
@@ -13,10 +13,10 @@ INSERT INTO authors (name, bio) VALUES ($1, $2);
 
 -- name: GetAuthorsByIds :many
 SELECT id, name FROM authors
-WHERE id IN (sqlc.slice(ids));
+WHERE id IN (sqlode.slice(ids));
 
 -- name: GetBookWithAuthor :one
-SELECT sqlc.embed(authors), books.title
+SELECT sqlode.embed(authors), books.title
 FROM books
 JOIN authors ON books.author_id = authors.id
 WHERE books.id = $1;

--- a/test/fixtures/sqlite_extended_query.sql
+++ b/test/fixtures/sqlite_extended_query.sql
@@ -8,10 +8,10 @@ INSERT INTO authors (name, bio) VALUES (?1, ?2);
 UPDATE authors SET bio = ?1 WHERE id = ?2;
 
 -- name: UpdateBioNullable :exec
-UPDATE authors SET bio = sqlc.narg(new_bio) WHERE id = sqlc.arg(author_id);
+UPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);
 
 -- name: GetAuthorsByIds :many
-SELECT id, name, bio FROM authors WHERE id IN (sqlc.slice(ids));
+SELECT id, name, bio FROM authors WHERE id IN (sqlode.slice(ids));
 
 -- name: CreatePost :exec
 INSERT INTO posts (title, body, author_id) VALUES (?1, ?2, ?3);
@@ -22,7 +22,7 @@ FROM posts JOIN authors ON posts.author_id = authors.id
 WHERE posts.id = ?1;
 
 -- name: GetAuthorsByIdsAndNames :many
-SELECT id, name, bio FROM authors WHERE id IN (sqlc.slice(ids)) AND name IN (sqlc.slice(names));
+SELECT id, name, bio FROM authors WHERE id IN (sqlode.slice(ids)) AND name IN (sqlode.slice(names));
 
 -- name: ListAuthors :many
 SELECT id, name, bio FROM authors ORDER BY name;

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -244,7 +244,7 @@ pub fn sqlc_arg_sets_param_name_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetByName :one\nSELECT id, name FROM authors WHERE name = sqlc.arg(author_name);"
+    "-- name: GetByName :one\nSELECT id, name FROM authors WHERE name = sqlode.arg(author_name);"
   let assert Ok(queries) =
     query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, sql)
 
@@ -273,7 +273,7 @@ pub fn sqlc_narg_sets_nullable_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: UpdateBio :exec\nUPDATE authors SET bio = sqlc.narg(new_bio) WHERE id = sqlc.arg(author_id);"
+    "-- name: UpdateBio :exec\nUPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);"
   let assert Ok(queries) =
     query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, sql)
 
@@ -297,7 +297,7 @@ pub fn sqlc_slice_sets_is_list_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetByIds :many\nSELECT id, name FROM authors WHERE id IN (sqlc.slice(ids));"
+    "-- name: GetByIds :many\nSELECT id, name FROM authors WHERE id IN (sqlode.slice(ids));"
   let assert Ok(queries) =
     query_parser.parse_file("slice.sql", model.PostgreSQL, naming_ctx, sql)
 
@@ -373,7 +373,7 @@ pub fn sqlc_embed_expands_table_columns_test() {
   let naming_ctx = naming.new()
   let catalog = join_catalog()
   let sql =
-    "-- name: GetBookFull :one\nSELECT sqlc.embed(authors), books.title FROM books JOIN authors ON books.author_id = authors.id WHERE books.id = $1;"
+    "-- name: GetBookFull :one\nSELECT sqlode.embed(authors), books.title FROM books JOIN authors ON books.author_id = authors.id WHERE books.id = $1;"
   let assert Ok(queries) =
     query_parser.parse_file("embed.sql", model.PostgreSQL, naming_ctx, sql)
 

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -75,7 +75,7 @@ pub fn expand_sqlc_arg_macro_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlc.arg(author_name);"
+    <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
     query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
@@ -83,8 +83,8 @@ pub fn expand_sqlc_arg_macro_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
-  string.contains(query.sql, "sqlc.arg") |> should.be_false()
+  |> should.equal([model.MacroArg(index: 1, name: "author_name")])
+  string.contains(query.sql, "sqlode.arg") |> should.be_false()
   string.contains(query.sql, "$1") |> should.be_true()
 }
 
@@ -92,7 +92,7 @@ pub fn expand_sqlc_narg_macro_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: UpdateBio :exec\n"
-    <> "UPDATE authors SET bio = sqlc.narg(new_bio) WHERE id = sqlc.arg(author_id);"
+    <> "UPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
     query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
@@ -101,18 +101,18 @@ pub fn expand_sqlc_narg_macro_test() {
   query.param_count |> should.equal(2)
   query.macros
   |> should.equal([
-    model.SqlcNarg(index: 1, name: "new_bio"),
-    model.SqlcArg(index: 2, name: "author_id"),
+    model.MacroNarg(index: 1, name: "new_bio"),
+    model.MacroArg(index: 2, name: "author_id"),
   ])
-  string.contains(query.sql, "sqlc.narg") |> should.be_false()
-  string.contains(query.sql, "sqlc.arg") |> should.be_false()
+  string.contains(query.sql, "sqlode.narg") |> should.be_false()
+  string.contains(query.sql, "sqlode.arg") |> should.be_false()
 }
 
 pub fn expand_sqlc_arg_mysql_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlc.arg(author_name);"
+    <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
     query_parser.parse_file("arg_mysql.sql", model.MySQL, naming_ctx, content)
@@ -128,7 +128,7 @@ pub fn expand_sqlc_arg_single_quoted_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlc.arg('author_name');"
+    <> "SELECT id FROM authors WHERE name = sqlode.arg('author_name');"
 
   let assert Ok(queries) =
     query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
@@ -136,8 +136,8 @@ pub fn expand_sqlc_arg_single_quoted_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
-  string.contains(query.sql, "sqlc.arg") |> should.be_false()
+  |> should.equal([model.MacroArg(index: 1, name: "author_name")])
+  string.contains(query.sql, "sqlode.arg") |> should.be_false()
   string.contains(query.sql, "$1") |> should.be_true()
 }
 
@@ -145,7 +145,7 @@ pub fn expand_sqlc_arg_double_quoted_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlc.arg(\"author_name\");"
+    <> "SELECT id FROM authors WHERE name = sqlode.arg(\"author_name\");"
 
   let assert Ok(queries) =
     query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
@@ -153,14 +153,14 @@ pub fn expand_sqlc_arg_double_quoted_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+  |> should.equal([model.MacroArg(index: 1, name: "author_name")])
 }
 
 pub fn expand_sqlc_narg_single_quoted_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: UpdateBio :exec\n"
-    <> "UPDATE authors SET bio = sqlc.narg('new_bio') WHERE id = sqlc.arg(author_id);"
+    <> "UPDATE authors SET bio = sqlode.narg('new_bio') WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
     query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
@@ -169,8 +169,8 @@ pub fn expand_sqlc_narg_single_quoted_test() {
   query.param_count |> should.equal(2)
   query.macros
   |> should.equal([
-    model.SqlcNarg(index: 1, name: "new_bio"),
-    model.SqlcArg(index: 2, name: "author_id"),
+    model.MacroNarg(index: 1, name: "new_bio"),
+    model.MacroArg(index: 2, name: "author_id"),
   ])
 }
 
@@ -178,14 +178,14 @@ pub fn expand_sqlc_slice_double_quoted_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetByIds :many\n"
-    <> "SELECT id, name FROM authors WHERE id IN (sqlc.slice(\"ids\"));"
+    <> "SELECT id, name FROM authors WHERE id IN (sqlode.slice(\"ids\"));"
 
   let assert Ok(queries) =
     query_parser.parse_file("slice.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.macros
-  |> should.equal([model.SqlcSlice(index: 1, name: "ids")])
+  |> should.equal([model.MacroSlice(index: 1, name: "ids")])
 }
 
 // @name shorthand tests
@@ -202,7 +202,7 @@ pub fn expand_at_name_postgresql_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+  |> should.equal([model.MacroArg(index: 1, name: "author_name")])
   string.contains(query.sql, "@author_name") |> should.be_false()
   string.contains(query.sql, "$1") |> should.be_true()
 }
@@ -219,7 +219,7 @@ pub fn expand_at_name_sqlite_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "author_name")])
+  |> should.equal([model.MacroArg(index: 1, name: "author_name")])
   string.contains(query.sql, "@author_name") |> should.be_false()
   string.contains(query.sql, "?1") |> should.be_true()
 }
@@ -237,8 +237,8 @@ pub fn expand_multiple_at_names_test() {
   query.param_count |> should.equal(2)
   query.macros
   |> should.equal([
-    model.SqlcArg(index: 1, name: "new_bio"),
-    model.SqlcArg(index: 2, name: "author_id"),
+    model.MacroArg(index: 1, name: "new_bio"),
+    model.MacroArg(index: 2, name: "author_id"),
   ])
   string.contains(query.sql, "$1") |> should.be_true()
   string.contains(query.sql, "$2") |> should.be_true()
@@ -248,7 +248,7 @@ pub fn expand_at_name_mixed_with_sqlc_arg_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: Update :exec\n"
-    <> "UPDATE authors SET bio = @new_bio WHERE id = sqlc.arg(author_id);"
+    <> "UPDATE authors SET bio = @new_bio WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
     query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
@@ -257,8 +257,8 @@ pub fn expand_at_name_mixed_with_sqlc_arg_test() {
   query.param_count |> should.equal(2)
   query.macros
   |> should.equal([
-    model.SqlcArg(index: 1, name: "new_bio"),
-    model.SqlcArg(index: 2, name: "author_id"),
+    model.MacroArg(index: 1, name: "new_bio"),
+    model.MacroArg(index: 2, name: "author_id"),
   ])
 }
 
@@ -436,7 +436,7 @@ pub fn ignore_at_name_in_string_literal_test() {
 
   // @skip_me inside string should not be expanded
   query.param_count |> should.equal(1)
-  query.macros |> should.equal([model.SqlcArg(index: 1, name: "real_id")])
+  query.macros |> should.equal([model.MacroArg(index: 1, name: "real_id")])
   string.contains(query.sql, "'@skip_me'") |> should.be_true()
 }
 
@@ -600,7 +600,7 @@ pub fn sqlc_arg_in_string_literal_ignored_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: MacroInString :one\n"
-    <> "SELECT id FROM authors WHERE note = 'sqlc.arg(fake)' AND id = sqlc.arg(real_id);"
+    <> "SELECT id FROM authors WHERE note = 'sqlode.arg(fake)' AND id = sqlode.arg(real_id);"
 
   let assert Ok(queries) =
     query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -608,8 +608,8 @@ pub fn sqlc_arg_in_string_literal_ignored_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "real_id")])
-  string.contains(query.sql, "'sqlc.arg(fake)'") |> should.be_true()
+  |> should.equal([model.MacroArg(index: 1, name: "real_id")])
+  string.contains(query.sql, "'sqlode.arg(fake)'") |> should.be_true()
 }
 
 pub fn sqlc_narg_in_line_comment_ignored_test() {
@@ -617,8 +617,8 @@ pub fn sqlc_narg_in_line_comment_ignored_test() {
   let content =
     "-- name: MacroInComment :one\n"
     <> "SELECT id FROM authors\n"
-    <> "-- WHERE name = sqlc.narg(ignored)\n"
-    <> "WHERE id = sqlc.arg(real_id);"
+    <> "-- WHERE name = sqlode.narg(ignored)\n"
+    <> "WHERE id = sqlode.arg(real_id);"
 
   let assert Ok(queries) =
     query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -626,7 +626,7 @@ pub fn sqlc_narg_in_line_comment_ignored_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcArg(index: 1, name: "real_id")])
+  |> should.equal([model.MacroArg(index: 1, name: "real_id")])
 }
 
 pub fn sqlc_slice_in_block_comment_ignored_test() {
@@ -634,7 +634,7 @@ pub fn sqlc_slice_in_block_comment_ignored_test() {
   let content =
     "-- name: MacroInBlock :many\n"
     <> "SELECT id FROM authors\n"
-    <> "WHERE /* sqlc.slice(phantom) */ id IN (sqlc.slice(real_ids));"
+    <> "WHERE /* sqlode.slice(phantom) */ id IN (sqlode.slice(real_ids));"
 
   let assert Ok(queries) =
     query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -642,7 +642,7 @@ pub fn sqlc_slice_in_block_comment_ignored_test() {
 
   query.param_count |> should.equal(1)
   query.macros
-  |> should.equal([model.SqlcSlice(index: 1, name: "real_ids")])
+  |> should.equal([model.MacroSlice(index: 1, name: "real_ids")])
 }
 
 pub fn error_to_string_coverage_test() {

--- a/test/sqlc_compat_test.gleam
+++ b/test/sqlc_compat_test.gleam
@@ -390,7 +390,7 @@ pub fn macro_duplicate_arg_name_test() {
 
   let assert Ok(search) =
     list.find(queries, fn(q) { q.name == "SearchByNameOrBio" })
-  // Two sqlc.arg(search_term) should produce two separate placeholders
+  // Two sqlode.arg(search_term) should produce two separate placeholders
   search.param_count |> should.equal(2)
   list.length(search.macros) |> should.equal(2)
 }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Replace all `sqlc.*` query macro syntax with `sqlode.*` to establish the project's own identity before public release. No compatibility aliases are kept.

- `sqlc.arg(name)` → `sqlode.arg(name)`
- `sqlc.narg(name)` → `sqlode.narg(name)`
- `sqlc.slice(name)` → `sqlode.slice(name)`
- `sqlc.embed(table)` → `sqlode.embed(table)`

## Changes

- **`src/sqlode/model.gleam`**: Rename types `SqlcMacro` → `Macro`, `SqlcArg` → `MacroArg`, `SqlcNarg` → `MacroNarg`, `SqlcSlice` → `MacroSlice`
- **`src/sqlode/query_parser.gleam`**: Update regex patterns from `sqlc\\.` to `sqlode\\.`, rename `sqlc_macro_re` → `macro_re`, `masked_sqlc_macro_re` → `masked_macro_re`, and related function/variable names
- **`src/sqlode/query_analyzer.gleam`**: Update all references to renamed model types
- **`src/sqlode/query_analyzer/column_inferencer.gleam`**: Update `sqlc.embed` string matching to `sqlode.embed`, rename helper function
- **`src/sqlode/runtime.gleam`**: Update doc comment
- **`test/`**: Update all test files and SQL fixtures from `sqlc.*` to `sqlode.*` syntax and renamed model types
- **`README.md`**: Update all examples, macro reference table, and migration notes to reflect new syntax
- **`integration_test/`**: Update comments referencing `sqlc.*` macros

## Migration guide

Users migrating from sqlc or previous sqlode versions need to find-and-replace in their `.sql` query files:
- `sqlc.arg(` → `sqlode.arg(`
- `sqlc.narg(` → `sqlode.narg(`
- `sqlc.slice(` → `sqlode.slice(`
- `sqlc.embed(` → `sqlode.embed(`

The `@name` shorthand syntax is unchanged.

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SQL macro function namespace: `sqlc.arg()`, `sqlc.narg()`, `sqlc.slice()`, and `sqlc.embed()` are now `sqlode.arg()`, `sqlode.narg()`, `sqlode.slice()`, and `sqlode.embed()` respectively. Update existing SQL queries to use the new naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->