### PR TITLE
refactor(analyzer): remove dead regexes and primary_table_name from AnalyzerContext

### DIFF
--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -1,6 +1,6 @@
 import gleam/int
 import gleam/list
-import gleam/option.{type Option, None, Some}
+import gleam/option.{type Option, None}
 import gleam/regexp
 import gleam/string
 import sqlode/model
@@ -68,14 +68,7 @@ pub type AnalyzerContext {
     mysql_placeholder_re: regexp.Regexp,
     sqlite_placeholder_re: regexp.Regexp,
     whitespace_re: regexp.Regexp,
-    table_from_re: regexp.Regexp,
-    table_into_re: regexp.Regexp,
-    table_update_re: regexp.Regexp,
-    table_delete_re: regexp.Regexp,
-    cte_re: regexp.Regexp,
     returning_re: regexp.Regexp,
-    join_re: regexp.Regexp,
-    select_columns_re: regexp.Regexp,
     type_cast_re: regexp.Regexp,
     in_clause_re: regexp.Regexp,
   )
@@ -97,24 +90,8 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
       "(\\?[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
     )
   let assert Ok(whitespace_re) = regexp.from_string("\\s+")
-  let assert Ok(table_from_re) =
-    regexp.from_string("from\\s+([a-zA-Z_][a-zA-Z0-9_]*)")
-  let assert Ok(table_into_re) =
-    regexp.from_string("into\\s+([a-zA-Z_][a-zA-Z0-9_]*)")
-  let assert Ok(table_update_re) =
-    regexp.from_string("update\\s+([a-zA-Z_][a-zA-Z0-9_]*)")
-  let assert Ok(table_delete_re) =
-    regexp.from_string("delete\\s+from\\s+([a-zA-Z_][a-zA-Z0-9_]*)")
-  let assert Ok(cte_re) =
-    regexp.from_string("^with\\s+.+\\)\\s+(select|insert|update|delete)\\s")
   let assert Ok(returning_re) =
     regexp.from_string("returning\\s+(.+?)\\s*;?\\s*$")
-  let assert Ok(join_re) =
-    regexp.from_string(
-      "(?:(left|right|full|inner|cross)\\s+(?:outer\\s+)?)?join\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s",
-    )
-  let assert Ok(select_columns_re) =
-    regexp.from_string("select\\s+(.+?)\\s+from\\s")
   let assert Ok(type_cast_re) =
     regexp.from_string("(\\$[0-9]+)::[a-zA-Z_][a-zA-Z0-9_]*")
   let assert Ok(in_clause_re) =
@@ -130,14 +107,7 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     mysql_placeholder_re:,
     sqlite_placeholder_re:,
     whitespace_re:,
-    table_from_re:,
-    table_into_re:,
-    table_update_re:,
-    table_delete_re:,
-    cte_re:,
     returning_re:,
-    join_re:,
-    select_columns_re:,
     type_cast_re:,
     in_clause_re:,
   )
@@ -147,30 +117,6 @@ pub fn normalize_sql(ctx: AnalyzerContext, sql: String) -> String {
   let lowered = string.lowercase(sql)
   regexp.replace(ctx.whitespace_re, lowered, " ")
   |> string.trim
-}
-
-pub fn primary_table_name(ctx: AnalyzerContext, sql: String) -> Option(String) {
-  let regexes = [
-    ctx.table_from_re,
-    ctx.table_into_re,
-    ctx.table_update_re,
-    ctx.table_delete_re,
-  ]
-  find_first_match(regexes, sql)
-}
-
-fn find_first_match(regexes: List(regexp.Regexp), sql: String) -> Option(String) {
-  list.find_map(regexes, fn(re) {
-    case regexp.scan(re, sql) {
-      [match, ..] ->
-        case match.submatches {
-          [Some(name)] -> Ok(name)
-          _ -> Error(Nil)
-        }
-      [] -> Error(Nil)
-    }
-  })
-  |> option.from_result
 }
 
 pub fn find_column(


### PR DESCRIPTION
## Summary
- Remove 7 unused regex fields from `AnalyzerContext` that were superseded by token-based code paths
- Delete the `primary_table_name` function and its helper `find_first_match` (~55 lines of dead code)

## Changes
- **context.gleam**: Removed `table_from_re`, `table_into_re`, `table_update_re`, `table_delete_re`, `cte_re`, `join_re`, `select_columns_re` fields and their compilation from `new()`
- Removed `primary_table_name` and `find_first_match` functions
- Cleaned up unused `Some` import

## Design Decisions
- Only removed regexes confirmed to have zero call sites outside `context.gleam` itself
- Kept the 9 regexes that are still actively used by `param_inferencer`, `placeholder`, `column_inferencer`, and `normalize_sql`

Closes #231