### PR TITLE
fix(query_analyzer): deduplicate SQLite named placeholders in param inference (#219)

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -158,6 +158,9 @@ fn build_inference_dict(
 ) -> dict.Dict(Int, model.Column) {
   list.fold(inferences, dict.new(), fn(d, entry) {
     let #(index, column) = entry
-    dict.insert(d, index, column)
+    case dict.has_key(d, index) {
+      True -> d
+      False -> dict.insert(d, index, column)
+    }
   })
 }

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -38,6 +38,7 @@ pub fn infer_insert_params(
             columns,
             values,
             1,
+            dict.new(),
             [],
           )
           |> list.reverse
@@ -55,25 +56,26 @@ fn map_insert_columns(
   columns: List(String),
   values: List(String),
   occurrence: Int,
+  seen: dict.Dict(String, Int),
   acc: List(#(Int, model.Column)),
 ) -> List(#(Int, model.Column)) {
   case columns, values {
     [], _ | _, [] -> acc
     [column_name, ..rest_columns], [value, ..rest_values] -> {
-      let acc = case
-        placeholder.placeholder_index_for_token(engine, value, occurrence)
+      let #(maybe_index, next_occurrence, updated_seen) = case
+        placeholder.is_placeholder_token(value)
       {
+        True -> placeholder.resolve_index(engine, value, occurrence, seen)
+        False -> #(None, occurrence, seen)
+      }
+
+      let acc = case maybe_index {
         Some(index) ->
           case context.find_column(catalog, table_name, column_name) {
             Some(column) -> [#(index, column), ..acc]
             None -> acc
           }
         None -> acc
-      }
-
-      let next_occurrence = case placeholder.is_placeholder_token(value) {
-        True -> occurrence + 1
-        False -> occurrence
       }
 
       map_insert_columns(
@@ -83,6 +85,7 @@ fn map_insert_columns(
         rest_columns,
         rest_values,
         next_occurrence,
+        updated_seen,
         acc,
       )
     }
@@ -109,6 +112,7 @@ pub fn infer_equality_params(
         all_tables,
         regexp.scan(ctx.equality_re, normalized),
         1,
+        dict.new(),
         [],
       )
       |> list.reverse
@@ -122,6 +126,7 @@ fn scan_equality_matches(
   all_tables: List(String),
   matches: List(regexp.Match),
   occurrence: Int,
+  seen: dict.Dict(String, Int),
   acc: List(#(Int, model.Column)),
 ) -> List(#(Int, model.Column)) {
   case matches {
@@ -141,9 +146,10 @@ fn scan_equality_matches(
           }
           let normalized_col = naming.normalize_identifier(col_name)
 
-          let acc = case
-            placeholder.placeholder_index_for_token(engine, token, occurrence)
-          {
+          let #(maybe_index, next_occurrence, updated_seen) =
+            placeholder.resolve_index(engine, token, occurrence, seen)
+
+          let acc = case maybe_index {
             Some(index) -> {
               let found = case search_table {
                 Some(table) ->
@@ -173,13 +179,6 @@ fn scan_equality_matches(
             None -> acc
           }
 
-          let next_occurrence = case
-            placeholder.sequential_placeholder(engine)
-          {
-            True -> occurrence + 1
-            False -> occurrence
-          }
-
           scan_equality_matches(
             engine,
             catalog,
@@ -187,6 +186,7 @@ fn scan_equality_matches(
             all_tables,
             rest,
             next_occurrence,
+            updated_seen,
             acc,
           )
         }
@@ -198,6 +198,7 @@ fn scan_equality_matches(
             all_tables,
             rest,
             occurrence,
+            seen,
             acc,
           )
       }
@@ -224,6 +225,7 @@ pub fn infer_in_params(
         all_tables,
         regexp.scan(ctx.in_clause_re, normalized),
         1,
+        dict.new(),
         [],
       )
       |> list.reverse

--- a/src/sqlode/query_analyzer/placeholder.gleam
+++ b/src/sqlode/query_analyzer/placeholder.gleam
@@ -62,6 +62,40 @@ pub fn placeholder_index_for_token(
   }
 }
 
+/// Resolves placeholder index with SQLite named-placeholder deduplication.
+/// Returns #(Option(index), next_occurrence, updated_seen_dict).
+/// For SQLite named tokens (not bare ?), reuses the index of the first
+/// occurrence so that the same placeholder always maps to the same index.
+pub fn resolve_index(
+  engine: model.Engine,
+  token: String,
+  occurrence: Int,
+  seen: dict.Dict(String, Int),
+) -> #(Option(Int), Int, dict.Dict(String, Int)) {
+  case engine {
+    model.SQLite if token != "?" ->
+      case dict.get(seen, token) {
+        Ok(existing_index) -> #(Some(existing_index), occurrence, seen)
+        Error(_) -> {
+          let maybe_index =
+            placeholder_index_for_token(engine, token, occurrence)
+          let stored = case maybe_index {
+            Some(i) -> i
+            None -> occurrence
+          }
+          #(maybe_index, occurrence + 1, dict.insert(seen, token, stored))
+        }
+      }
+    _ -> {
+      let next = case sequential_placeholder(engine) {
+        True -> occurrence + 1
+        False -> occurrence
+      }
+      #(placeholder_index_for_token(engine, token, occurrence), next, seen)
+    }
+  }
+}
+
 pub fn sequential_placeholder(engine: model.Engine) -> Bool {
   case engine {
     model.PostgreSQL -> False

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -762,6 +762,66 @@ pub fn full_join_makes_both_tables_nullable_test() {
   ])
 }
 
+pub fn sqlite_repeated_named_placeholder_single_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: ReusedNamed :one\n"
+    <> "SELECT id FROM authors WHERE name = :name OR bio = :name;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("dedup.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+
+  // Repeated :name should produce exactly one parameter
+  list.length(query.params) |> should.equal(1)
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn sqlite_repeated_and_distinct_placeholders_correct_index_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: MixedDedup :one\n"
+    <> "SELECT id FROM authors WHERE name = :name AND bio = :name AND id = :id;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("mixed.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+
+  // :name deduped to index=1, :id gets index=2
+  list.length(query.params) |> should.equal(2)
+  let assert [name_param, id_param] = query.params
+  name_param.index |> should.equal(1)
+  name_param.scalar_type |> should.equal(model.StringType)
+  id_param.index |> should.equal(2)
+  id_param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn sqlite_repeated_at_placeholder_single_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: ReusedAt :one\n"
+    <> "SELECT id FROM authors WHERE id = @id OR name = @id;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("at.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+
+  list.length(query.params) |> should.equal(1)
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+}
+
 fn join_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/join_schema.sql")
   let assert Ok(catalog) =

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -627,6 +627,18 @@ pub fn sqlc_slice_in_block_comment_ignored_test() {
   query_parser_test.sqlc_slice_in_block_comment_ignored_test()
 }
 
+pub fn sqlite_repeated_named_placeholder_single_param_test() {
+  query_analyzer_test.sqlite_repeated_named_placeholder_single_param_test()
+}
+
+pub fn sqlite_repeated_and_distinct_placeholders_correct_index_test() {
+  query_analyzer_test.sqlite_repeated_and_distinct_placeholders_correct_index_test()
+}
+
+pub fn sqlite_repeated_at_placeholder_single_param_test() {
+  query_analyzer_test.sqlite_repeated_at_placeholder_single_param_test()
+}
+
 pub fn compound_query_column_count_mismatch_test() {
   query_analyzer_test.compound_query_column_count_mismatch_test()
 }


### PR DESCRIPTION
## Summary

- Add `resolve_index` to `placeholder.gleam` that encapsulates SQLite named-placeholder deduplication logic, ensuring the same token always maps to the same parameter index
- Update `scan_equality_matches` and `map_insert_columns` in `param_inferencer.gleam` to use `resolve_index` with a seen-dict, aligning occurrence counters with the placeholder extractor
- Change `build_inference_dict` to keep-first semantics so duplicate indices from repeated placeholders don't overwrite the original inference

## Changes

### Root cause
`param_inferencer` called `placeholder_index_for_token` directly, incrementing the occurrence counter for every placeholder match. Meanwhile, `placeholder.build_occurrences` deduplicated SQLite named tokens (`:name`, `@name`, `$name`) to share a single index. This mismatch caused the inference dictionary to store type information under wrong indices when repeated and distinct named placeholders coexisted (e.g. `WHERE name = :name AND bio = :name AND id = :id`).

### Fix
- **`placeholder.gleam`**: New public `resolve_index` function mirrors the dedup logic from `build_occurrences` — for SQLite named tokens it checks a `seen` dict and reuses the existing index.
- **`param_inferencer.gleam`**: Both `scan_equality_matches` and `map_insert_columns` now thread a `seen` dict through recursion via `resolve_index`, keeping their occurrence counters aligned with the placeholder extractor.
- **`query_analyzer.gleam`**: `build_inference_dict` uses first-wins insertion to prevent later occurrences of a deduplicated placeholder from overwriting the initial column inference.

## Design Decisions

- Extracted `resolve_index` as a shared helper rather than inlining the dedup logic in each call site to prevent future drift between placeholder extraction and param inference.
- Did not refactor `build_occurrences` itself to use `resolve_index` to minimize diff size; the existing inline logic is functionally identical.
- `build_inference_dict` first-wins is safe for all engines: PostgreSQL indices are parsed from tokens (no duplicates), MySQL uses positional `?` (always unique).

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dictionary entry handling to prevent overwriting existing values during query analysis.
  * Corrected SQLite named placeholder deduplication to properly track repeated parameters.

* **Tests**
  * Added tests for SQLite named and at-sign placeholder deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->