### PR TITLE
refactor(runtime): move QueryInfo type into runtime.gleam instead of re-generating per output

### DIFF
--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -58,16 +58,7 @@ pub fn render(
       imports,
       [
         "",
-        "pub type QueryInfo {",
-        "  QueryInfo(",
-        "    name: String,",
-        "    sql: String,",
-        "    command: runtime.QueryCommand,",
-        "    param_count: Int,",
-        "  )",
-        "}",
-        "",
-        "pub fn all() -> List(QueryInfo) {",
+        "pub fn all() -> List(runtime.QueryInfo) {",
         "  " <> all_items,
         "}",
         "",
@@ -148,7 +139,7 @@ fn render_query_function(
 }
 
 fn render_query_info_literal(query: model.ParsedQuery) -> String {
-  "QueryInfo(name: \""
+  "runtime.QueryInfo(name: \""
   <> common.escape_string(query.name)
   <> "\", sql: \""
   <> common.escape_string(query.sql)

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -26,6 +26,12 @@ pub type Value {
   SqlArray(List(Value))
 }
 
+/// Lightweight metadata for a query, used by the generated `all()` function
+/// to list every query in a module without carrying encoder closures.
+pub type QueryInfo {
+  QueryInfo(name: String, sql: String, command: QueryCommand, param_count: Int)
+}
+
 /// A typed raw query descriptor that bundles SQL metadata with its parameter
 /// encoder.  The type parameter `p` represents the parameter type for this
 /// query, which ties the query to its expected parameters at the type level.

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -39,7 +39,7 @@ pub fn render_queries_module_test() {
   |> should.be_true()
   string.contains(rendered, "slice_info: fn(_) { [] },")
   |> should.be_true()
-  string.contains(rendered, "pub fn all() -> List(QueryInfo) {")
+  string.contains(rendered, "pub fn all() -> List(runtime.QueryInfo) {")
   |> should.be_true()
   list.length(analyzed) |> should.equal(2)
   // Parameterless query should use Nil type and inline encode
@@ -792,12 +792,12 @@ pub fn readme_queries_snapshot_test() {
   )
   |> should.be_true()
 
-  // README: QueryInfo type
+  // QueryInfo is now in runtime, not generated inline
   string.contains(rendered, "pub type QueryInfo {")
-  |> should.be_true()
+  |> should.be_false()
 
-  // README: pub fn all() -> List(QueryInfo) { ... }
-  string.contains(rendered, "pub fn all() -> List(QueryInfo) {")
+  // all() uses runtime.QueryInfo
+  string.contains(rendered, "pub fn all() -> List(runtime.QueryInfo) {")
   |> should.be_true()
 }
 


### PR DESCRIPTION
## Summary
- Move `QueryInfo` type definition from generated `queries.gleam` into `runtime.gleam` as a shared type
- Generated code now references `runtime.QueryInfo` instead of defining its own copy per SQL block

## Changes
- **runtime.gleam**: Added `QueryInfo` type alongside `RawQuery` and `QueryCommand`
- **codegen/queries.gleam**: Removed inline `QueryInfo` type definition from generated output; `all()` now returns `List(runtime.QueryInfo)` and literals use `runtime.QueryInfo(...)`
- **test/codegen_test.gleam**: Updated assertions to verify `QueryInfo` is no longer generated inline and `runtime.QueryInfo` is referenced instead

## Design Decisions
- `QueryInfo` is a natural companion to `RawQuery` — it carries the same metadata fields (name, sql, command, param_count) without the encoder closures, making it suitable for introspection
- Users with multiple SQL blocks now share a single `QueryInfo` type definition instead of getting incompatible duplicates

Closes #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code generation now references query metadata through a shared runtime type instead of generating it locally in each module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->