### PR TITLE
test(cli): add unit and integration tests for init, generate, and version commands

### DIFF
--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+Describe 'sqlode CLI'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  Describe 'init command'
+    setup_init_test() {
+      clean_test_output
+      mkdir -p "$TEST_OUTPUT_DIR"
+    }
+    Before 'setup_init_test'
+    After 'clean_test_output'
+
+    It 'creates config file and stub files'
+      When run init_cmd --output="$TEST_OUTPUT_DIR/sqlode.yaml"
+      The status should be success
+      The output should include 'Created'
+      The path "$TEST_OUTPUT_DIR/sqlode.yaml" should be file
+      The path "$TEST_OUTPUT_DIR/db/schema.sql" should be file
+      The path "$TEST_OUTPUT_DIR/db/query.sql" should be file
+    End
+
+    It 'fails when config file already exists'
+      mkdir -p "$TEST_OUTPUT_DIR"
+      echo "existing" > "$TEST_OUTPUT_DIR/sqlode.yaml"
+      When run init_cmd --output="$TEST_OUTPUT_DIR/sqlode.yaml"
+      The status should be failure
+      The output should include 'already exists'
+    End
+  End
+
+  Describe 'generate command'
+    It 'fails when config file does not exist'
+      When run generate --config=nonexistent.yaml
+      The status should be failure
+      The output should include 'Config file not found'
+    End
+
+    It 'fails with invalid config'
+      When run generate --config=test/fixtures/malformed.yaml
+      The status should be failure
+      The output should include 'Error'
+    End
+  End
+
+  Describe 'version command'
+    It 'outputs the version string'
+      When run version_cmd
+      The status should be success
+      The output should include 'sqlode v'
+    End
+  End
+
+  Describe 'help flags'
+    It 'init --help shows usage'
+      When run init_cmd --help
+      The status should be success
+      The output should include 'Create a sqlode.yaml config file'
+    End
+
+    It 'version --help shows usage'
+      When run version_cmd --help
+      The status should be success
+      The output should include 'Print the sqlode version'
+    End
+  End
+End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -18,3 +18,11 @@ generate() {
 clean_test_output() {
   rm -rf "$TEST_OUTPUT_DIR"
 }
+
+init_cmd() {
+  cd "$PROJECT_ROOT" && gleam run -- init "$@" 2>&1
+}
+
+version_cmd() {
+  cd "$PROJECT_ROOT" && gleam run -- version "$@" 2>&1
+}

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -1,0 +1,110 @@
+import gleam/result
+import gleam/string
+import gleeunit/should
+import glint
+import simplifile
+import sqlode/cli
+
+const base_dir = "test_output/cli_test"
+
+fn cleanup(subdir: String) {
+  let _ = simplifile.delete(base_dir <> "/" <> subdir)
+  Nil
+}
+
+fn setup(subdir: String) {
+  cleanup(subdir)
+  let _ = simplifile.create_directory_all(base_dir <> "/" <> subdir)
+  Nil
+}
+
+fn run_init(path: String) {
+  cli.app()
+  |> glint.execute(["init", "--output=" <> path])
+}
+
+pub fn init_creates_config_file_test() {
+  setup("config")
+  let dir = base_dir <> "/config"
+  let config_path = dir <> "/sqlode.yaml"
+
+  run_init(config_path)
+  |> result.is_ok
+  |> should.be_true
+
+  let assert Ok(content) = simplifile.read(config_path)
+  content |> string.contains("version: \"2\"") |> should.be_true
+  content |> string.contains("schema: \"db/schema.sql\"") |> should.be_true
+  content |> string.contains("queries: \"db/query.sql\"") |> should.be_true
+  content |> string.contains("engine: \"postgresql\"") |> should.be_true
+  content |> string.contains("out: \"src/db\"") |> should.be_true
+  content |> string.contains("runtime: \"raw\"") |> should.be_true
+
+  cleanup("config")
+}
+
+pub fn init_creates_stub_schema_file_test() {
+  setup("schema")
+  let dir = base_dir <> "/schema"
+  let config_path = dir <> "/sqlode.yaml"
+
+  run_init(config_path)
+  |> result.is_ok
+  |> should.be_true
+
+  let assert Ok(content) = simplifile.read(dir <> "/db/schema.sql")
+  content |> string.contains("CREATE TABLE authors") |> should.be_true
+  content |> string.contains("id BIGSERIAL PRIMARY KEY") |> should.be_true
+  content |> string.contains("name TEXT NOT NULL") |> should.be_true
+  content |> string.contains("bio TEXT") |> should.be_true
+
+  cleanup("schema")
+}
+
+pub fn init_creates_stub_query_file_test() {
+  setup("query")
+  let dir = base_dir <> "/query"
+  let config_path = dir <> "/sqlode.yaml"
+
+  run_init(config_path)
+  |> result.is_ok
+  |> should.be_true
+
+  let assert Ok(content) = simplifile.read(dir <> "/db/query.sql")
+  content |> string.contains("-- name: GetAuthor :one") |> should.be_true
+  content |> string.contains("-- name: ListAuthors :many") |> should.be_true
+  content |> string.contains("-- name: CreateAuthor :exec") |> should.be_true
+
+  cleanup("query")
+}
+
+pub fn init_does_not_overwrite_existing_stubs_test() {
+  setup("no_overwrite")
+  let dir = base_dir <> "/no_overwrite"
+  let config_path = dir <> "/sqlode.yaml"
+  let schema_path = dir <> "/db/schema.sql"
+  let query_path = dir <> "/db/query.sql"
+
+  let assert Ok(_) = simplifile.create_directory_all(dir <> "/db")
+  let assert Ok(_) = simplifile.write(schema_path, "custom_schema")
+  let assert Ok(_) = simplifile.write(query_path, "custom_query")
+
+  run_init(config_path)
+  |> result.is_ok
+  |> should.be_true
+
+  let assert Ok(schema) = simplifile.read(schema_path)
+  schema |> should.equal("custom_schema")
+
+  let assert Ok(query) = simplifile.read(query_path)
+  query |> should.equal("custom_query")
+
+  cleanup("no_overwrite")
+}
+
+pub fn version_command_succeeds_test() {
+  cli.app()
+  |> glint.execute(["version"])
+  |> result.is_ok
+  |> should.be_true
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -1,3 +1,4 @@
+import cli_test
 import codegen_test
 import config_test
 import generate_test
@@ -616,4 +617,26 @@ pub fn compound_query_valid_union_test() {
 
 pub fn compound_query_except_mismatch_test() {
   query_analyzer_test.compound_query_except_mismatch_test()
+}
+
+// --- CLI tests ---
+
+pub fn init_creates_config_file_test() {
+  cli_test.init_creates_config_file_test()
+}
+
+pub fn init_creates_stub_schema_file_test() {
+  cli_test.init_creates_stub_schema_file_test()
+}
+
+pub fn init_creates_stub_query_file_test() {
+  cli_test.init_creates_stub_query_file_test()
+}
+
+pub fn init_does_not_overwrite_existing_stubs_test() {
+  cli_test.init_does_not_overwrite_existing_stubs_test()
+}
+
+pub fn version_command_succeeds_test() {
+  cli_test.version_command_succeeds_test()
 }


### PR DESCRIPTION
## Summary
- Add Gleam unit tests (`test/cli_test.gleam`) and shellspec integration tests (`spec/cli_spec.sh`) for the CLI module
- Cover init file creation, init with existing files, generate error paths, and version command

## Changes
- **`test/cli_test.gleam`** (new): 5 Gleam unit tests exercising `init` success paths (config creation, stub schema/query creation, no-overwrite of existing stubs) and `version` command via `glint.execute`
- **`spec/cli_spec.sh`** (new): 7 shellspec tests covering init success/failure, generate with missing/invalid config, version output, and help flags for init/version
- **`spec/spec_helper.sh`**: Add `init_cmd` and `version_cmd` helper functions for shellspec
- **`test/sqlode_test.gleam`**: Add proxy functions for cli_test following existing convention

## Design Decisions
- Error paths that call `halt(1)` (`init:stop/1`) are tested via shellspec rather than Gleam unit tests, since `halt` shuts down the OTP VM and would kill the test runner
- Success paths are tested in Gleam to verify file system side effects (content assertions) since `io.println` output cannot be captured in Gleam tests
- Each Gleam test uses an isolated subdirectory under `test_output/cli_test/` to avoid race conditions from parallel test execution

Closes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive CLI test suite covering `init`, `generate`, `version`, and help functionality.
  * Included tests for configuration file creation, validation, and error handling.
  * Added tests to verify stub SQL file generation and protection against overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->