### PR TITLE
fix(parser): parse ALTER TABLE ADD COLUMN for incremental schema evolution

### DIFF
--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -440,6 +440,8 @@ fn is_sql_keyword(word: String) -> Bool {
     | "type"
     | "index"
     | "alter"
+    | "add"
+    | "column"
     | "drop"
     | "if"
     | "exists"

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -72,14 +72,21 @@ fn parse_content(
             None -> tables
           })
         }
-        False -> {
-          let statement = tokens_to_string(stmt_tokens)
-          use maybe_table <- result.try(parse_statement(statement, all_enums))
-          Ok(case maybe_table {
-            Some(table) -> [table, ..tables]
-            None -> tables
-          })
-        }
+        False ->
+          case is_alter_table_add_column_tokens(stmt_tokens) {
+            True -> apply_alter_table_add_column(stmt_tokens, all_enums, tables)
+            False -> {
+              let statement = tokens_to_string(stmt_tokens)
+              use maybe_table <- result.try(parse_statement(
+                statement,
+                all_enums,
+              ))
+              Ok(case maybe_table {
+                Some(table) -> [table, ..tables]
+                None -> tables
+              })
+            }
+          }
       }
     })
     |> result.map(list.reverse),
@@ -346,6 +353,106 @@ fn tok_split_select_columns(
       tok_split_select_columns(rest, depth - 1, [lexer.RParen, ..current], acc)
     [token, ..rest] ->
       tok_split_select_columns(rest, depth, [token, ..current], acc)
+  }
+}
+
+/// Detect ALTER TABLE ... ADD [COLUMN] pattern.
+fn is_alter_table_add_column_tokens(tokens: List(lexer.Token)) -> Bool {
+  case tokens {
+    [
+      lexer.Keyword("alter"),
+      lexer.Keyword("table"),
+      _,
+      lexer.Keyword("add"),
+      lexer.Keyword("column"),
+      ..
+    ] -> True
+    [
+      lexer.Keyword("alter"),
+      lexer.Keyword("table"),
+      _,
+      lexer.Keyword("add"),
+      ..rest
+    ] ->
+      case rest {
+        [lexer.Keyword(k), ..]
+          if k == "constraint"
+          || k == "primary"
+          || k == "unique"
+          || k == "foreign"
+          || k == "check"
+          || k == "index"
+        -> False
+        _ -> True
+      }
+    _ -> False
+  }
+}
+
+/// Parse ALTER TABLE <name> ADD [COLUMN] <col_def> and apply to existing tables.
+fn apply_alter_table_add_column(
+  tokens: List(lexer.Token),
+  enums: List(model.EnumDef),
+  tables: List(model.Table),
+) -> Result(List(model.Table), ParseError) {
+  let #(table_name, col_tokens) = extract_alter_table_parts(tokens)
+
+  case table_name {
+    "" -> Ok(tables)
+    _ -> {
+      let col_str =
+        lexer.tokens_to_string(
+          col_tokens,
+          lexer.TokenRenderOptions(
+            uppercase_keywords: True,
+            preserve_quotes: True,
+          ),
+        )
+      use maybe_col <- result.try(parse_column(table_name, col_str, enums))
+      case maybe_col {
+        None -> Ok(tables)
+        Some(col) ->
+          Ok(
+            list.map(tables, fn(t) {
+              case t.name == table_name {
+                True -> model.Table(..t, columns: list.append(t.columns, [col]))
+                False -> t
+              }
+            }),
+          )
+      }
+    }
+  }
+}
+
+fn extract_alter_table_parts(
+  tokens: List(lexer.Token),
+) -> #(String, List(lexer.Token)) {
+  case tokens {
+    [
+      lexer.Keyword("alter"),
+      lexer.Keyword("table"),
+      name_tok,
+      lexer.Keyword("add"),
+      lexer.Keyword("column"),
+      ..rest
+    ] -> #(extract_ident(name_tok), rest)
+    [
+      lexer.Keyword("alter"),
+      lexer.Keyword("table"),
+      name_tok,
+      lexer.Keyword("add"),
+      ..rest
+    ] -> #(extract_ident(name_tok), rest)
+    _ -> #("", [])
+  }
+}
+
+fn extract_ident(token: lexer.Token) -> String {
+  case token {
+    lexer.Ident(n) -> naming.normalize_identifier(n)
+    lexer.QuotedIdent(n) -> naming.normalize_identifier(n)
+    _ -> ""
   }
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -250,3 +250,63 @@ pub fn unrecognized_sql_type_returns_error_test() {
   string.contains(msg, "geo") |> should.be_true()
   string.contains(msg, "GEOMETRY") |> should.be_true()
 }
+
+// --- ALTER TABLE ADD COLUMN tests ---
+
+pub fn alter_table_add_column_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+ALTER TABLE users ADD COLUMN email TEXT;"
+  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  table.name |> should.equal("users")
+  list.length(table.columns) |> should.equal(3)
+  let assert [_, _, email] = table.columns
+  email.name |> should.equal("email")
+  email.scalar_type |> should.equal(model.StringType)
+  email.nullable |> should.equal(True)
+}
+
+pub fn alter_table_add_column_with_keyword_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users ADD COLUMN status TEXT NOT NULL;"
+  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(2)
+  let assert [_, status] = table.columns
+  status.name |> should.equal("status")
+  status.nullable |> should.equal(False)
+}
+
+pub fn alter_table_add_without_column_keyword_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users ADD bio TEXT;"
+  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(2)
+  let assert [_, bio] = table.columns
+  bio.name |> should.equal("bio")
+}
+
+pub fn alter_table_add_column_nonexistent_table_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE posts ADD COLUMN title TEXT;"
+  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  // posts table does not exist, so ALTER TABLE is silently ignored
+  let assert [table] = catalog.tables
+  table.name |> should.equal("users")
+  list.length(table.columns) |> should.equal(1)
+}
+
+pub fn alter_table_add_constraint_ignored_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
+ALTER TABLE users ADD CONSTRAINT unique_email UNIQUE (email);"
+  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  // ADD CONSTRAINT should not add a column
+  list.length(table.columns) |> should.equal(2)
+}


### PR DESCRIPTION
## Summary
- Parse `ALTER TABLE ... ADD [COLUMN] <col_def>` statements and apply the column addition to the existing table in the catalog
- This enables sqlc-style incremental schema definitions where tables are created and then modified with ALTER TABLE

## Changes
- **lexer.gleam**: Added `"add"` and `"column"` to the SQL keyword list so they are correctly lexed as `Keyword` tokens
- **schema_parser.gleam**: Added `is_alter_table_add_column_tokens` for token-level detection of ALTER TABLE ADD COLUMN statements
- Added `apply_alter_table_add_column` that extracts the table name and column definition, parses the column using the existing `parse_column`, and appends it to the matching table
- Integrated ALTER TABLE handling into the `parse_content` fold loop between CREATE VIEW and CREATE TABLE processing
- **schema_parser_test.gleam**: Added 5 tests covering ADD COLUMN with/without the COLUMN keyword, NOT NULL constraints, nonexistent table (silently ignored), and ADD CONSTRAINT (correctly not treated as column addition)

## Design Decisions
- `ALTER TABLE ... ADD COLUMN` modifies the in-progress table list during the fold, so columns added by ALTER TABLE are immediately visible to subsequent statements
- `ALTER TABLE ... ADD CONSTRAINT` and other DDL are correctly distinguished and silently ignored
- If the target table doesn't exist, the ALTER TABLE is silently skipped (matching sqlc behavior)
- Column definition reuses the existing `parse_column` function via `tokens_to_string` conversion

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing `ALTER TABLE` statements with `ADD COLUMN` syntax, enabling users to extend existing table schemas with new columns. The implementation handles both explicit and implicit `COLUMN` keyword variants, properly maps data types, and gracefully handles edge cases like references to non-existent tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->