### PR TITLE
feat(query_parser): add sqlode:skip annotation to bypass unsupported queries

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -53,7 +53,16 @@ pub fn parse_file(
   content: String,
 ) -> Result(List(model.ParsedQuery), ParseError) {
   let ctx = new_parser_context(naming_ctx)
-  parse_lines(ctx, string.split(content, "\n"), path, engine, 1, None, [])
+  parse_lines(
+    ctx,
+    string.split(content, "\n"),
+    path,
+    engine,
+    1,
+    None,
+    [],
+    False,
+  )
   |> result.map(list.reverse)
 }
 
@@ -65,14 +74,16 @@ fn parse_lines(
   line_number: Int,
   pending: Option(PendingQuery),
   parsed_rev: List(model.ParsedQuery),
+  skip_next: Bool,
 ) -> Result(List(model.ParsedQuery), ParseError) {
   case lines {
     [] -> finalize_pending(ctx, pending, path, engine, parsed_rev)
     [line, ..rest] -> {
       let trimmed = string.trim(line)
 
-      case parse_annotation(ctx, trimmed, path, line_number) {
-        Ok(Some(next_pending)) -> {
+      case is_skip_annotation(trimmed) {
+        True -> {
+          // Finalize any current pending query before entering skip mode
           use parsed_rev <- result.try(finalize_pending(
             ctx,
             pending,
@@ -80,49 +91,88 @@ fn parse_lines(
             engine,
             parsed_rev,
           ))
-
           parse_lines(
             ctx,
             rest,
             path,
             engine,
             line_number + 1,
-            Some(next_pending),
+            None,
             parsed_rev,
+            True,
           )
         }
-        Ok(None) -> {
-          let pending = case pending {
-            Some(PendingQuery(
-              name:,
-              function_name:,
-              command:,
-              start_line:,
-              body_rev:,
-            )) ->
-              Some(
-                PendingQuery(
+        False ->
+          case parse_annotation(ctx, trimmed, path, line_number) {
+            Ok(Some(next_pending)) -> {
+              use parsed_rev <- result.try(finalize_pending(
+                ctx,
+                pending,
+                path,
+                engine,
+                parsed_rev,
+              ))
+
+              case skip_next {
+                True ->
+                  // Skip this query: don't set pending, clear skip flag
+                  parse_lines(
+                    ctx,
+                    rest,
+                    path,
+                    engine,
+                    line_number + 1,
+                    None,
+                    parsed_rev,
+                    False,
+                  )
+                False ->
+                  parse_lines(
+                    ctx,
+                    rest,
+                    path,
+                    engine,
+                    line_number + 1,
+                    Some(next_pending),
+                    parsed_rev,
+                    False,
+                  )
+              }
+            }
+            Ok(None) -> {
+              let pending = case pending {
+                Some(PendingQuery(
                   name:,
                   function_name:,
                   command:,
                   start_line:,
-                  body_rev: [line, ..body_rev],
-                ),
-              )
-            None -> None
-          }
+                  body_rev:,
+                )) ->
+                  Some(
+                    PendingQuery(
+                      name:,
+                      function_name:,
+                      command:,
+                      start_line:,
+                      body_rev: [line, ..body_rev],
+                    ),
+                  )
+                None -> None
+              }
 
-          parse_lines(
-            ctx,
-            rest,
-            path,
-            engine,
-            line_number + 1,
-            pending,
-            parsed_rev,
-          )
-        }
-        Error(error) -> Error(error)
+              parse_lines(
+                ctx,
+                rest,
+                path,
+                engine,
+                line_number + 1,
+                pending,
+                parsed_rev,
+                skip_next,
+              )
+            }
+            Error(error) -> Error(error)
+          }
       }
     }
   }
@@ -220,6 +270,10 @@ fn parse_annotation(
       }
     }
   }
+}
+
+fn is_skip_annotation(line: String) -> Bool {
+  line == "-- sqlode:skip"
 }
 
 fn count_parameters(engine: model.Engine, sql: String) -> Int {

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -663,3 +663,60 @@ pub fn error_to_string_coverage_test() {
   |> string.contains("MyQuery")
   |> should.be_true()
 }
+
+pub fn skip_annotation_skips_query_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- sqlode:skip\n"
+    <> "-- name: SkippedQuery :one\n"
+    <> "SELECT complex_stuff FROM somewhere;\n"
+    <> "\n"
+    <> "-- name: KeptQuery :many\n"
+    <> "SELECT id FROM authors;\n"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
+
+  list.length(queries) |> should.equal(1)
+  let assert [query] = queries
+  query.name |> should.equal("KeptQuery")
+  query.command |> should.equal(runtime.QueryMany)
+}
+
+pub fn skip_annotation_all_queries_skipped_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- sqlode:skip\n"
+    <> "-- name: SkippedOne :one\n"
+    <> "SELECT 1;\n"
+    <> "\n"
+    <> "-- sqlode:skip\n"
+    <> "-- name: SkippedTwo :many\n"
+    <> "SELECT 2;\n"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
+
+  list.length(queries) |> should.equal(0)
+}
+
+pub fn skip_annotation_middle_query_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: First :one\n"
+    <> "SELECT 1;\n"
+    <> "\n"
+    <> "-- sqlode:skip\n"
+    <> "-- name: Second :one\n"
+    <> "SELECT 2;\n"
+    <> "\n"
+    <> "-- name: Third :many\n"
+    <> "SELECT 3;\n"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
+
+  list.length(queries) |> should.equal(2)
+  let names = list.map(queries, fn(q) { q.name })
+  names |> should.equal(["First", "Third"])
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -639,6 +639,20 @@ pub fn compound_query_except_mismatch_test() {
   query_analyzer_test.compound_query_except_mismatch_test()
 }
 
+// --- skip annotation tests ---
+
+pub fn skip_annotation_skips_query_test() {
+  query_parser_test.skip_annotation_skips_query_test()
+}
+
+pub fn skip_annotation_all_queries_skipped_test() {
+  query_parser_test.skip_annotation_all_queries_skipped_test()
+}
+
+pub fn skip_annotation_middle_query_test() {
+  query_parser_test.skip_annotation_middle_query_test()
+}
+
 // --- CLI tests ---
 
 pub fn init_creates_config_file_test() {


### PR DESCRIPTION
## Summary
- Add `-- sqlode:skip` annotation that tells the parser to skip the next query block entirely
- Allows users to keep unsupported queries in SQL files without blocking generation

## Changes
- **`src/sqlode/query_parser.gleam`**: Add `skip_next: Bool` parameter to `parse_lines` and `is_skip_annotation` detection function. When `-- sqlode:skip` is encountered, the current pending query is finalized normally, and the next `-- name:` annotation creates no pending query (body lines are silently ignored).
- **`test/query_parser_test.gleam`**: Add 3 tests: skip first query, skip all queries, skip middle query
- **`test/sqlode_test.gleam`**: Add proxy functions for new tests

## Design Decisions
- `-- sqlode:skip` must appear on its own line before the `-- name:` annotation (not inline with it). This keeps the parser simple and the annotation visually distinct.
- When `-- sqlode:skip` is encountered with an existing pending query, that pending query is finalized normally before entering skip mode. This ensures preceding queries are not affected.
- The skip flag is cleared after the next `-- name:` annotation is processed (whether skipped or not), so it only affects exactly one query block.
- No changes to `model.gleam` or `generate.gleam` - filtering happens entirely at parse time.

## Usage
```sql
-- sqlode:skip
-- name: ComplexQuery :one
SELECT ... complex unsupported SQL ...;

-- name: SimpleQuery :many
SELECT id, name FROM authors;
```

Only `SimpleQuery` will be generated; `ComplexQuery` is silently skipped.

Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `-- sqlode:skip` annotation to exclude specific SQL queries from being parsed and included in query processing.

* **Tests**
  * Added comprehensive test coverage for skip annotation behavior, validating scenarios including single skipped queries, all queries skipped, and skip annotations placed between multiple queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->