### PR TITLE
fix!: unify QueryCommand enum — deduplicate model.gleam and runtime.gleam

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -5,6 +5,7 @@ import gleam/string
 import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
+import sqlode/runtime
 
 type AdapterConfig {
   AdapterConfig(
@@ -130,8 +131,8 @@ fn render_adapter(
 
   let has_exec_rows =
     list.any(queries, fn(query) {
-      query.base.command == model.ExecRows
-      || query.base.command == model.ExecResult
+      query.base.command == runtime.QueryExecRows
+      || query.base.command == runtime.QueryExecResult
     })
 
   let has_slices = common.queries_have_slices(queries)
@@ -202,11 +203,11 @@ fn render_adapter_function(
 
   comment
   <> case query.base.command {
-    model.One | model.BatchOne ->
+    runtime.QueryOne | runtime.QueryBatchOne ->
       render_adapter_one(ctx, query, fn_name, has_params)
-    model.Many | model.BatchMany ->
+    runtime.QueryMany | runtime.QueryBatchMany ->
       render_adapter_many(ctx, query, fn_name, has_params)
-    model.Exec | model.BatchExec | model.CopyFrom ->
+    runtime.QueryExec | runtime.QueryBatchExec | runtime.QueryCopyFrom ->
       render_adapter_exec(
         ctx.naming_ctx,
         query,
@@ -214,7 +215,7 @@ fn render_adapter_function(
         has_params,
         ctx.config,
       )
-    model.ExecResult ->
+    runtime.QueryExecResult ->
       render_adapter_exec(
         ctx.naming_ctx,
         query,
@@ -222,7 +223,7 @@ fn render_adapter_function(
         has_params,
         ctx.config,
       )
-    model.ExecRows ->
+    runtime.QueryExecRows ->
       render_adapter_exec_rows(
         ctx.naming_ctx,
         query,
@@ -230,7 +231,7 @@ fn render_adapter_function(
         has_params,
         ctx.config,
       )
-    model.ExecLastId ->
+    runtime.QueryExecLastId ->
       render_adapter_exec_last_id(
         ctx.naming_ctx,
         query,
@@ -1059,7 +1060,8 @@ fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {
         }
       })
     let has_one_command =
-      query.base.command == model.One || query.base.command == model.BatchOne
+      query.base.command == runtime.QueryOne
+      || query.base.command == runtime.QueryBatchOne
 
     has_nullable_params || has_nullable_results || has_one_command
   })

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -134,7 +134,7 @@ fn render_query_function(
         "    name: \"" <> common.escape_string(query.base.name) <> "\",",
         "    sql: \"" <> common.escape_string(query.base.sql) <> "\",",
         "    command: runtime."
-          <> model.query_command_to_variant(query.base.command)
+          <> model.query_command_to_string(query.base.command)
           <> ",",
         "    param_count: " <> int.to_string(query.base.param_count) <> ",",
         encode_line,
@@ -153,7 +153,7 @@ fn render_query_info_literal(query: model.ParsedQuery) -> String {
   <> "\", sql: \""
   <> common.escape_string(query.sql)
   <> "\", command: runtime."
-  <> model.query_command_to_variant(query.command)
+  <> model.query_command_to_string(query.command)
   <> ", param_count: "
   <> int.to_string(query.param_count)
   <> ")"

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -14,6 +14,7 @@ import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
 import sqlode/query_parser
+import sqlode/runtime
 import sqlode/schema_parser
 import sqlode/writer
 
@@ -481,20 +482,22 @@ fn find_column_rename(
 fn validate_unsupported_annotations(
   queries: List(model.AnalyzedQuery),
 ) -> Result(Nil, GenerateError) {
-  let unsupported = fn(command: model.QueryCommand) -> Bool {
+  let unsupported = fn(command: runtime.QueryCommand) -> Bool {
     case command {
-      model.BatchOne | model.BatchMany | model.BatchExec | model.CopyFrom ->
-        True
+      runtime.QueryBatchOne
+      | runtime.QueryBatchMany
+      | runtime.QueryBatchExec
+      | runtime.QueryCopyFrom -> True
       _ -> False
     }
   }
   case list.find(queries, fn(q) { unsupported(q.base.command) }) {
     Ok(q) -> {
       let #(command, alternative) = case q.base.command {
-        model.BatchOne -> #(":batchone", ":one")
-        model.BatchMany -> #(":batchmany", ":many")
-        model.BatchExec -> #(":batchexec", ":exec")
-        model.CopyFrom -> #(":copyfrom", ":exec")
+        runtime.QueryBatchOne -> #(":batchone", ":one")
+        runtime.QueryBatchMany -> #(":batchmany", ":many")
+        runtime.QueryBatchExec -> #(":batchexec", ":exec")
+        runtime.QueryCopyFrom -> #(":copyfrom", ":exec")
         _ -> #("", ":exec")
       }
       Error(UnsupportedAnnotation(
@@ -513,7 +516,7 @@ fn validate_unsupported_annotations(
 fn validate_native_annotations(
   queries: List(model.AnalyzedQuery),
 ) -> Result(Nil, GenerateError) {
-  case list.find(queries, fn(q) { q.base.command == model.ExecResult }) {
+  case list.find(queries, fn(q) { q.base.command == runtime.QueryExecResult }) {
     Ok(q) ->
       Error(UnsupportedAnnotation(
         query_name: q.base.name,

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -1,6 +1,7 @@
 import gleam/list
 import gleam/option.{type Option}
 import gleam/string
+import sqlode/runtime
 
 pub type Engine {
   PostgreSQL
@@ -115,38 +116,30 @@ pub type Config {
   Config(version: Int, sql: List(SqlBlock))
 }
 
-pub type QueryCommand {
-  One
-  Many
-  Exec
-  ExecResult
-  ExecRows
-  ExecLastId
-  BatchOne
-  BatchMany
-  BatchExec
-  CopyFrom
-}
-
-pub fn is_result_command(command: QueryCommand) -> Bool {
+pub fn is_result_command(command: runtime.QueryCommand) -> Bool {
   case command {
-    One | Many | BatchOne | BatchMany -> True
+    runtime.QueryOne
+    | runtime.QueryMany
+    | runtime.QueryBatchOne
+    | runtime.QueryBatchMany -> True
     _ -> False
   }
 }
 
-pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
+pub fn parse_query_command(
+  value: String,
+) -> Result(runtime.QueryCommand, String) {
   case value {
-    ":one" -> Ok(One)
-    ":many" -> Ok(Many)
-    ":exec" -> Ok(Exec)
-    ":execresult" -> Ok(ExecResult)
-    ":execrows" -> Ok(ExecRows)
-    ":execlastid" -> Ok(ExecLastId)
-    ":batchone" -> Ok(BatchOne)
-    ":batchmany" -> Ok(BatchMany)
-    ":batchexec" -> Ok(BatchExec)
-    ":copyfrom" -> Ok(CopyFrom)
+    ":one" -> Ok(runtime.QueryOne)
+    ":many" -> Ok(runtime.QueryMany)
+    ":exec" -> Ok(runtime.QueryExec)
+    ":execresult" -> Ok(runtime.QueryExecResult)
+    ":execrows" -> Ok(runtime.QueryExecRows)
+    ":execlastid" -> Ok(runtime.QueryExecLastId)
+    ":batchone" -> Ok(runtime.QueryBatchOne)
+    ":batchmany" -> Ok(runtime.QueryBatchMany)
+    ":batchexec" -> Ok(runtime.QueryBatchExec)
+    ":copyfrom" -> Ok(runtime.QueryCopyFrom)
     _ ->
       Error(
         "must be one of: :one, :many, :exec, :execresult, :execrows, :execlastid, :batchone, :batchmany, :batchexec, :copyfrom",
@@ -154,18 +147,18 @@ pub fn parse_query_command(value: String) -> Result(QueryCommand, String) {
   }
 }
 
-pub fn query_command_to_variant(command: QueryCommand) -> String {
+pub fn query_command_to_string(command: runtime.QueryCommand) -> String {
   case command {
-    One -> "QueryOne"
-    Many -> "QueryMany"
-    Exec -> "QueryExec"
-    ExecResult -> "QueryExecResult"
-    ExecRows -> "QueryExecRows"
-    ExecLastId -> "QueryExecLastId"
-    BatchOne -> "QueryBatchOne"
-    BatchMany -> "QueryBatchMany"
-    BatchExec -> "QueryBatchExec"
-    CopyFrom -> "QueryCopyFrom"
+    runtime.QueryOne -> "QueryOne"
+    runtime.QueryMany -> "QueryMany"
+    runtime.QueryExec -> "QueryExec"
+    runtime.QueryExecResult -> "QueryExecResult"
+    runtime.QueryExecRows -> "QueryExecRows"
+    runtime.QueryExecLastId -> "QueryExecLastId"
+    runtime.QueryBatchOne -> "QueryBatchOne"
+    runtime.QueryBatchMany -> "QueryBatchMany"
+    runtime.QueryBatchExec -> "QueryBatchExec"
+    runtime.QueryCopyFrom -> "QueryCopyFrom"
   }
 }
 
@@ -179,7 +172,7 @@ pub type ParsedQuery {
   ParsedQuery(
     name: String,
     function_name: String,
-    command: QueryCommand,
+    command: runtime.QueryCommand,
     sql: String,
     source_path: String,
     param_count: Int,

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -9,6 +9,7 @@ import sqlode/query_analyzer/context.{
   type AnalysisError, type AnalyzerContext, ColumnNotFound,
   CompoundColumnCountMismatch, TableNotFound,
 }
+import sqlode/runtime
 
 type ExtractedColumn {
   ExtractedColumn(
@@ -25,13 +26,16 @@ pub fn infer_result_columns(
   catalog: model.Catalog,
 ) -> Result(List(model.ResultColumn), AnalysisError) {
   case query.command {
-    model.Exec
-    | model.ExecResult
-    | model.ExecRows
-    | model.ExecLastId
-    | model.BatchExec
-    | model.CopyFrom -> Ok([])
-    model.One | model.Many | model.BatchOne | model.BatchMany -> {
+    runtime.QueryExec
+    | runtime.QueryExecResult
+    | runtime.QueryExecRows
+    | runtime.QueryExecLastId
+    | runtime.QueryBatchExec
+    | runtime.QueryCopyFrom -> Ok([])
+    runtime.QueryOne
+    | runtime.QueryMany
+    | runtime.QueryBatchOne
+    | runtime.QueryBatchMany -> {
       let tokens = lexer.tokenize(query.sql, engine)
       let normalized = context.normalize_sql(ctx, query.sql)
 

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -7,6 +7,7 @@ import gleam/result
 import gleam/string
 import sqlode/model
 import sqlode/naming
+import sqlode/runtime
 
 pub type ParseError {
   InvalidAnnotation(path: String, line: Int, detail: String)
@@ -17,7 +18,7 @@ type PendingQuery {
   PendingQuery(
     name: String,
     function_name: String,
-    command: model.QueryCommand,
+    command: runtime.QueryCommand,
     start_line: Int,
     body_rev: List(String),
   )

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -6,6 +6,7 @@ import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
 import sqlode/query_parser
+import sqlode/runtime
 import sqlode/schema_parser
 
 pub fn main() {
@@ -251,7 +252,7 @@ pub fn exec_result_command_test() {
     )
 
   let assert [query] = analyzed
-  query.base.command |> should.equal(model.ExecResult)
+  query.base.command |> should.equal(runtime.QueryExecResult)
   query.result_columns |> should.equal([])
   query.base.param_count |> should.equal(1)
 }
@@ -272,7 +273,7 @@ pub fn exec_rows_command_test() {
     )
 
   let assert [query] = analyzed
-  query.base.command |> should.equal(model.ExecRows)
+  query.base.command |> should.equal(runtime.QueryExecRows)
   query.result_columns |> should.equal([])
 }
 
@@ -287,7 +288,7 @@ pub fn exec_last_id_command_test() {
     query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, queries)
 
   let assert [query] = analyzed
-  query.base.command |> should.equal(model.ExecLastId)
+  query.base.command |> should.equal(runtime.QueryExecLastId)
   query.result_columns |> should.equal([])
 }
 

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -3,6 +3,7 @@ import gleam/string
 import gleeunit
 import gleeunit/should
 import sqlode/model
+import sqlode/runtime
 
 pub fn main() {
   gleeunit.main()
@@ -47,45 +48,50 @@ pub fn parse_runtime_invalid_test() {
 // parse_query_command tests
 
 pub fn parse_query_command_one_test() {
-  model.parse_query_command(":one") |> should.equal(Ok(model.One))
+  model.parse_query_command(":one") |> should.equal(Ok(runtime.QueryOne))
 }
 
 pub fn parse_query_command_many_test() {
-  model.parse_query_command(":many") |> should.equal(Ok(model.Many))
+  model.parse_query_command(":many") |> should.equal(Ok(runtime.QueryMany))
 }
 
 pub fn parse_query_command_exec_test() {
-  model.parse_query_command(":exec") |> should.equal(Ok(model.Exec))
+  model.parse_query_command(":exec") |> should.equal(Ok(runtime.QueryExec))
 }
 
 pub fn parse_query_command_execresult_test() {
   model.parse_query_command(":execresult")
-  |> should.equal(Ok(model.ExecResult))
+  |> should.equal(Ok(runtime.QueryExecResult))
 }
 
 pub fn parse_query_command_execrows_test() {
-  model.parse_query_command(":execrows") |> should.equal(Ok(model.ExecRows))
+  model.parse_query_command(":execrows")
+  |> should.equal(Ok(runtime.QueryExecRows))
 }
 
 pub fn parse_query_command_execlastid_test() {
   model.parse_query_command(":execlastid")
-  |> should.equal(Ok(model.ExecLastId))
+  |> should.equal(Ok(runtime.QueryExecLastId))
 }
 
 pub fn parse_query_command_batchone_test() {
-  model.parse_query_command(":batchone") |> should.equal(Ok(model.BatchOne))
+  model.parse_query_command(":batchone")
+  |> should.equal(Ok(runtime.QueryBatchOne))
 }
 
 pub fn parse_query_command_batchmany_test() {
-  model.parse_query_command(":batchmany") |> should.equal(Ok(model.BatchMany))
+  model.parse_query_command(":batchmany")
+  |> should.equal(Ok(runtime.QueryBatchMany))
 }
 
 pub fn parse_query_command_batchexec_test() {
-  model.parse_query_command(":batchexec") |> should.equal(Ok(model.BatchExec))
+  model.parse_query_command(":batchexec")
+  |> should.equal(Ok(runtime.QueryBatchExec))
 }
 
 pub fn parse_query_command_copyfrom_test() {
-  model.parse_query_command(":copyfrom") |> should.equal(Ok(model.CopyFrom))
+  model.parse_query_command(":copyfrom")
+  |> should.equal(Ok(runtime.QueryCopyFrom))
 }
 
 pub fn parse_query_command_invalid_test() {
@@ -107,17 +113,20 @@ pub fn runtime_to_string_roundtrip_test() {
   model.runtime_to_string(model.Native) |> should.equal("native")
 }
 
-// query_command_to_variant tests
+// query_command_to_string tests
 
-pub fn query_command_to_variant_test() {
-  model.query_command_to_variant(model.One) |> should.equal("QueryOne")
-  model.query_command_to_variant(model.Many) |> should.equal("QueryMany")
-  model.query_command_to_variant(model.Exec) |> should.equal("QueryExec")
-  model.query_command_to_variant(model.ExecResult)
+pub fn query_command_to_string_test() {
+  model.query_command_to_string(runtime.QueryOne)
+  |> should.equal("QueryOne")
+  model.query_command_to_string(runtime.QueryMany)
+  |> should.equal("QueryMany")
+  model.query_command_to_string(runtime.QueryExec)
+  |> should.equal("QueryExec")
+  model.query_command_to_string(runtime.QueryExecResult)
   |> should.equal("QueryExecResult")
-  model.query_command_to_variant(model.ExecRows)
+  model.query_command_to_string(runtime.QueryExecRows)
   |> should.equal("QueryExecRows")
-  model.query_command_to_variant(model.ExecLastId)
+  model.query_command_to_string(runtime.QueryExecLastId)
   |> should.equal("QueryExecLastId")
 }
 

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -6,6 +6,7 @@ import simplifile
 import sqlode/model
 import sqlode/naming
 import sqlode/query_parser
+import sqlode/runtime
 
 pub fn main() {
   gleeunit.main()
@@ -27,11 +28,11 @@ pub fn parse_queries_from_sqlc_annotations_test() {
   let assert [get_author, list_authors] = queries
   get_author.name |> should.equal("GetAuthor")
   get_author.function_name |> should.equal("get_author")
-  get_author.command |> should.equal(model.One)
+  get_author.command |> should.equal(runtime.QueryOne)
   get_author.param_count |> should.equal(1)
   get_author.macros |> should.equal([])
   list_authors.function_name |> should.equal("list_authors")
-  list_authors.command |> should.equal(model.Many)
+  list_authors.command |> should.equal(runtime.QueryMany)
 }
 
 pub fn reject_query_without_sql_body_test() {
@@ -327,11 +328,11 @@ pub fn multiple_queries_test() {
 
   let assert [q1, q2, q3] = queries
   q1.name |> should.equal("Q1")
-  q1.command |> should.equal(model.One)
+  q1.command |> should.equal(runtime.QueryOne)
   q2.name |> should.equal("Q2")
-  q2.command |> should.equal(model.Many)
+  q2.command |> should.equal(runtime.QueryMany)
   q3.name |> should.equal("Q3")
-  q3.command |> should.equal(model.Exec)
+  q3.command |> should.equal(runtime.QueryExec)
 }
 
 pub fn all_command_types_test() {
@@ -349,12 +350,12 @@ pub fn all_command_types_test() {
   list.length(queries) |> should.equal(6)
 
   let assert [a, b, c, d, e, f] = queries
-  a.command |> should.equal(model.One)
-  b.command |> should.equal(model.Many)
-  c.command |> should.equal(model.Exec)
-  d.command |> should.equal(model.ExecResult)
-  e.command |> should.equal(model.ExecRows)
-  f.command |> should.equal(model.ExecLastId)
+  a.command |> should.equal(runtime.QueryOne)
+  b.command |> should.equal(runtime.QueryMany)
+  c.command |> should.equal(runtime.QueryExec)
+  d.command |> should.equal(runtime.QueryExecResult)
+  e.command |> should.equal(runtime.QueryExecRows)
+  f.command |> should.equal(runtime.QueryExecLastId)
 }
 
 pub fn multiline_sql_body_test() {

--- a/test/sqlc_compat_test.gleam
+++ b/test/sqlc_compat_test.gleam
@@ -6,6 +6,7 @@ import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
 import sqlode/query_parser
+import sqlode/runtime
 import sqlode/schema_parser
 
 pub fn main() {
@@ -224,7 +225,7 @@ pub fn complex_query_basic_crud_test() {
   // GetPost :one - should have result columns
   let assert Ok(get_post) =
     list.find(analyzed, fn(q) { q.base.name == "GetPost" })
-  get_post.base.command |> should.equal(model.One)
+  get_post.base.command |> should.equal(runtime.QueryOne)
   list.length(get_post.result_columns) |> should.equal(4)
   let assert [id, title, body, published] = get_post.result_columns
   let assert model.ResultColumn(scalar_type: id_type, ..) = id
@@ -239,14 +240,14 @@ pub fn complex_query_basic_crud_test() {
   // CreatePost :exec - no result columns
   let assert Ok(create_post) =
     list.find(analyzed, fn(q) { q.base.name == "CreatePost" })
-  create_post.base.command |> should.equal(model.Exec)
+  create_post.base.command |> should.equal(runtime.QueryExec)
   create_post.result_columns |> should.equal([])
   create_post.base.param_count |> should.equal(8)
 
   // DeletePost :exec
   let assert Ok(delete_post) =
     list.find(analyzed, fn(q) { q.base.name == "DeletePost" })
-  delete_post.base.command |> should.equal(model.Exec)
+  delete_post.base.command |> should.equal(runtime.QueryExec)
   delete_post.base.param_count |> should.equal(1)
 }
 
@@ -327,7 +328,7 @@ pub fn complex_query_returning_clause_test() {
   // INSERT ... RETURNING
   let assert Ok(create_returning) =
     list.find(analyzed, fn(q) { q.base.name == "CreatePostReturning" })
-  create_returning.base.command |> should.equal(model.One)
+  create_returning.base.command |> should.equal(runtime.QueryOne)
   list.length(create_returning.result_columns) |> should.equal(2)
   let assert [id, title] = create_returning.result_columns
   id.name |> should.equal("id")
@@ -338,13 +339,13 @@ pub fn complex_query_returning_clause_test() {
   // DELETE ... RETURNING
   let assert Ok(delete_returning) =
     list.find(analyzed, fn(q) { q.base.name == "DeletePostReturning" })
-  delete_returning.base.command |> should.equal(model.One)
+  delete_returning.base.command |> should.equal(runtime.QueryOne)
   list.length(delete_returning.result_columns) |> should.equal(2)
 
   // UPDATE ... RETURNING
   let assert Ok(update_returning) =
     list.find(analyzed, fn(q) { q.base.name == "UpdatePostReturning" })
-  update_returning.base.command |> should.equal(model.One)
+  update_returning.base.command |> should.equal(runtime.QueryOne)
   list.length(update_returning.result_columns) |> should.equal(3)
   let assert [_, _, published] = update_returning.result_columns
   published.name |> should.equal("published")


### PR DESCRIPTION
## Summary
- Remove the duplicate `QueryCommand` type from `model.gleam` and use `runtime.QueryCommand` as the single source of truth
- Eliminate the fragile string-based `query_command_to_variant` bridging function, replaced by compile-time safe `query_command_to_string`
- All internal code now references `runtime.QueryCommand` variants directly

## Changes
- **model.gleam**: Removed `QueryCommand` type definition; `parse_query_command`, `is_result_command`, and `query_command_to_string` now operate on `runtime.QueryCommand`
- **codegen/adapter.gleam**: Pattern matches updated from `model.One` → `runtime.QueryOne` etc.
- **codegen/queries.gleam**: Uses `query_command_to_string` instead of `query_command_to_variant`
- **query_parser.gleam**: `PendingQuery.command` field now typed as `runtime.QueryCommand`
- **query_analyzer/column_inferencer.gleam**: Pattern matches updated to runtime variants
- **generate.gleam**: Validation functions updated to runtime variants
- All test files updated to reference `runtime.QueryCommand` variants

## Design Decisions
- Kept variant names with `Query` prefix (e.g., `QueryOne`, `QueryMany`) since these are the public API in `runtime.gleam`
- `query_command_to_string` still exists for codegen (emitting variant names as string literals in generated code), but now takes and returns the same type, providing compile-time exhaustiveness checking

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal query command type definitions and associated utility functions for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->