### PR TITLE
fix(cli): replace raw erlang:halt with init:stop and output errors to stderr

### DIFF
--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -76,7 +76,7 @@ fn run_generate(config_path: String) -> Nil {
       list.each(written, fn(path) { io.println("  Generated: " <> path) })
     }
     Error(error) -> {
-      io.println("Error: " <> generate.error_to_string(error))
+      io.println_error("Error: " <> generate.error_to_string(error))
       halt(1)
     }
   }
@@ -96,7 +96,7 @@ fn run_init(path: String) -> Nil {
 
   case simplifile.is_file(path) {
     Ok(True) -> {
-      io.println("Error: " <> path <> " already exists")
+      io.println_error("Error: " <> path <> " already exists")
       halt(1)
     }
     _ -> {
@@ -106,7 +106,7 @@ fn run_init(path: String) -> Nil {
           create_stub_files(filepath.directory_name(path))
         }
         Error(_) -> {
-          io.println("Error: failed to write " <> path)
+          io.println_error("Error: failed to write " <> path)
           halt(1)
         }
       }
@@ -161,5 +161,8 @@ fn create_stub_files(base_dir: String) -> Nil {
   }
 }
 
-@external(erlang, "erlang", "halt")
+/// Exit the process with the given status code, flushing I/O before shutdown.
+/// Uses init:stop/1 which triggers a graceful OTP shutdown instead of the
+/// abrupt erlang:halt/1.
+@external(erlang, "init", "stop")
 fn halt(code: Int) -> Nil


### PR DESCRIPTION
## Summary
- Replace `erlang:halt/1` (abrupt process kill) with `init:stop/1` (graceful OTP shutdown with I/O flush)
- Error messages now go to stderr via `io.println_error` instead of stdout

## Changes
- **cli.gleam**: Changed `@external(erlang, "erlang", "halt")` to `@external(erlang, "init", "stop")` — this triggers a graceful OTP shutdown that flushes I/O buffers before exiting
- All error output (`"Error: ..."`) now uses `io.println_error` (stderr) instead of `io.println` (stdout)

## Design Decisions
- `init:stop/1` is the Erlang-recommended way to terminate a node with a status code, as it triggers the OTP shutdown sequence and flushes all I/O before exit
- Error messages on stderr allows proper Unix-style error handling (e.g., `sqlode generate 2>/dev/null` suppresses errors while keeping generated file output)
- The glint framework itself uses `erlang:halt` internally for its own error paths, but our application-level errors now use the safer `init:stop`

Closes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages are now properly directed to stderr, improving output stream handling in the CLI.
  * Application shutdown is now performed gracefully through standard shutdown procedures rather than immediate termination, improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->