### PR TITLE
fix(schema_parser): extract all source tables from view FROM clause (#321)

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -6,6 +6,7 @@ import gleam/string
 import sqlode/lexer
 import sqlode/model
 import sqlode/naming
+import sqlode/query_analyzer/token_utils
 
 pub type ParseError {
   InvalidCreateTable(detail: String)
@@ -227,20 +228,28 @@ fn parse_create_view_from_tokens(
           // Find FROM keyword at depth 0 to split SELECT columns from FROM clause
           let #(select_tokens, from_tokens) = split_at_from(after_select, 0, [])
 
-          // Extract table names from FROM clause
-          let source_tables = extract_view_source_tables(from_tokens)
+          // Extract table names from FROM clause (prepend "from" keyword
+          // because split_at_from already consumed it)
+          let source_tables =
+            token_utils.extract_table_names([
+              lexer.Keyword("from"),
+              ..from_tokens
+            ])
 
           case select_tokens {
-            [lexer.Star] ->
-              case source_tables {
-                [table_name, ..] ->
+            [lexer.Star] -> {
+              let columns =
+                list.flat_map(source_tables, fn(table_name) {
                   case list.find(tables, fn(t) { t.name == table_name }) {
-                    Ok(table) ->
-                      Some(model.Table(name: view_name, columns: table.columns))
-                    Error(_) -> None
+                    Ok(table) -> table.columns
+                    Error(_) -> []
                   }
+                })
+              case columns {
                 [] -> None
+                _ -> Some(model.Table(name: view_name, columns: columns))
               }
+            }
             _ -> {
               let view_cols = extract_view_columns(select_tokens)
               let columns =
@@ -318,17 +327,6 @@ fn split_at_from(
       split_at_from(rest, depth - 1, [lexer.RParen, ..acc])
     [lexer.Keyword("from"), ..rest] if depth == 0 -> #(list.reverse(acc), rest)
     [token, ..rest] -> split_at_from(rest, depth, [token, ..acc])
-  }
-}
-
-fn extract_view_source_tables(tokens: List(lexer.Token)) -> List(String) {
-  case tokens {
-    [lexer.Ident(_schema), lexer.Dot, lexer.Ident(name), ..] -> [
-      string.lowercase(name),
-    ]
-    [lexer.Ident(name), ..] -> [string.lowercase(name)]
-    [lexer.QuotedIdent(name), ..] -> [string.lowercase(name)]
-    _ -> []
   }
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -415,3 +415,54 @@ pub fn serial_types_are_implicitly_not_null_test() {
   // Plain INTEGER without NOT NULL should be nullable
   d.nullable |> should.equal(True)
 }
+
+pub fn view_with_join_extracts_all_source_tables_test() {
+  let content =
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, amount INTEGER NOT NULL);\n"
+    <> "CREATE VIEW user_orders AS SELECT u.name, o.amount FROM users u JOIN orders o ON u.id = o.user_id;\n"
+
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("join_view.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "user_orders" })
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["name", "amount"])
+
+  let assert Ok(name_col) = list.find(view.columns, fn(c) { c.name == "name" })
+  name_col.scalar_type |> should.equal(model.StringType)
+
+  let assert Ok(amount_col) =
+    list.find(view.columns, fn(c) { c.name == "amount" })
+  amount_col.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn view_with_left_join_test() {
+  let content =
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "CREATE TABLE profiles (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, bio TEXT);\n"
+    <> "CREATE VIEW user_profiles AS SELECT u.name, p.bio FROM users u LEFT JOIN profiles p ON u.id = p.user_id;\n"
+
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("left_join.sql", content)])
+
+  let assert Ok(view) =
+    list.find(catalog.tables, fn(tbl) { tbl.name == "user_profiles" })
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["name", "bio"])
+}
+
+pub fn view_star_with_join_test() {
+  let content =
+    "CREATE TABLE t1 (a INTEGER NOT NULL, b TEXT NOT NULL);\n"
+    <> "CREATE TABLE t2 (c INTEGER NOT NULL, d TEXT NOT NULL);\n"
+    <> "CREATE VIEW v AS SELECT * FROM t1 JOIN t2 ON t1.a = t2.c;\n"
+
+  let assert Ok(catalog) =
+    schema_parser.parse_files([#("star_join.sql", content)])
+
+  let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
+  let col_names = list.map(view.columns, fn(c) { c.name })
+  col_names |> should.equal(["a", "b", "c", "d"])
+}


### PR DESCRIPTION
## Summary
- Views with JOINs now correctly resolve columns from all source tables, not just the first
- SELECT * on JOINed views now includes columns from all joined tables

## Changes
- **src/sqlode/schema_parser.gleam**: Replaced `extract_view_source_tables` (single-table extraction) with `token_utils.extract_table_names` (handles FROM, JOIN, LEFT JOIN, etc.). Updated SELECT * handling to collect columns from all source tables via `list.flat_map`.
- **test/schema_parser_test.gleam**: Added 3 tests — JOIN with explicit columns, LEFT JOIN, and SELECT * with JOIN

## Design Decisions
- Reused the existing `token_utils.extract_table_names` rather than duplicating JOIN-handling logic, prepending a synthetic `Keyword("from")` token since `split_at_from` already consumed the original FROM keyword
- Removed the now-unused `extract_view_source_tables` function entirely

Closes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced view support to properly extract columns from views containing JOIN and LEFT JOIN operations.
  * Improved SELECT * expansion to correctly include columns from all joined source tables.

* **Bug Fixes**
  * Fixed column derivation logic for views to handle multiple source tables accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->