### PR TITLE
fix(schema_parser): treat SERIAL/BIGSERIAL/SMALLSERIAL as implicit NOT NULL (#320)

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -785,6 +785,7 @@ fn parse_column_tokens(
               let nullable = case
                 tokens_contain_not_null(tokens)
                 || tokens_contain_keyword(tokens, "primary")
+                || string.contains(type_text, "serial")
               {
                 True -> False
                 False -> True
@@ -906,6 +907,7 @@ fn is_column_constraint(keyword: String) -> Bool {
       "constraint",
       "generated",
       "collate",
+      "autoincrement",
     ],
     keyword,
   )

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -393,3 +393,25 @@ pub fn view_with_literal_expression_test() {
     list.find(view.columns, fn(c) { c.name == "greeting" })
   greeting.scalar_type |> should.equal(model.StringType)
 }
+
+pub fn serial_types_are_implicitly_not_null_test() {
+  let content =
+    "CREATE TABLE t (\n"
+    <> "  a SERIAL,\n"
+    <> "  b BIGSERIAL,\n"
+    <> "  c SMALLSERIAL,\n"
+    <> "  d INTEGER\n"
+    <> ");\n"
+
+  let assert Ok(catalog) = schema_parser.parse_files([#("serial.sql", content)])
+
+  let assert [table] = catalog.tables
+  let assert [a, b, c, d] = table.columns
+
+  // SERIAL/BIGSERIAL/SMALLSERIAL should be implicitly NOT NULL
+  a.nullable |> should.equal(False)
+  b.nullable |> should.equal(False)
+  c.nullable |> should.equal(False)
+  // Plain INTEGER without NOT NULL should be nullable
+  d.nullable |> should.equal(True)
+}


### PR DESCRIPTION
## Summary
- Columns defined with SERIAL, BIGSERIAL, or SMALLSERIAL (PostgreSQL) are now correctly treated as implicitly NOT NULL
- Added "autoincrement" to the column constraint keyword list so it is properly recognized as a constraint token rather than a type token

## Changes
- **src/sqlode/schema_parser.gleam**: Added `string.contains(type_text, "serial")` check to the nullable detection logic in `parse_column_tokens`, and added "autoincrement" to `is_column_constraint`
- **test/schema_parser_test.gleam**: Added `serial_types_are_implicitly_not_null_test` verifying SERIAL/BIGSERIAL/SMALLSERIAL columns are non-nullable while plain INTEGER remains nullable

## Design Decisions
- Used substring match on `type_text` (which is already lowercased) for "serial" — this covers SERIAL, BIGSERIAL, and SMALLSERIAL in a single check
- SQLite AUTOINCREMENT is always paired with PRIMARY KEY, so it was already handled; adding it to `is_column_constraint` is a correctness improvement for token classification

Closes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema parsing to correctly recognize SERIAL, BIGSERIAL, and SMALLSERIAL column types as non-nullable by default.
  * Improved constraint detection to properly handle AUTOINCREMENT keywords during schema parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->