### PR TITLE
refactor(codegen): deduplicate param_accessors_flattened by reusing render_param_value

### DIFF
--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -266,92 +266,18 @@ fn param_accessors_flattened(
 ) -> List(String) {
   params
   |> list.map(fn(param) {
-    let value_expr = "params." <> param.field_name
-    let runtime_fn = model.scalar_type_to_runtime_function(param.scalar_type)
-    let unwrap = strong_unwrap_expr(param.scalar_type, type_mapping)
-
     case param.is_list {
-      True ->
-        case param.scalar_type {
-          model.EnumType(name) -> {
-            let to_str = "models." <> model.enum_to_string_fn(name)
-            "list.map("
-            <> value_expr
-            <> ", fn(v) { "
-            <> runtime_fn
-            <> "("
-            <> to_str
-            <> "(v)) })"
-          }
-          _ ->
-            case unwrap {
-              option.None ->
-                "list.map(" <> value_expr <> ", " <> runtime_fn <> ")"
-              option.Some(fn_name) ->
-                "list.map("
-                <> value_expr
-                <> ", fn(v) { "
-                <> runtime_fn
-                <> "("
-                <> fn_name
-                <> "(v)) })"
-            }
-        }
-      False ->
-        case param.scalar_type {
-          model.EnumType(name) -> {
-            let to_str = "models." <> model.enum_to_string_fn(name)
-            case param.nullable {
-              True -> {
-                let encode_fn =
-                  "fn(v) { " <> runtime_fn <> "(" <> to_str <> "(v)) }"
-                "[runtime.nullable(" <> value_expr <> ", " <> encode_fn <> ")]"
-              }
-              False ->
-                "[" <> runtime_fn <> "(" <> to_str <> "(" <> value_expr <> "))]"
-            }
-          }
-          model.ArrayType(element) -> {
-            let mapper = render_array_element_mapper(element, type_mapping)
-            case param.nullable {
-              True ->
-                "[runtime.nullable("
-                <> value_expr
-                <> ", fn(v) { runtime.array(list.map(v, "
-                <> mapper
-                <> ")) })]"
-              False ->
-                "[runtime.array(list.map("
-                <> value_expr
-                <> ", "
-                <> mapper
-                <> "))]"
-            }
-          }
-          _ ->
-            case param.nullable {
-              True -> {
-                let encode_fn = case unwrap {
-                  option.None -> runtime_fn
-                  option.Some(fn_name) ->
-                    "fn(v) { " <> runtime_fn <> "(" <> fn_name <> "(v)) }"
-                }
-                "[runtime.nullable(" <> value_expr <> ", " <> encode_fn <> ")]"
-              }
-              False ->
-                case unwrap {
-                  option.None -> "[" <> runtime_fn <> "(" <> value_expr <> ")]"
-                  option.Some(fn_name) ->
-                    "["
-                    <> runtime_fn
-                    <> "("
-                    <> fn_name
-                    <> "("
-                    <> value_expr
-                    <> "))]"
-                }
-            }
-        }
+      True -> render_list_param_mapper(param, type_mapping)
+      False -> "[" <> render_param_value(param, type_mapping) <> "]"
     }
   })
+}
+
+fn render_list_param_mapper(
+  param: model.QueryParam,
+  type_mapping: model.TypeMapping,
+) -> String {
+  let value_expr = "params." <> param.field_name
+  let mapper = render_array_element_mapper(param.scalar_type, type_mapping)
+  "list.map(" <> value_expr <> ", " <> mapper <> ")"
 }


### PR DESCRIPTION
## Summary
- Eliminate ~75 lines of deeply nested duplicate code in `param_accessors_flattened` by reusing the existing `render_param_value` for scalar params
- Extract `render_list_param_mapper` for the list/slice case, reusing the existing `render_array_element_mapper`

## Changes
- **params.gleam**: `param_accessors_flattened` now delegates to `render_param_value` for non-list params (wrapping result in `[...]`) and to a new `render_list_param_mapper` for list params
- Removed the 5-level deep nested case expression that duplicated nullable/enum/strong-type wrapping logic

## Design Decisions
- The non-list branch (`is_list == False`) was identical to `render_param_value` wrapped in `[...]`, so direct reuse eliminates the duplication entirely
- The list branch uses `render_array_element_mapper` which already handles enum-to-string and strong-type unwrap, making `render_list_param_mapper` a simple one-liner
- This ensures the nullable/enum/strong-unwrap branching logic exists in exactly one place, preventing silent divergence

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of code generation logic for improved maintainability. No user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->