### PR TITLE
docs(readme): sync init stubs with README examples and mention all created files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sqlode init
 gleam run -m sqlode -- init
 ```
 
-This creates `sqlode.yaml`:
+This creates `sqlode.yaml` along with stub files `db/schema.sql` and `db/query.sql`:
 
 ```yaml
 version: "2"
@@ -128,7 +128,7 @@ sqlode generates reusable record types for each table in the schema, plus per-qu
 ```gleam
 // Table record type (singularized) — reusable across queries
 pub type Author {
-  Author(id: Int, name: String, bio: Option(String))
+  Author(id: Int, name: String, bio: Option(String), created_at: String)
 }
 
 // Exact table match — alias instead of duplicate

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -119,7 +119,8 @@ fn create_stub_files(base_dir: String) -> Nil {
     "CREATE TABLE authors (\n"
     <> "  id BIGSERIAL PRIMARY KEY,\n"
     <> "  name TEXT NOT NULL,\n"
-    <> "  bio TEXT\n"
+    <> "  bio TEXT,\n"
+    <> "  created_at TIMESTAMP NOT NULL\n"
     <> ");\n"
 
   let query_content =
@@ -134,7 +135,8 @@ fn create_stub_files(base_dir: String) -> Nil {
     <> "ORDER BY name;\n"
     <> "\n"
     <> "-- name: CreateAuthor :exec\n"
-    <> "INSERT INTO authors (name, bio) VALUES ($1, $2);\n"
+    <> "INSERT INTO authors (name, bio)\n"
+    <> "VALUES (sqlode.arg(author_name), sqlode.narg(bio));\n"
 
   let db_dir = filepath.join(base_dir, "db")
   let schema_path = filepath.join(db_dir, "schema.sql")

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -57,6 +57,7 @@ pub fn init_creates_stub_schema_file_test() {
   content |> string.contains("id BIGSERIAL PRIMARY KEY") |> should.be_true
   content |> string.contains("name TEXT NOT NULL") |> should.be_true
   content |> string.contains("bio TEXT") |> should.be_true
+  content |> string.contains("created_at TIMESTAMP NOT NULL") |> should.be_true
 
   cleanup("schema")
 }
@@ -74,6 +75,8 @@ pub fn init_creates_stub_query_file_test() {
   content |> string.contains("-- name: GetAuthor :one") |> should.be_true
   content |> string.contains("-- name: ListAuthors :many") |> should.be_true
   content |> string.contains("-- name: CreateAuthor :exec") |> should.be_true
+  content |> string.contains("sqlode.arg(author_name)") |> should.be_true
+  content |> string.contains("sqlode.narg(bio)") |> should.be_true
 
   cleanup("query")
 }


### PR DESCRIPTION
## Summary
- Sync the `init` command stubs with the README getting-started examples
- Update README to mention all files created by `init`

## Changes
- **`src/sqlode/cli.gleam`**: Update schema stub to include `created_at TIMESTAMP NOT NULL` and query stub to use `sqlode.arg(author_name), sqlode.narg(bio)` instead of `$1, $2` — matching the README examples
- **`README.md`**: Update init description to mention `db/schema.sql` and `db/query.sql` alongside `sqlode.yaml`; add `created_at` field to the Author type example in the models section
- **`test/cli_test.gleam`**: Add assertions for `created_at` in schema stub and `sqlode.arg`/`sqlode.narg` in query stub

## Design Decisions
- Updated stubs to match README (not the other way around) because the README examples showcase sqlode macro syntax (`sqlode.arg`, `sqlode.narg`), which is more useful for users learning the tool in the getting-started flow

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `sqlode init` now generates SQL stub files with an added `created_at TIMESTAMP` column in the authors table.
  * Updated SQL query generation to use a new parameter formatting approach with `sqlode.arg()` and `sqlode.narg()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->