### PR TITLE
fix(codegen): support module-qualified custom gleam_type with auto-generated imports (#224)

### DIFF
--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import gleam/option
 import gleam/result
 import gleam/string
 import sqlode/model
@@ -36,6 +37,61 @@ pub fn queries_have_enums(queries: List(model.AnalyzedQuery)) -> Bool {
         _ -> False
       }
     })
+  })
+}
+
+/// Collect import statements for module-qualified custom types from scalar types.
+pub fn custom_type_imports(scalar_types: List(model.ScalarType)) -> List(String) {
+  scalar_types
+  |> list.filter_map(fn(st) {
+    case st {
+      model.CustomType(name, option.Some(module), _) ->
+        Ok("import " <> module <> ".{type " <> name <> "}")
+      _ -> Error(Nil)
+    }
+  })
+  |> list.unique
+  |> list.sort(string.compare)
+}
+
+/// Collect all scalar types from query result columns.
+pub fn result_scalar_types(
+  queries: List(model.AnalyzedQuery),
+) -> List(model.ScalarType) {
+  list.flat_map(queries, fn(query) {
+    list.filter_map(query.result_columns, fn(col) {
+      case col {
+        model.ResultColumn(scalar_type:, ..) -> Ok(scalar_type)
+        model.EmbeddedColumn(columns:, ..) ->
+          case
+            list.find_map(columns, fn(c) {
+              case c.scalar_type {
+                model.CustomType(..) -> Ok(c.scalar_type)
+                _ -> Error(Nil)
+              }
+            })
+          {
+            Ok(st) -> Ok(st)
+            Error(_) -> Error(Nil)
+          }
+      }
+    })
+  })
+}
+
+/// Collect all scalar types from query params.
+pub fn param_scalar_types(
+  queries: List(model.AnalyzedQuery),
+) -> List(model.ScalarType) {
+  list.flat_map(queries, fn(query) {
+    list.map(query.params, fn(p) { p.scalar_type })
+  })
+}
+
+/// Collect all scalar types from catalog tables.
+pub fn catalog_scalar_types(catalog: model.Catalog) -> List(model.ScalarType) {
+  list.flat_map(catalog.tables, fn(table) {
+    list.map(table.columns, fn(col) { col.scalar_type })
   })
 }
 

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -2,6 +2,7 @@ import gleam/dict.{type Dict}
 import gleam/list
 import gleam/option
 import gleam/string
+import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
 
@@ -44,13 +45,22 @@ pub fn render(
     ))
     |> string.join("\n\n")
 
-  let imports = case
+  let option_imports = case
     needs_option_import_for_results(queries)
     || needs_option_import_for_tables(catalog)
   {
     True -> ["import gleam/option.{type Option}"]
     False -> []
   }
+
+  let custom_imports =
+    list.flatten([
+      common.result_scalar_types(queries),
+      common.catalog_scalar_types(catalog),
+    ])
+    |> common.custom_type_imports
+
+  let imports = list.flatten([option_imports, custom_imports])
 
   let custom_type_warning = case has_custom_types_in_results(queries) {
     True -> [

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -17,6 +17,10 @@ pub fn render(
 
   let has_enums = common.queries_have_enum_params(queries)
 
+  let custom_imports =
+    common.param_scalar_types(queries)
+    |> common.custom_type_imports
+
   let needs_models_for_strong =
     type_mapping == model.StrongMapping
     && list.any(queries, fn(q) {
@@ -38,6 +42,7 @@ pub fn render(
           True -> ["import " <> module_path <> "/models"]
           False -> []
         },
+        custom_imports,
       ])
     False ->
       list.flatten([
@@ -50,6 +55,7 @@ pub fn render(
           True -> ["import " <> module_path <> "/models"]
           False -> []
         },
+        custom_imports,
       ])
   }
 

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -263,14 +263,20 @@ fn validate_gleam_type(gleam_type: String) -> Result(Nil, ConfigError) {
         detail: "must not be empty",
       ))
     False -> {
+      // For module-qualified types like "myapp/types.UserId",
+      // validate the type name part (after the last dot)
+      let type_name = case string.split_once(gleam_type, ".") {
+        Ok(#(_, name)) -> name
+        Error(_) -> gleam_type
+      }
       let first =
-        string.first(gleam_type)
+        string.first(type_name)
         |> result.unwrap("")
       case is_uppercase_letter(first) {
         False ->
           Error(InvalidValue(
             field: "overrides.types.gleam_type",
-            detail: "must start with an uppercase letter, got \""
+            detail: "type name must start with an uppercase letter, got \""
               <> gleam_type
               <> "\"",
           ))

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -418,6 +418,7 @@ fn gleam_type_to_scalar(
     "string" -> model.StringType
     "bitarray" -> model.BytesType
     _ -> {
+      let #(module, type_name) = parse_module_qualified_type(gleam_type)
       let underlying_name =
         model.scalar_type_to_gleam_type(underlying, model.StringMapping)
       io.println_error(
@@ -426,15 +427,24 @@ fn gleam_type_to_scalar(
         <> "\" will use the encoder/decoder for the underlying \""
         <> underlying_name
         <> "\" type. Ensure \""
-        <> gleam_type
+        <> type_name
         <> "\" is defined as a transparent type alias (e.g., pub type "
-        <> gleam_type
+        <> type_name
         <> " = "
         <> underlying_name
         <> "). Opaque types are not supported.",
       )
-      model.CustomType(name: gleam_type, underlying:)
+      model.CustomType(name: type_name, module:, underlying:)
     }
+  }
+}
+
+fn parse_module_qualified_type(
+  gleam_type: String,
+) -> #(option.Option(String), String) {
+  case string.split_once(gleam_type, ".") {
+    Ok(#(module_path, type_name)) -> #(option.Some(module_path), type_name)
+    Error(_) -> #(option.None, gleam_type)
   }
 }
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -192,7 +192,11 @@ pub type ScalarType {
   UuidType
   JsonType
   EnumType(name: String)
-  CustomType(name: String, underlying: ScalarType)
+  CustomType(
+    name: String,
+    module: option.Option(String),
+    underlying: ScalarType,
+  )
   ArrayType(element: ScalarType)
 }
 
@@ -405,7 +409,7 @@ pub fn scalar_type_to_gleam_type(
     option.None ->
       case scalar_type {
         EnumType(name) -> enum_type_name(name)
-        CustomType(name, _) -> name
+        CustomType(name, _, _) -> name
         ArrayType(element) ->
           "List(" <> scalar_type_to_gleam_type(element, type_mapping) <> ")"
         _ -> "String"
@@ -433,7 +437,8 @@ pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
     option.None ->
       case scalar_type {
         EnumType(_) -> "runtime.string"
-        CustomType(_, underlying) -> scalar_type_to_runtime_function(underlying)
+        CustomType(_, _, underlying) ->
+          scalar_type_to_runtime_function(underlying)
         ArrayType(element) -> scalar_type_to_runtime_function(element)
         _ -> "runtime.string"
       }
@@ -446,7 +451,7 @@ pub fn scalar_type_to_db_name(scalar_type: ScalarType) -> String {
     option.None ->
       case scalar_type {
         EnumType(name) -> name
-        CustomType(_, underlying) -> scalar_type_to_db_name(underlying)
+        CustomType(_, _, underlying) -> scalar_type_to_db_name(underlying)
         ArrayType(element) -> scalar_type_to_db_name(element) <> "[]"
         _ -> "string"
       }
@@ -470,7 +475,7 @@ pub fn scalar_type_to_value_function(
     option.None ->
       case scalar_type {
         EnumType(_) -> "text"
-        CustomType(_, underlying) ->
+        CustomType(_, _, underlying) ->
           scalar_type_to_value_function(engine, underlying)
         ArrayType(element) ->
           "array(pog." <> scalar_type_to_value_function(engine, element) <> ")"
@@ -494,7 +499,8 @@ pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String
     option.None ->
       case scalar_type {
         EnumType(_) -> "decode.string"
-        CustomType(_, underlying) -> scalar_type_to_decoder(engine, underlying)
+        CustomType(_, _, underlying) ->
+          scalar_type_to_decoder(engine, underlying)
         ArrayType(element) ->
           "decode.list(" <> scalar_type_to_decoder(engine, element) <> ")"
         _ -> "decode.string"

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -238,6 +238,98 @@ pub fn no_custom_type_omits_alias_warning_comment_test() {
   cleanup()
 }
 
+pub fn module_qualified_custom_type_generates_import_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "myapp/types.UserId",
+            nullable: option.None,
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Should generate import for the module-qualified type
+  string.contains(models, "import myapp/types.{type UserId}")
+  |> should.be_true()
+  // Should use the bare type name in declarations
+  string.contains(models, "id: UserId") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn module_qualified_custom_type_in_params_generates_import_test() {
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+      ),
+      overrides: model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "myapp/types.UserId",
+            nullable: option.None,
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let params = read_generated("params.gleam")
+
+  // Params module should also import the module-qualified type
+  string.contains(params, "import myapp/types.{type UserId}")
+  |> should.be_true()
+
+  cleanup()
+}
+
+pub fn bare_custom_type_omits_module_import_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "UserId",
+            nullable: option.None,
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // Bare custom type should NOT generate a module import
+  string.contains(models, "import myapp") |> should.be_false()
+  // But should still use the type name
+  string.contains(models, "id: UserId") |> should.be_true()
+
+  cleanup()
+}
+
 pub fn no_overrides_leaves_types_unchanged_test() {
   cleanup()
   let block = base_block(model.empty_overrides())

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -148,7 +148,10 @@ pub fn scalar_type_to_gleam_type_string_mapping_test() {
   model.scalar_type_to_gleam_type(model.JsonType, m) |> should.equal("String")
   model.scalar_type_to_gleam_type(model.EnumType("status"), m)
   |> should.equal("Status")
-  model.scalar_type_to_gleam_type(model.CustomType("UserId", model.IntType), m)
+  model.scalar_type_to_gleam_type(
+    model.CustomType("UserId", option.None, model.IntType),
+    m,
+  )
   |> should.equal("UserId")
 }
 
@@ -172,7 +175,7 @@ pub fn scalar_type_to_gleam_type_rich_mapping_test() {
 }
 
 pub fn custom_type_delegates_to_underlying_test() {
-  let custom = model.CustomType("UserId", model.IntType)
+  let custom = model.CustomType("UserId", option.None, model.IntType)
   model.scalar_type_to_runtime_function(custom)
   |> should.equal("runtime.int")
   model.scalar_type_to_db_name(custom) |> should.equal("int")


### PR DESCRIPTION
## Summary

- Support module-qualified `gleam_type` overrides (e.g., `myapp/types.UserId`) that auto-generate Gleam import statements in models and params modules
- Extend `CustomType` in the data model to carry an optional module path
- Keep backward compatibility for bare type names (e.g., `UserId`) with existing warning behavior

## Changes

### Root cause
Custom `gleam_type` overrides generated bare type references (e.g., `UserId`) without any import mechanism. Users had no way to bring the type into scope in generated code, making the feature unusable without manual patching.

### Fix
- **`model.gleam`**: Extended `CustomType` variant with an `module: Option(String)` field to store the module path when a qualified name is used.
- **`config.gleam`**: Updated `validate_gleam_type` to accept module-qualified names like `myapp/types.UserId` — validation now applies to the type name part after the dot.
- **`generate.gleam`**: Added `parse_module_qualified_type` that splits `myapp/types.UserId` into module path and type name, storing both in `CustomType`.
- **`codegen/common.gleam`**: Added `custom_type_imports` helper that collects `import myapp/types.{type UserId}` statements from scalar types with module paths.
- **`codegen/models.gleam`**: Generates import statements for module-qualified custom types in result columns and catalog tables.
- **`codegen/params.gleam`**: Generates import statements for module-qualified custom types in query parameters.

## Design Decisions

- Module-qualified format uses Gleam's standard `module/path.TypeName` convention, making imports straightforward.
- Bare custom type names remain supported with the existing transparent-alias warning — no breaking change for current users.
- Import generation is centralized in `codegen/common.gleam` to avoid duplication between models and params modules.
- The encoder/decoder still delegates to the underlying primitive type, which is correct for transparent type aliases.

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for module-qualified custom scalar types in code generation, enabling users to reference custom types from external modules (e.g., `mymodule.MyType`).
  * Improved generated code to automatically include necessary imports for custom scalar type dependencies.

* **Bug Fixes**
  * Enhanced validation to correctly handle module-qualified type names.

* **Tests**
  * Added comprehensive tests validating module-qualified and bare custom type handling across generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->