### PR TITLE
refactor(lexer): extract duplicated token-to-string rendering into shared lexer function

### DIFF
--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -2,6 +2,17 @@ import gleam/list
 import gleam/string
 import sqlode/model
 
+/// Options for controlling how tokens are rendered back to text.
+pub type TokenRenderOptions {
+  TokenRenderOptions(
+    /// When True, SQL keywords are rendered in UPPERCASE.
+    uppercase_keywords: Bool,
+    /// When True, quoted identifiers keep their quotes and string
+    /// literals escape embedded single-quotes.
+    preserve_quotes: Bool,
+  )
+}
+
 /// A SQL token produced by the lexer.
 pub type Token {
   /// SQL keyword (lowercased): SELECT, FROM, CREATE, etc.
@@ -636,4 +647,69 @@ fn is_alpha(g: String) -> Bool {
     _ -> 0
   }
   { cp >= 65 && cp <= 90 } || { cp >= 97 && cp <= 122 }
+}
+
+/// Render a list of tokens back to a SQL string with smart spacing.
+pub fn tokens_to_string(
+  tokens: List(Token),
+  options: TokenRenderOptions,
+) -> String {
+  tokens_to_string_loop(tokens, [], options)
+  |> list.reverse
+  |> string.concat
+}
+
+fn tokens_to_string_loop(
+  tokens: List(Token),
+  acc: List(String),
+  options: TokenRenderOptions,
+) -> List(String) {
+  case tokens {
+    [] -> acc
+    [token, ..rest] -> {
+      let s = token_to_string(token, options)
+      let with_space = case acc, token {
+        _, Comma | _, Semicolon | _, LParen | _, RParen | _, Dot | _, Star -> [
+          s,
+          ..acc
+        ]
+        ["(", ..], _ | [".", ..], _ -> [s, ..acc]
+        _, Operator("[") -> [s, ..acc]
+        ["]", ..], _ | ["[", ..], _ -> [s, ..acc]
+        [], _ -> [s]
+        _, _ -> [s, " ", ..acc]
+      }
+      tokens_to_string_loop(rest, with_space, options)
+    }
+  }
+}
+
+fn token_to_string(token: Token, options: TokenRenderOptions) -> String {
+  case token {
+    Keyword(k) ->
+      case options.uppercase_keywords {
+        True -> string.uppercase(k)
+        False -> k
+      }
+    Ident(name) -> name
+    QuotedIdent(name) ->
+      case options.preserve_quotes {
+        True -> "\"" <> name <> "\""
+        False -> name
+      }
+    StringLit(value) ->
+      case options.preserve_quotes {
+        True -> "'" <> string.replace(value, "'", "''") <> "'"
+        False -> "'" <> value <> "'"
+      }
+    NumberLit(n) -> n
+    Placeholder(p) -> p
+    Operator(op) -> op
+    LParen -> "("
+    RParen -> ")"
+    Comma -> ","
+    Semicolon -> ";"
+    Dot -> "."
+    Star -> "*"
+  }
 }

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -979,48 +979,9 @@ fn tok_find_last_as_idx(
   }
 }
 
-/// Convert token list to text with smart spacing (no space before parens/dots/commas).
 fn tok_tokens_to_text(tokens: List(lexer.Token)) -> String {
-  tok_text_loop(tokens, [])
-  |> list.reverse
-  |> string.concat
-}
-
-fn tok_text_loop(tokens: List(lexer.Token), acc: List(String)) -> List(String) {
-  case tokens {
-    [] -> acc
-    [token, ..rest] -> {
-      let s = case token {
-        lexer.Keyword(k) -> k
-        lexer.Ident(n) -> n
-        lexer.QuotedIdent(n) -> n
-        lexer.StringLit(s) -> "'" <> s <> "'"
-        lexer.NumberLit(n) -> n
-        lexer.Placeholder(p) -> p
-        lexer.Operator(op) -> op
-        lexer.LParen -> "("
-        lexer.RParen -> ")"
-        lexer.Comma -> ","
-        lexer.Semicolon -> ";"
-        lexer.Dot -> "."
-        lexer.Star -> "*"
-      }
-      let with_space = case acc, token {
-        // No space before these
-        _, lexer.LParen
-        | _, lexer.RParen
-        | _, lexer.Comma
-        | _, lexer.Dot
-        | _, lexer.Star
-        -> [s, ..acc]
-        // No space after LParen or Dot
-        ["(", ..], _ | [".", ..], _ -> [s, ..acc]
-        // First token
-        [], _ -> [s]
-        // Default: space before
-        _, _ -> [s, " ", ..acc]
-      }
-      tok_text_loop(rest, with_space)
-    }
-  }
+  lexer.tokens_to_string(
+    tokens,
+    lexer.TokenRenderOptions(uppercase_keywords: False, preserve_quotes: False),
+  )
 }

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -155,59 +155,11 @@ fn extract_enum_values(
   }
 }
 
-/// Reconstruct a SQL string from tokens (for backward compatibility with
-/// string-based parsing functions during incremental migration).
 fn tokens_to_string(tokens: List(lexer.Token)) -> String {
-  tokens_to_string_loop(tokens, [])
-  |> list.reverse
-  |> string.concat
-}
-
-fn tokens_to_string_loop(
-  tokens: List(lexer.Token),
-  acc: List(String),
-) -> List(String) {
-  case tokens {
-    [] -> acc
-    [token, ..rest] -> {
-      let s = token_to_string(token)
-      let with_space = case acc, token {
-        // No space before these tokens
-        _, lexer.Comma | _, lexer.Semicolon | _, lexer.RParen | _, lexer.Dot -> [
-          s,
-          ..acc
-        ]
-        // No space after LParen or Dot
-        ["(", ..], _ | [".", ..], _ -> [s, ..acc]
-        // No space before/after [] (array syntax)
-        _, lexer.Operator("[") -> [s, ..acc]
-        ["]", ..], _ | ["[", ..], _ -> [s, ..acc]
-        // First token
-        [], _ -> [s]
-        // Default: add space before
-        _, _ -> [s, " ", ..acc]
-      }
-      tokens_to_string_loop(rest, with_space)
-    }
-  }
-}
-
-fn token_to_string(token: lexer.Token) -> String {
-  case token {
-    lexer.Keyword(k) -> string.uppercase(k)
-    lexer.Ident(name) -> name
-    lexer.QuotedIdent(name) -> "\"" <> name <> "\""
-    lexer.StringLit(value) -> "'" <> string.replace(value, "'", "''") <> "'"
-    lexer.NumberLit(n) -> n
-    lexer.Placeholder(p) -> p
-    lexer.Operator(op) -> op
-    lexer.LParen -> "("
-    lexer.RParen -> ")"
-    lexer.Comma -> ","
-    lexer.Semicolon -> ";"
-    lexer.Dot -> "."
-    lexer.Star -> "*"
-  }
+  lexer.tokens_to_string(
+    tokens,
+    lexer.TokenRenderOptions(uppercase_keywords: True, preserve_quotes: True),
+  )
 }
 
 fn parse_statement(


### PR DESCRIPTION
## Summary
- Extract two duplicate token-to-string implementations into a single `lexer.tokens_to_string` function with configurable rendering options
- Both `schema_parser.gleam` and `column_inferencer.gleam` now delegate to the shared implementation

## Changes
- **lexer.gleam**: Added `TokenRenderOptions` type and `tokens_to_string(tokens, options)` function with smart spacing rules (superset of both original implementations)
- **schema_parser.gleam**: Replaced 3 local functions (~50 lines) with a one-liner calling `lexer.tokens_to_string` with `uppercase_keywords: True, preserve_quotes: True`
- **column_inferencer.gleam**: Replaced 2 local functions (~45 lines) with a one-liner calling `lexer.tokens_to_string` with `uppercase_keywords: False, preserve_quotes: False`

## Design Decisions
- `TokenRenderOptions` controls two axes of variation: keyword casing and quote/escaping behavior
- Spacing rules are the superset of both implementations (no space before comma, semicolon, parens, dot, star; no space after lparen/dot; array bracket handling)
- Each caller wraps the shared function in a thin local function to preserve its existing API

Closes #240