### PR TITLE
fix(ux): add actionable fix suggestions to error messages

### DIFF
--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -335,7 +335,8 @@ fn check_unknown_keys(
         fields ->
           Error(UnsupportedFields(
             fields:,
-            message: "these sqlc options are not supported by sqlode; please remove them from your config",
+            message: "these sqlc options are not supported by sqlode; please remove them. Valid keys: "
+              <> string.join(known_keys, ", "),
           ))
       }
     }

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -518,7 +518,7 @@ fn validate_unsupported_annotations(
         detail: command
           <> " is not yet supported. Use "
           <> alternative
-          <> " instead",
+          <> " instead, or add '-- sqlode:skip' before the annotation to bypass this query",
       ))
     }
     Error(_) -> Ok(Nil)

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -265,7 +265,7 @@ fn parse_annotation(
           Error(InvalidAnnotation(
             path:,
             line: line_number,
-            detail: "expected '-- name: <Name> <command>'",
+            detail: "expected '-- name: <Name> <command>' where command is one of: :one, :many, :exec, :execresult, :execrows, :execlastid",
           ))
       }
     }

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -750,7 +750,13 @@ fn take_type_tokens(tokens: List(String), acc: List(String)) -> List(String) {
 
 fn infer_scalar_type(type_text: String) -> Result(model.ScalarType, String) {
   model.parse_sql_type(type_text)
-  |> result.replace_error("unrecognized SQL type \"" <> type_text <> "\"")
+  |> result.replace_error(
+    "unrecognized SQL type \""
+    <> type_text
+    <> "\". Supported types: int, serial, float, numeric, bool, text, char, bytea,"
+    <> " uuid, json, jsonb, timestamp, datetime, date, time, interval."
+    <> " Hint: add a type override in sqlode.yaml under overrides.db_type",
+  )
 }
 
 fn is_table_constraint(token: String) -> Bool {

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -68,6 +68,7 @@ pub fn reject_unsupported_root_field_test() {
   let msg = config.error_to_string(error)
   string.contains(msg, "database") |> should.be_true()
   string.contains(msg, "Unsupported") |> should.be_true()
+  string.contains(msg, "Valid keys: version, sql") |> should.be_true()
 }
 
 pub fn reject_unsupported_sql_block_field_test() {

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -287,6 +287,8 @@ pub fn invalid_annotation_format_test() {
     query_parser.parse_file("bad.sql", model.PostgreSQL, naming_ctx, content)
   let msg = query_parser.error_to_string(error)
   string.contains(msg, "expected") |> should.be_true()
+  string.contains(msg, ":one") |> should.be_true()
+  string.contains(msg, ":exec") |> should.be_true()
 }
 
 pub fn invalid_command_test() {

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -257,6 +257,8 @@ pub fn unrecognized_sql_type_returns_error_test() {
   let msg = schema_parser.error_to_string(error)
   string.contains(msg, "geo") |> should.be_true()
   string.contains(msg, "GEOMETRY") |> should.be_true()
+  string.contains(msg, "Hint:") |> should.be_true()
+  string.contains(msg, "Supported types:") |> should.be_true()
 }
 
 // --- ALTER TABLE ADD COLUMN tests ---


### PR DESCRIPTION
## Summary
- Improve error messages across 4 modules to include actionable fix suggestions and valid options
- Users now see what they can do to fix the problem, not just what went wrong

## Changes
- **`src/sqlode/schema_parser.gleam`**: Unrecognized SQL type error now lists supported types and suggests using `overrides.db_type` in config
- **`src/sqlode/query_parser.gleam`**: Invalid annotation format error now lists all valid commands (`:one`, `:many`, `:exec`, etc.)
- **`src/sqlode/generate.gleam`**: Unsupported batch command error now also suggests `-- sqlode:skip` as an alternative
- **`src/sqlode/config.gleam`**: Unknown config key error now lists valid keys for the current config section
- Updated tests to verify the new hint/suggestion text is present

## Design Decisions
- Suggestions are appended to existing error messages rather than restructured, preserving backward compatibility for any tooling that parses error output
- Config key validation dynamically uses the `known_keys` list already passed to `check_unknown_keys`, so valid keys stay in sync with the validation logic automatically

Closes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages to provide clearer guidance and list valid options when configuration keys, annotations, or SQL types are invalid.
  * Error messages now include detailed hints about supported values, available alternatives, and configuration overrides to help resolve issues faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->