### PR TITLE
fix(generate): reject out paths that produce invalid Gleam module imports

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -34,6 +34,7 @@ pub type GenerateError {
   )
   DuplicateQueryName(name: String, paths: List(String))
   UnsupportedAnnotation(query_name: String, command: String, detail: String)
+  InvalidOutPath(path: String)
   WriteError(writer.WriteError)
 }
 
@@ -90,6 +91,7 @@ fn generate_sql_block(
   naming_ctx: naming.NamingContext,
   block: model.SqlBlock,
 ) -> Result(List(writer.GeneratedFile), GenerateError) {
+  use Nil <- result.try(validate_out_path(block.gleam.out))
   use raw_catalog <- result.try(load_catalog(block.schema, block.engine))
   let catalog =
     apply_type_overrides(raw_catalog, block.overrides.type_overrides)
@@ -479,6 +481,16 @@ fn find_column_rename(
   })
 }
 
+fn validate_out_path(out: String) -> Result(Nil, GenerateError) {
+  let module_path = common.out_to_module_path(out)
+  case
+    string.starts_with(module_path, "/") || string.starts_with(module_path, ".")
+  {
+    True -> Error(InvalidOutPath(path: out))
+    False -> Ok(Nil)
+  }
+}
+
 fn validate_unsupported_annotations(
   queries: List(model.AnalyzedQuery),
 ) -> Result(Nil, GenerateError) {
@@ -678,6 +690,10 @@ pub fn error_to_string(error: GenerateError) -> String {
       <> string.join(paths, ", ")
     UnsupportedAnnotation(query_name:, command:, detail:) ->
       "Query " <> query_name <> " uses " <> command <> ": " <> detail
+    InvalidOutPath(path:) ->
+      "Invalid output path \""
+      <> path
+      <> "\": produces an invalid Gleam module path. Use a relative path under src/ (e.g., \"src/db\")"
     WriteError(inner) -> writer.error_to_string(inner)
   }
 }

--- a/test/fixtures/subdir/sqlode_relative.yaml
+++ b/test/fixtures/subdir/sqlode_relative.yaml
@@ -5,5 +5,5 @@ sql:
     engine: "postgresql"
     gen:
       gleam:
-        out: "/tmp/sqlode_resolve_paths_test"
+        out: "../../../src/resolve_paths_test"
         runtime: "raw"

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1222,7 +1222,7 @@ pub fn view_select_star_inferred_test() {
 
 // --- Config path resolution tests ---
 
-const resolve_out = "/tmp/sqlode_resolve_paths_test"
+const resolve_out = "src/resolve_paths_test"
 
 fn cleanup_resolve() {
   let _ = simplifile.delete(resolve_out)
@@ -1242,6 +1242,27 @@ pub fn run_resolves_paths_relative_to_config_dir_test() {
   string.contains(models, "Author") |> should.be_true()
 
   cleanup_resolve()
+}
+
+pub fn invalid_out_path_rejected_test() {
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/query.sql"],
+      gleam: model.GleamOutput(
+        out: "/tmp/invalid_absolute_path",
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let cfg = model.Config(version: 2, sql: [block])
+  let result = generate.generate_config(cfg)
+  result |> should.be_error()
 }
 
 // --- Directory input tests ---


### PR DESCRIPTION
## Summary
- Validate `gen.gleam.out` paths before code generation to reject paths that would produce invalid Gleam module imports
- Paths like `/tmp/foo` that don't contain `src/` produce absolute module paths (`/tmp/foo/params`) which are not valid Gleam imports

## Changes
- **generate.gleam**: Added `validate_out_path` that checks whether `out_to_module_path(out)` produces a valid relative module path (rejects paths starting with `/` or `.`)
- Added `InvalidOutPath` error variant with an actionable error message suggesting `src/db` as an example
- **generate_test.gleam**: Added `invalid_out_path_rejected_test` to verify absolute paths are rejected
- **test/fixtures/subdir/sqlode_relative.yaml**: Updated test fixture to use a valid `src/`-relative output path instead of `/tmp/`

## Design Decisions
- Validation operates on the derived module path (after `out_to_module_path`) rather than the raw `out` value, so it catches both direct absolute paths and paths that resolve to absolute after `filepath.expand`
- Relative paths without `src/` (like `test_output/db` used in tests) are allowed since they produce valid relative module paths

Closes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for output paths in generated Gleam modules—paths must now be relative and located under `src/`. Invalid absolute paths are rejected with descriptive error messages.

* **Tests**
  * Added test coverage validating rejection of invalid output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->