### PR TITLE
refactor(analyzer): extract duplicated tok_* helpers into shared token_utils module

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -9,6 +9,7 @@ import sqlode/query_analyzer/context.{
   type AnalysisError, type AnalyzerContext, ColumnNotFound,
   CompoundColumnCountMismatch, TableNotFound,
 }
+import sqlode/query_analyzer/token_utils
 import sqlode/runtime
 
 type ExtractedColumn {
@@ -42,7 +43,7 @@ pub fn infer_result_columns(
       // RETURNING clause still uses regex (works well, no subquery risk)
       case extract_returning_columns(ctx, normalized) {
         Some(returning_cols) -> {
-          let table_names = tok_extract_table_names(tokens)
+          let table_names = token_utils.extract_table_names(tokens)
           let nullable_tables = tok_extract_nullable_tables(tokens, table_names)
           case table_names {
             [] -> Ok([])
@@ -64,7 +65,7 @@ pub fn infer_result_columns(
             main_tokens,
           ))
           let main_tokens2 = tok_strip_compound(main_tokens)
-          let table_names = tok_extract_table_names(main_tokens2)
+          let table_names = token_utils.extract_table_names(main_tokens2)
           let nullable_tables =
             tok_extract_nullable_tables(main_tokens2, table_names)
 
@@ -217,7 +218,11 @@ fn resolve_select_columns(
                 }
               None ->
                 case
-                  find_column_in_tables(catalog, all_tables, normalized_name)
+                  context.find_column_in_tables(
+                    catalog,
+                    all_tables,
+                    normalized_name,
+                  )
                 {
                   Some(#(found_table, column)) ->
                     Ok([
@@ -465,7 +470,7 @@ fn resolve_column_type(
     Ok(#(_, col)) -> string.trim(col)
     Error(_) -> name
   }
-  case find_column_in_tables(catalog, table_names, col_name) {
+  case context.find_column_in_tables(catalog, table_names, col_name) {
     Some(#(_, column)) -> Some(column.scalar_type)
     None -> None
   }
@@ -478,20 +483,6 @@ fn is_integer_literal(s: String) -> Bool {
     let value = string.utf_codepoint_to_int(cp)
     value >= 48 && value <= 57
   })
-}
-
-fn find_column_in_tables(
-  catalog: model.Catalog,
-  table_names: List(String),
-  column_name: String,
-) -> Option(#(String, model.Column)) {
-  list.find_map(table_names, fn(name) {
-    case context.find_column(catalog, name, column_name) {
-      Some(col) -> Ok(#(name, col))
-      None -> Error(Nil)
-    }
-  })
-  |> option.from_result
 }
 
 // ============================================================
@@ -513,24 +504,10 @@ fn tok_skip_cte_defs(tokens: List(lexer.Token)) -> List(lexer.Token) {
       if kw == "select" || kw == "insert" || kw == "update" || kw == "delete"
     -> tokens
     [lexer.LParen, ..rest] -> {
-      let remaining = tok_skip_parens(rest, 1)
+      let remaining = token_utils.skip_parens(rest, 1)
       tok_skip_cte_defs(remaining)
     }
     [_, ..rest] -> tok_skip_cte_defs(rest)
-  }
-}
-
-/// Skip tokens until matching closing paren.
-fn tok_skip_parens(tokens: List(lexer.Token), depth: Int) -> List(lexer.Token) {
-  case depth <= 0 {
-    True -> tokens
-    False ->
-      case tokens {
-        [] -> []
-        [lexer.LParen, ..rest] -> tok_skip_parens(rest, depth + 1)
-        [lexer.RParen, ..rest] -> tok_skip_parens(rest, depth - 1)
-        [_, ..rest] -> tok_skip_parens(rest, depth)
-      }
   }
 }
 
@@ -654,64 +631,6 @@ fn tok_split_compound_branches_loop(
   }
 }
 
-/// Extract table names from FROM/JOIN/INTO/UPDATE keywords.
-fn tok_extract_table_names(tokens: List(lexer.Token)) -> List(String) {
-  tok_table_names_loop(tokens, [])
-  |> list.unique
-}
-
-fn tok_table_names_loop(
-  tokens: List(lexer.Token),
-  acc: List(String),
-) -> List(String) {
-  case tokens {
-    [] -> list.reverse(acc)
-    // FROM (SELECT ...) — skip subquery
-    [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
-      let remaining = tok_skip_parens(rest, 1)
-      tok_table_names_loop(remaining, acc)
-    }
-    // FROM table, INTO table, UPDATE table
-    [lexer.Keyword(kw), ..rest]
-      if kw == "from" || kw == "into" || kw == "update"
-    -> {
-      let #(name, remaining) = tok_read_table_name(rest)
-      case name {
-        Some(n) -> tok_table_names_loop(remaining, [n, ..acc])
-        None -> tok_table_names_loop(rest, acc)
-      }
-    }
-    // JOIN table (possibly preceded by LEFT/RIGHT/FULL/INNER/CROSS + OUTER)
-    [lexer.Keyword("join"), ..rest] -> {
-      let #(name, remaining) = tok_read_table_name(rest)
-      case name {
-        Some(n) -> tok_table_names_loop(remaining, [n, ..acc])
-        None -> tok_table_names_loop(rest, acc)
-      }
-    }
-    [_, ..rest] -> tok_table_names_loop(rest, acc)
-  }
-}
-
-/// Read the next table name (handling schema.table → last part).
-fn tok_read_table_name(
-  tokens: List(lexer.Token),
-) -> #(Option(String), List(lexer.Token)) {
-  case tokens {
-    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), ..rest] -> #(
-      Some(string.lowercase(name)),
-      rest,
-    )
-    [lexer.Ident(name), ..rest] -> #(Some(string.lowercase(name)), rest)
-    [lexer.QuotedIdent(name), ..rest] -> #(Some(string.lowercase(name)), rest)
-    [lexer.LParen, ..rest] -> {
-      let remaining = tok_skip_parens(rest, 1)
-      #(None, remaining)
-    }
-    _ -> #(None, tokens)
-  }
-}
-
 /// Extract nullable tables from LEFT/RIGHT/FULL JOIN keywords.
 fn tok_extract_nullable_tables(
   tokens: List(lexer.Token),
@@ -741,7 +660,7 @@ fn tok_nullable_loop(
       let rest2 = tok_skip_keyword(rest, "outer")
       case rest2 {
         [lexer.Keyword("join"), ..after_join] -> {
-          let #(name, remaining) = tok_read_table_name(after_join)
+          let #(name, remaining) = token_utils.read_table_name(after_join)
           case name {
             Some(n) ->
               tok_nullable_loop(remaining, [n, ..acc], primary_nullable)
@@ -756,7 +675,7 @@ fn tok_nullable_loop(
       let rest2 = tok_skip_keyword(rest, "outer")
       case rest2 {
         [lexer.Keyword("join"), ..after_join] -> {
-          let #(name, remaining) = tok_read_table_name(after_join)
+          let #(name, remaining) = token_utils.read_table_name(after_join)
           case name {
             Some(n) -> tok_nullable_loop(remaining, [n, ..acc], True)
             None -> tok_nullable_loop(remaining, acc, True)

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -1,6 +1,6 @@
 import gleam/int
 import gleam/list
-import gleam/option.{type Option, None}
+import gleam/option.{type Option, None, Some}
 import gleam/regexp
 import gleam/string
 import sqlode/model
@@ -138,6 +138,22 @@ pub fn find_column(
       |> option.from_result
     Error(_) -> None
   }
+}
+
+/// Search for a column across multiple tables, returning the column and the
+/// table name where it was found.
+pub fn find_column_in_tables(
+  catalog: model.Catalog,
+  table_names: List(String),
+  column_name: String,
+) -> Option(#(String, model.Column)) {
+  list.find_map(table_names, fn(name) {
+    case find_column(catalog, name, column_name) {
+      Some(col) -> Ok(#(name, col))
+      None -> Error(Nil)
+    }
+  })
+  |> option.from_result
 }
 
 pub fn split_csv(text: String) -> List(String) {

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -1,7 +1,7 @@
 import gleam/dict
 import gleam/int
 import gleam/list
-import gleam/option.{type Option, None, Some}
+import gleam/option.{None, Some}
 import gleam/regexp
 import gleam/string
 import sqlode/lexer
@@ -9,6 +9,7 @@ import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer/context.{type AnalyzerContext}
 import sqlode/query_analyzer/placeholder
+import sqlode/query_analyzer/token_utils
 
 pub fn infer_insert_params(
   ctx: AnalyzerContext,
@@ -96,7 +97,7 @@ pub fn infer_equality_params(
 ) -> List(#(Int, model.Column)) {
   let normalized = context.normalize_sql(ctx, query.sql)
   let tokens = lexer.tokenize(query.sql, engine)
-  let all_tables = tok_extract_table_names(tokens)
+  let all_tables = token_utils.extract_table_names(tokens)
 
   case all_tables {
     [] -> []
@@ -148,7 +149,14 @@ fn scan_equality_matches(
                 Some(table) ->
                   context.find_column(catalog, table, normalized_col)
                 None ->
-                  find_column_in_tables(catalog, all_tables, normalized_col)
+                  option.map(
+                    context.find_column_in_tables(
+                      catalog,
+                      all_tables,
+                      normalized_col,
+                    ),
+                    fn(pair) { pair.1 },
+                  )
               }
               case found {
                 Some(column) -> [#(index, column), ..acc]
@@ -204,7 +212,7 @@ pub fn infer_in_params(
 ) -> List(#(Int, model.Column)) {
   let normalized = context.normalize_sql(ctx, query.sql)
   let tokens = lexer.tokenize(query.sql, engine)
-  let all_tables = tok_extract_table_names(tokens)
+  let all_tables = token_utils.extract_table_names(tokens)
 
   case all_tables {
     [] -> []
@@ -259,87 +267,4 @@ pub fn extract_type_casts(
 fn cast_type_to_scalar(type_name: String) -> Result(model.ScalarType, Nil) {
   model.parse_sql_type(string.trim(type_name))
 }
-
 // --- Token-based helpers ---
-
-/// Search all tables for a column by name.
-fn find_column_in_tables(
-  catalog: model.Catalog,
-  table_names: List(String),
-  column_name: String,
-) -> Option(model.Column) {
-  list.find_map(table_names, fn(name) {
-    case context.find_column(catalog, name, column_name) {
-      Some(col) -> Ok(col)
-      None -> Error(Nil)
-    }
-  })
-  |> option.from_result
-}
-
-/// Extract table names from tokens (FROM/JOIN/INTO/UPDATE).
-fn tok_extract_table_names(tokens: List(lexer.Token)) -> List(String) {
-  tok_table_names_loop(tokens, [])
-  |> list.unique
-}
-
-fn tok_table_names_loop(
-  tokens: List(lexer.Token),
-  acc: List(String),
-) -> List(String) {
-  case tokens {
-    [] -> list.reverse(acc)
-    [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
-      let remaining = tok_skip_parens(rest, 1)
-      tok_table_names_loop(remaining, acc)
-    }
-    [lexer.Keyword(kw), ..rest]
-      if kw == "from" || kw == "into" || kw == "update"
-    -> {
-      let #(name, remaining) = tok_read_table_name(rest)
-      case name {
-        Some(n) -> tok_table_names_loop(remaining, [n, ..acc])
-        None -> tok_table_names_loop(rest, acc)
-      }
-    }
-    [lexer.Keyword("join"), ..rest] -> {
-      let #(name, remaining) = tok_read_table_name(rest)
-      case name {
-        Some(n) -> tok_table_names_loop(remaining, [n, ..acc])
-        None -> tok_table_names_loop(rest, acc)
-      }
-    }
-    [_, ..rest] -> tok_table_names_loop(rest, acc)
-  }
-}
-
-fn tok_read_table_name(
-  tokens: List(lexer.Token),
-) -> #(Option(String), List(lexer.Token)) {
-  case tokens {
-    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), ..rest] -> #(
-      Some(string.lowercase(name)),
-      rest,
-    )
-    [lexer.Ident(name), ..rest] -> #(Some(string.lowercase(name)), rest)
-    [lexer.QuotedIdent(name), ..rest] -> #(Some(string.lowercase(name)), rest)
-    [lexer.LParen, ..rest] -> {
-      let remaining = tok_skip_parens(rest, 1)
-      #(None, remaining)
-    }
-    _ -> #(None, tokens)
-  }
-}
-
-fn tok_skip_parens(tokens: List(lexer.Token), depth: Int) -> List(lexer.Token) {
-  case depth <= 0 {
-    True -> tokens
-    False ->
-      case tokens {
-        [] -> []
-        [lexer.LParen, ..rest] -> tok_skip_parens(rest, depth + 1)
-        [lexer.RParen, ..rest] -> tok_skip_parens(rest, depth - 1)
-        [_, ..rest] -> tok_skip_parens(rest, depth)
-      }
-  }
-}

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -1,0 +1,74 @@
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import sqlode/lexer
+
+/// Extract all table names referenced in a token list (FROM, INTO, UPDATE, JOIN).
+pub fn extract_table_names(tokens: List(lexer.Token)) -> List(String) {
+  table_names_loop(tokens, [])
+  |> list.unique
+}
+
+fn table_names_loop(
+  tokens: List(lexer.Token),
+  acc: List(String),
+) -> List(String) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      table_names_loop(remaining, acc)
+    }
+    [lexer.Keyword(kw), ..rest]
+      if kw == "from" || kw == "into" || kw == "update"
+    -> {
+      let #(name, remaining) = read_table_name(rest)
+      case name {
+        Some(n) -> table_names_loop(remaining, [n, ..acc])
+        None -> table_names_loop(rest, acc)
+      }
+    }
+    [lexer.Keyword("join"), ..rest] -> {
+      let #(name, remaining) = read_table_name(rest)
+      case name {
+        Some(n) -> table_names_loop(remaining, [n, ..acc])
+        None -> table_names_loop(rest, acc)
+      }
+    }
+    [_, ..rest] -> table_names_loop(rest, acc)
+  }
+}
+
+/// Read a table name from the current token position, handling schema-qualified
+/// names (schema.table) and subqueries in parentheses.
+pub fn read_table_name(
+  tokens: List(lexer.Token),
+) -> #(Option(String), List(lexer.Token)) {
+  case tokens {
+    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), ..rest] -> #(
+      Some(string.lowercase(name)),
+      rest,
+    )
+    [lexer.Ident(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    [lexer.QuotedIdent(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    [lexer.LParen, ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      #(None, remaining)
+    }
+    _ -> #(None, tokens)
+  }
+}
+
+/// Skip tokens until all parentheses at the given depth are closed.
+pub fn skip_parens(tokens: List(lexer.Token), depth: Int) -> List(lexer.Token) {
+  case depth <= 0 {
+    True -> tokens
+    False ->
+      case tokens {
+        [] -> []
+        [lexer.LParen, ..rest] -> skip_parens(rest, depth + 1)
+        [lexer.RParen, ..rest] -> skip_parens(rest, depth - 1)
+        [_, ..rest] -> skip_parens(rest, depth)
+      }
+  }
+}


### PR DESCRIPTION
## Summary
- Extract 4 duplicated token navigation functions from `column_inferencer.gleam` and `param_inferencer.gleam` into a new shared `token_utils.gleam` module
- Consolidate `find_column_in_tables` into `context.gleam` alongside the existing `find_column`

## Changes
- **New file `query_analyzer/token_utils.gleam`**: Contains `extract_table_names`, `read_table_name`, and `skip_parens` — previously duplicated verbatim in both inferencer modules
- **context.gleam**: Added `find_column_in_tables` that returns `Option(#(String, model.Column))` (table name + column)
- **column_inferencer.gleam**: Removed ~65 lines of duplicated code, now imports from `token_utils` and `context`
- **param_inferencer.gleam**: Removed ~80 lines of duplicated code, now imports from `token_utils` and `context`

## Design Decisions
- `find_column_in_tables` returns the richer `#(String, model.Column)` tuple (needed by column_inferencer); param_inferencer maps to extract just the column via `option.map`
- `schema_parser.find_column_in_tables` was left unchanged as it takes `List(model.Table)` directly rather than `catalog + table_names`, making it a different function

Closes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated token parsing utilities into a dedicated module for improved code organization and reduced duplication across query analyzers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->