### PR TITLE
test(mysql): add MySQL compile test and fix backtick identifier support in param inference

### DIFF
--- a/spec/compile_spec.sh
+++ b/spec/compile_spec.sh
@@ -98,6 +98,33 @@ YAML
     cd "$INTEGRATION_DIR" && gleam build 2>&1
   }
 
+  setup_mysql_raw_project() {
+    rm -rf "$INTEGRATION_DIR"
+    mkdir -p "$INTEGRATION_DIR/src/db"
+
+    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
+name = "integration_test"
+version = "0.1.0"
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+sqlode = { path = "$PROJECT_ROOT" }
+TOML
+
+    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/mysql_schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/mysql_query.sql"
+    engine: "mysql"
+    gen:
+      gleam:
+        out: "$INTEGRATION_DIR/src/db"
+        runtime: "raw"
+YAML
+  }
+
   setup_all_commands_sqlight_project() {
     rm -rf "$INTEGRATION_DIR"
     mkdir -p "$INTEGRATION_DIR/src/db"
@@ -167,6 +194,18 @@ YAML
     After 'cleanup_project'
 
     It 'generates and builds code for all query command types'
+      When call generate_and_build
+      The status should be success
+      The output should include 'Successfully generated'
+      The output should include 'Compiled in'
+    End
+  End
+
+  Describe 'MySQL raw mode (backtick identifiers and ? placeholders)'
+    Before 'setup_mysql_raw_project'
+    After 'cleanup_project'
+
+    It 'generates and builds MySQL raw mode code'
       When call generate_and_build
       The status should be success
       The output should include 'Successfully generated'

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -77,11 +77,11 @@ pub type AnalyzerContext {
 pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
   let assert Ok(insert_re) =
     regexp.from_string(
-      "insert\\s+into\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(([^)]*)\\)\\s*values\\s*\\(([^)]*)\\)",
+      "insert\\s+into\\s+(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(([^)]*)\\)\\s*values\\s*\\(([^)]*)\\)",
     )
   let assert Ok(equality_re) =
     regexp.from_string(
-      "([a-zA-Z_][a-zA-Z0-9_.]*)\\s*(?:<=|>=|!=|<>|=|<|>|\\blike\\b|\\bilike\\b)\\s*(\\$[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
+      "(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_.]*)\\s*(?:<=|>=|!=|<>|=|<|>|\\blike\\b|\\bilike\\b)\\s*(\\$[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
     )
   let assert Ok(postgresql_placeholder_re) = regexp.from_string("(\\$[0-9]+)")
   let assert Ok(mysql_placeholder_re) = regexp.from_string("(\\?)")
@@ -96,7 +96,7 @@ pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
     regexp.from_string("(\\$[0-9]+)::[a-zA-Z_][a-zA-Z0-9_]*")
   let assert Ok(in_clause_re) =
     regexp.from_string(
-      "([a-zA-Z_][a-zA-Z0-9_.]*)\\s+in\\s*\\(\\s*(\\$[0-9]+|\\?[0-9]*|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)\\s*\\)",
+      "(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_.]*)\\s+in\\s*\\(\\s*(\\$[0-9]+|\\?[0-9]*|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)\\s*\\)",
     )
 
   AnalyzerContext(

--- a/test/fixtures/mysql_query.sql
+++ b/test/fixtures/mysql_query.sql
@@ -1,11 +1,14 @@
 -- name: GetAuthor :one
-SELECT id, name FROM authors WHERE id = ?;
+SELECT `id`, `name` FROM `authors` WHERE `id` = ?;
 
 -- name: CreateAuthor :exec
-INSERT INTO authors (name, bio) VALUES (?, ?);
+INSERT INTO `authors` (`name`, `bio`) VALUES (?, ?);
 
 -- name: UpdateAuthor :exec
-UPDATE authors SET name = ?, bio = ? WHERE id = ?;
+UPDATE `authors` SET `name` = ?, `bio` = ? WHERE `id` = ?;
 
 -- name: ListAuthors :many
-SELECT id, name FROM authors ORDER BY name;
+SELECT `id`, `name` FROM `authors` ORDER BY `name`;
+
+-- name: DeleteAuthor :exec
+DELETE FROM `authors` WHERE `id` = ?;

--- a/test/fixtures/mysql_schema.sql
+++ b/test/fixtures/mysql_schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE authors (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  bio TEXT,
+  created_at DATETIME NOT NULL
+);


### PR DESCRIPTION
## Summary
- Add MySQL raw-mode compile test to verify generated code compiles
- Fix backtick-quoted identifier support in parameter type inference regexes
- Add MySQL-specific schema fixture with AUTO_INCREMENT and VARCHAR

## Changes
- **`spec/compile_spec.sh`**: Add `setup_mysql_raw_project` and a new shellspec test that generates MySQL raw-mode code and verifies it compiles
- **`test/fixtures/mysql_schema.sql`** (new): MySQL-specific schema with `BIGINT AUTO_INCREMENT`, `VARCHAR(255)`, and `DATETIME`
- **`test/fixtures/mysql_query.sql`**: Update queries to use backtick-quoted identifiers and add DeleteAuthor query
- **`src/sqlode/query_analyzer/context.gleam`**: Update `equality_re`, `insert_re`, and `in_clause_re` regex patterns to match backtick-quoted identifiers (`` `column` ``) in addition to bare identifiers. This fixes `ParameterTypeNotInferred` errors for MySQL queries using backtick syntax.

## Design Decisions
- The regex fix adds `` `[^`]+` `` as an alternative pattern before the existing `[a-zA-Z_]...` pattern. `naming.normalize_identifier` already strips backtick quotes, so no changes needed downstream.
- MySQL compile test uses `raw` runtime since MySQL `native` runtime is not supported (no adapter generation for MySQL)

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MySQL raw mode support with backtick-quoted identifiers and `?` parameter placeholders

* **Tests**
  * Added integration test fixtures and validation suite for MySQL raw mode operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->