### PR TITLE
refactor(codegen): use ScalarTypeInfo as source of truth for strong type unwrap functions

### DIFF
--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -1,5 +1,6 @@
 import gleam/dict.{type Dict}
 import gleam/list
+import gleam/option
 import gleam/string
 import sqlode/model
 import sqlode/naming
@@ -145,10 +146,14 @@ fn render_semantic_type_aliases(
   catalog: model.Catalog,
   queries: List(model.AnalyzedQuery),
 ) -> String {
-  let all_types = collect_rich_types(catalog, queries)
+  let all_types = collect_rich_scalar_types(catalog, queries)
 
   all_types
-  |> list.map(fn(alias_name) { "pub type " <> alias_name <> " =\n  String" })
+  |> list.map(fn(scalar_type) {
+    let alias_name =
+      model.scalar_type_to_gleam_type(scalar_type, model.RichMapping)
+    "pub type " <> alias_name <> " =\n  String"
+  })
   |> string.join("\n\n")
 }
 
@@ -156,11 +161,16 @@ fn render_strong_type_wrappers(
   catalog: model.Catalog,
   queries: List(model.AnalyzedQuery),
 ) -> String {
-  let all_types = collect_rich_types(catalog, queries)
+  let all_types = collect_rich_scalar_types(catalog, queries)
 
   all_types
-  |> list.map(fn(type_name) {
-    let unwrap_fn = strong_type_unwrap_fn_from_name(type_name)
+  |> list.map(fn(scalar_type) {
+    let type_name =
+      model.scalar_type_to_gleam_type(scalar_type, model.StrongMapping)
+    let unwrap_fn = case model.strong_type_unwrap_fn(scalar_type) {
+      option.Some(fn_name) -> fn_name
+      option.None -> type_name <> "_to_string"
+    }
     "pub type "
     <> type_name
     <> " {\n  "
@@ -176,31 +186,16 @@ fn render_strong_type_wrappers(
   |> string.join("\n\n")
 }
 
-fn strong_type_unwrap_fn_from_name(type_name: String) -> String {
-  case type_name {
-    "SqlTimestamp" -> "sql_timestamp_to_string"
-    "SqlDate" -> "sql_date_to_string"
-    "SqlTime" -> "sql_time_to_string"
-    "SqlUuid" -> "sql_uuid_to_string"
-    "SqlJson" -> "sql_json_to_string"
-    _ -> "unknown_to_string"
-  }
-}
-
-fn collect_rich_types(
+fn collect_rich_scalar_types(
   catalog: model.Catalog,
   queries: List(model.AnalyzedQuery),
-) -> List(String) {
+) -> List(model.ScalarType) {
   let table_types =
     catalog.tables
     |> list.flat_map(fn(table) {
       list.filter_map(table.columns, fn(col) {
         case model.is_rich_type(col.scalar_type) {
-          True ->
-            Ok(model.scalar_type_to_gleam_type(
-              col.scalar_type,
-              model.RichMapping,
-            ))
+          True -> Ok(col.scalar_type)
           False -> Error(Nil)
         }
       })
@@ -213,11 +208,7 @@ fn collect_rich_types(
         case col {
           model.ResultColumn(scalar_type:, ..) ->
             case model.is_rich_type(scalar_type) {
-              True ->
-                Ok(model.scalar_type_to_gleam_type(
-                  scalar_type,
-                  model.RichMapping,
-                ))
+              True -> Ok(scalar_type)
               False -> Error(Nil)
             }
           model.EmbeddedColumn(..) -> Error(Nil)
@@ -227,7 +218,12 @@ fn collect_rich_types(
 
   list.flatten([table_types, query_types])
   |> list.unique
-  |> list.sort(string.compare)
+  |> list.sort(fn(a, b) {
+    string.compare(
+      model.scalar_type_to_gleam_type(a, model.RichMapping),
+      model.scalar_type_to_gleam_type(b, model.RichMapping),
+    )
+  })
 }
 
 fn needs_option_import_for_results(queries: List(model.AnalyzedQuery)) -> Bool {


### PR DESCRIPTION
## Summary
- Replace hardcoded `strong_type_unwrap_fn_from_name` string mapping with `model.strong_type_unwrap_fn(ScalarType)` lookup from the authoritative `ScalarTypeInfo` table
- Change `collect_rich_types` to return `List(ScalarType)` instead of `List(String)`, preserving type information for downstream consumers

## Changes
- **models.gleam**: Renamed `collect_rich_types` → `collect_rich_scalar_types`, now returns `List(model.ScalarType)` instead of `List(String)`
- `render_semantic_type_aliases` derives type name from `ScalarType` via `scalar_type_to_gleam_type`
- `render_strong_type_wrappers` derives both type name and unwrap function from `ScalarType` via `model.strong_type_unwrap_fn`
- Deleted `strong_type_unwrap_fn_from_name` (the fragile string-to-string mapping)

## Design Decisions
- Uses `model.strong_type_unwrap_fn(scalar_type)` which delegates to `ScalarTypeInfo`, ensuring any new rich type added to `model.gleam` automatically gets the correct unwrap function
- Falls back to `TypeName_to_string` pattern if `unwrap_fn` is `None`, though this should never happen for rich types

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code generation logic for semantic type aliases and strong type wrappers to streamline type collection and mapping processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->