### PR TITLE
fix(schema_parser): infer expression-based CREATE VIEW column types

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -17,6 +17,10 @@ type ParsedSchema {
   ParsedSchema(tables: List(model.Table), enums: List(model.EnumDef))
 }
 
+type ViewColumn {
+  ViewColumn(name: String, expr_tokens: List(lexer.Token))
+}
+
 pub fn parse_files(
   entries: List(#(String, String)),
 ) -> Result(model.Catalog, ParseError) {
@@ -240,21 +244,44 @@ fn parse_create_view_from_tokens(
                 [] -> None
               }
             _ -> {
-              let col_names = extract_view_column_names(select_tokens)
+              let view_cols = extract_view_columns(select_tokens)
               let columns =
-                list.filter_map(col_names, fn(col_name) {
-                  let normalized = naming.normalize_identifier(col_name)
+                list.filter_map(view_cols, fn(view_col) {
+                  let normalized = naming.normalize_identifier(view_col.name)
                   case find_column_in_tables(tables, normalized) {
                     Some(col) -> Ok(model.Column(..col, name: normalized))
-                    None -> {
-                      io.println_error(
-                        "Warning: view column \""
-                        <> normalized
-                        <> "\" could not be resolved from source tables"
-                        <> " — skipping column.",
-                      )
-                      Error(Nil)
-                    }
+                    None ->
+                      case
+                        resolve_column_from_expr_tokens(
+                          view_col.expr_tokens,
+                          tables,
+                        )
+                      {
+                        Some(col) -> Ok(model.Column(..col, name: normalized))
+                        None ->
+                          case
+                            infer_view_expression_type(
+                              view_col.expr_tokens,
+                              tables,
+                            )
+                          {
+                            Some(#(scalar_type, nullable)) ->
+                              Ok(model.Column(
+                                name: normalized,
+                                scalar_type: scalar_type,
+                                nullable: nullable,
+                              ))
+                            None -> {
+                              io.println_error(
+                                "Warning: view column \""
+                                <> normalized
+                                <> "\" could not be resolved from source tables"
+                                <> " — skipping column.",
+                              )
+                              Error(Nil)
+                            }
+                          }
+                      }
                   }
                 })
               case columns {
@@ -307,30 +334,131 @@ fn extract_view_source_tables(tokens: List(lexer.Token)) -> List(String) {
   }
 }
 
-fn extract_view_column_names(tokens: List(lexer.Token)) -> List(String) {
+fn extract_view_columns(tokens: List(lexer.Token)) -> List(ViewColumn) {
   let groups = tok_split_select_columns(tokens, 0, [], [])
-  list.map(groups, fn(col_tokens) {
+  list.filter_map(groups, fn(col_tokens) {
     // Check for AS alias (last two tokens: Keyword("as"), Ident/QuotedIdent)
     let reversed = list.reverse(col_tokens)
     case reversed {
-      [lexer.Ident(alias), lexer.Keyword("as"), ..] -> alias
-      [lexer.QuotedIdent(alias), lexer.Keyword("as"), ..] -> alias
+      [lexer.Ident(alias), lexer.Keyword("as"), ..rest] ->
+        Ok(ViewColumn(name: alias, expr_tokens: list.reverse(rest)))
+      [lexer.QuotedIdent(alias), lexer.Keyword("as"), ..rest] ->
+        Ok(ViewColumn(name: alias, expr_tokens: list.reverse(rest)))
       _ -> {
         // Check for table.column → use column
         case list.reverse(reversed) {
-          [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] -> col
+          [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] ->
+            Ok(ViewColumn(name: col, expr_tokens: col_tokens))
           _ ->
             // Use the last identifier
             case reversed {
-              [lexer.Ident(name), ..] -> name
-              [lexer.QuotedIdent(name), ..] -> name
-              _ -> ""
+              [lexer.Ident(name), ..] ->
+                Ok(ViewColumn(name: name, expr_tokens: col_tokens))
+              [lexer.QuotedIdent(name), ..] ->
+                Ok(ViewColumn(name: name, expr_tokens: col_tokens))
+              _ -> Error(Nil)
             }
         }
       }
     }
   })
-  |> list.filter(fn(n) { n != "" })
+}
+
+fn resolve_column_from_expr_tokens(
+  expr_tokens: List(lexer.Token),
+  tables: List(model.Table),
+) -> Option(model.Column) {
+  case expr_tokens {
+    [lexer.Ident(name)] -> find_column_in_tables(tables, string.lowercase(name))
+    [lexer.QuotedIdent(name)] ->
+      find_column_in_tables(tables, string.lowercase(name))
+    [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] ->
+      find_column_in_tables(tables, string.lowercase(col))
+    [lexer.QuotedIdent(_table), lexer.Dot, lexer.Ident(col)] ->
+      find_column_in_tables(tables, string.lowercase(col))
+    _ -> None
+  }
+}
+
+fn infer_view_expression_type(
+  expr_tokens: List(lexer.Token),
+  tables: List(model.Table),
+) -> Option(#(model.ScalarType, Bool)) {
+  case expr_tokens {
+    [lexer.Keyword("count"), lexer.LParen, ..] -> Some(#(model.IntType, False))
+    [lexer.Keyword("avg"), lexer.LParen, ..rest] ->
+      Some(#(
+        case extract_aggregate_inner_type(rest, tables) {
+          Some(col) ->
+            case col.scalar_type {
+              model.IntType | model.FloatType -> model.FloatType
+              other -> other
+            }
+          None -> model.FloatType
+        },
+        True,
+      ))
+    [lexer.Keyword("sum"), lexer.LParen, ..rest] ->
+      case extract_aggregate_inner_type(rest, tables) {
+        Some(col) -> Some(#(col.scalar_type, True))
+        None -> Some(#(model.FloatType, True))
+      }
+    [lexer.Keyword(fn_name), lexer.LParen, ..rest]
+      if fn_name == "min" || fn_name == "max"
+    ->
+      case extract_aggregate_inner_type(rest, tables) {
+        Some(col) -> Some(#(col.scalar_type, True))
+        None -> None
+      }
+    [lexer.Keyword("coalesce"), lexer.LParen, ..rest] ->
+      case extract_aggregate_inner_type(rest, tables) {
+        Some(col) -> Some(#(col.scalar_type, False))
+        None -> None
+      }
+    [lexer.Keyword("cast"), lexer.LParen, ..rest] -> infer_cast_type(rest)
+    [lexer.Keyword(fn_name), lexer.LParen, ..]
+      if fn_name == "row_number" || fn_name == "rank" || fn_name == "dense_rank"
+    -> Some(#(model.IntType, False))
+    [lexer.StringLit(_), ..] -> Some(#(model.StringType, False))
+    [lexer.NumberLit(n), ..] ->
+      case string.contains(n, ".") {
+        True -> Some(#(model.FloatType, False))
+        False -> Some(#(model.IntType, False))
+      }
+    _ -> None
+  }
+}
+
+fn extract_aggregate_inner_type(
+  tokens: List(lexer.Token),
+  tables: List(model.Table),
+) -> Option(model.Column) {
+  case tokens {
+    [lexer.Ident(name), lexer.RParen, ..] | [lexer.Ident(name), lexer.Comma, ..] ->
+      find_column_in_tables(tables, string.lowercase(name))
+    [lexer.Ident(_table), lexer.Dot, lexer.Ident(col), lexer.RParen, ..]
+    | [lexer.Ident(_table), lexer.Dot, lexer.Ident(col), lexer.Comma, ..] ->
+      find_column_in_tables(tables, string.lowercase(col))
+    [lexer.Keyword("distinct"), lexer.Ident(name), lexer.RParen, ..]
+    | [lexer.Keyword("distinct"), lexer.Ident(name), lexer.Comma, ..] ->
+      find_column_in_tables(tables, string.lowercase(name))
+    _ -> None
+  }
+}
+
+fn infer_cast_type(
+  tokens: List(lexer.Token),
+) -> Option(#(model.ScalarType, Bool)) {
+  case tokens {
+    [] -> None
+    [lexer.Keyword("as"), lexer.Ident(type_name), ..]
+    | [lexer.Keyword("as"), lexer.Keyword(type_name), ..] ->
+      case model.parse_sql_type(type_name) {
+        Ok(scalar_type) -> Some(#(scalar_type, True))
+        Error(_) -> None
+      }
+    [_, ..rest] -> infer_cast_type(rest)
+  }
 }
 
 fn tok_split_select_columns(

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -162,10 +162,15 @@ pub fn view_with_cast_expression_test() {
   let assert Ok(catalog) =
     schema_parser.parse_files([#("cast_view.sql", content)])
 
-  // Aliased expression columns (col_a, col_b) cannot be resolved from source
-  // tables, so they are skipped with a warning. The view is omitted if empty.
-  let view_found = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
-  view_found |> should.be_error()
+  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["col_a", "col_b"])
+
+  let assert Ok(col_a) = list.find(view.columns, fn(c) { c.name == "col_a" })
+  col_a.scalar_type |> should.equal(model.StringType)
+
+  let assert Ok(col_b) = list.find(view.columns, fn(c) { c.name == "col_b" })
+  col_b.scalar_type |> should.equal(model.StringType)
 }
 
 pub fn view_basic_select_test() {
@@ -191,9 +196,12 @@ pub fn view_with_alias_test() {
   let assert Ok(view) =
     list.find(catalog.tables, fn(tbl) { tbl.name == "user_names" })
   let col_names = list.map(view.columns, fn(c) { c.name })
-  // "display_name" alias cannot be resolved from source tables, so it is
-  // skipped. Only "id" (which matches a real column) is retained.
-  col_names |> should.equal(["id"])
+  col_names |> should.equal(["id", "display_name"])
+
+  let assert Ok(display) =
+    list.find(view.columns, fn(c) { c.name == "display_name" })
+  display.scalar_type |> should.equal(model.StringType)
+  display.nullable |> should.be_false
 }
 
 pub fn view_star_test() {
@@ -309,4 +317,77 @@ ALTER TABLE users ADD CONSTRAINT unique_email UNIQUE (email);"
   let assert [table] = catalog.tables
   // ADD CONSTRAINT should not add a column
   list.length(table.columns) |> should.equal(2)
+}
+
+pub fn view_with_count_expression_test() {
+  let content =
+    "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "CREATE VIEW author_counts AS SELECT COUNT(*) AS total FROM authors;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("count_view.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "author_counts" })
+  let assert Ok(total) = list.find(view.columns, fn(c) { c.name == "total" })
+  total.scalar_type |> should.equal(model.IntType)
+  total.nullable |> should.be_false
+}
+
+pub fn view_with_sum_expression_test() {
+  let content =
+    "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, amount INTEGER NOT NULL);\n"
+    <> "CREATE VIEW order_totals AS SELECT SUM(amount) AS total_amount FROM orders;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("sum_view.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "order_totals" })
+  let assert Ok(total) =
+    list.find(view.columns, fn(c) { c.name == "total_amount" })
+  total.scalar_type |> should.equal(model.IntType)
+  total.nullable |> should.be_true
+}
+
+pub fn view_with_avg_expression_test() {
+  let content =
+    "CREATE TABLE products (id BIGSERIAL PRIMARY KEY, price REAL NOT NULL);\n"
+    <> "CREATE VIEW avg_prices AS SELECT AVG(price) AS avg_price FROM products;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("avg_view.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "avg_prices" })
+  let assert Ok(avg) = list.find(view.columns, fn(c) { c.name == "avg_price" })
+  avg.scalar_type |> should.equal(model.FloatType)
+  avg.nullable |> should.be_true
+}
+
+pub fn view_with_coalesce_expression_test() {
+  let content =
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT);\n"
+    <> "CREATE VIEW user_display AS SELECT id, COALESCE(bio, 'N/A') AS bio_text FROM users;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("coalesce_view.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "user_display" })
+  let assert Ok(bio) = list.find(view.columns, fn(c) { c.name == "bio_text" })
+  bio.scalar_type |> should.equal(model.StringType)
+  bio.nullable |> should.be_false
+}
+
+pub fn view_with_literal_expression_test() {
+  let content =
+    "CREATE TABLE t (id BIGSERIAL PRIMARY KEY);\n"
+    <> "CREATE VIEW v AS SELECT 42 AS magic, 'hello' AS greeting FROM t;"
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("literal_view.sql", content)])
+
+  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  let assert Ok(magic) = list.find(view.columns, fn(c) { c.name == "magic" })
+  magic.scalar_type |> should.equal(model.IntType)
+
+  let assert Ok(greeting) =
+    list.find(view.columns, fn(c) { c.name == "greeting" })
+  greeting.scalar_type |> should.equal(model.StringType)
 }

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -501,6 +501,26 @@ pub fn view_nonexistent_table_test() {
   schema_parser_test.view_nonexistent_table_test()
 }
 
+pub fn view_with_count_expression_test() {
+  schema_parser_test.view_with_count_expression_test()
+}
+
+pub fn view_with_sum_expression_test() {
+  schema_parser_test.view_with_sum_expression_test()
+}
+
+pub fn view_with_avg_expression_test() {
+  schema_parser_test.view_with_avg_expression_test()
+}
+
+pub fn view_with_coalesce_expression_test() {
+  schema_parser_test.view_with_coalesce_expression_test()
+}
+
+pub fn view_with_literal_expression_test() {
+  schema_parser_test.view_with_literal_expression_test()
+}
+
 // query_analyzer error tests
 
 pub fn table_not_found_error_test() {


### PR DESCRIPTION
## Summary
- Infer types for expression-based CREATE VIEW columns (COUNT, SUM, AVG, CAST, COALESCE, etc.) instead of silently skipping them
- Resolve aliased simple column references (e.g., `name AS display_name`) by looking up the original column

## Changes
- **`src/sqlode/schema_parser.gleam`**: Add 3-step fallback chain for view column resolution:
  1. Direct name lookup in source tables (existing behavior)
  2. Resolve expression tokens as simple column reference with alias (`name AS display_name` → find `name`)
  3. Expression type inference for aggregates, CAST, COALESCE, window functions, and literals
- New internal type `ViewColumn(name, expr_tokens)` replaces `String` in column extraction
- New helper functions: `resolve_column_from_expr_tokens`, `infer_view_expression_type`, `extract_aggregate_inner_type`, `infer_cast_type`
- **`test/schema_parser_test.gleam`**: Update 2 existing view tests, add 5 new tests (COUNT, SUM, AVG, COALESCE, literals)
- **`test/sqlode_test.gleam`**: Add proxy functions for new tests

## Design Decisions
- Expression inference lives in `schema_parser.gleam` rather than reusing `column_inferencer.gleam` because the column inferencer depends on `AnalyzerContext` which is unavailable during schema parsing. The lightweight subset (prefix-based pattern matching on tokens) avoids coupling.
- Unresolvable columns still emit a warning and are skipped (fallback), matching the existing degradation behavior rather than hard-failing. This preserves backward compatibility for edge cases not yet covered.
- `extract_aggregate_inner_type` handles both single-arg (`SUM(x)`) and multi-arg (`COALESCE(x, y)`) patterns by matching on both `RParen` and `Comma` terminators.

## Limitations
- Complex nested expressions (e.g., `CASE WHEN ... THEN COUNT(*) END`) are not yet inferred — they fall through to the warning path
- `extract_view_source_tables` only extracts the first table from FROM clause; JOINed tables are not included in type resolution

Closes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Views with aliased columns, aggregate functions (COUNT, SUM, AVG), and scalar expressions (CAST, COALESCE, literals) are now properly resolved with accurate type information. Previously unsupported view columns are now recognized.

* **Tests**
  * Comprehensive test coverage added for view expression resolution, type inference, and aggregate function handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->