### PR TITLE
fix(column_inferencer): migrate RETURNING clause extraction to token-based analysis (#322)

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -1,6 +1,5 @@
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regexp
 import gleam/result
 import gleam/string
 import sqlode/lexer
@@ -21,7 +20,7 @@ type ExtractedColumn {
 }
 
 pub fn infer_result_columns(
-  ctx: AnalyzerContext,
+  _ctx: AnalyzerContext,
   engine: model.Engine,
   query: model.ParsedQuery,
   catalog: model.Catalog,
@@ -38,10 +37,8 @@ pub fn infer_result_columns(
     | runtime.QueryBatchOne
     | runtime.QueryBatchMany -> {
       let tokens = lexer.tokenize(query.sql, engine)
-      let normalized = context.normalize_sql(ctx, query.sql)
 
-      // RETURNING clause still uses regex (works well, no subquery risk)
-      case extract_returning_columns(ctx, normalized) {
+      case tok_extract_returning_columns(tokens) {
         Some(returning_cols) -> {
           let table_names = token_utils.extract_table_names(tokens)
           let nullable_tables = tok_extract_nullable_tables(tokens, table_names)
@@ -89,33 +86,40 @@ pub fn infer_result_columns(
   }
 }
 
-fn extract_returning_columns(
-  ctx: AnalyzerContext,
-  sql: String,
+/// Extract RETURNING columns from tokens using token-based analysis.
+fn tok_extract_returning_columns(
+  tokens: List(lexer.Token),
 ) -> Option(List(ExtractedColumn)) {
-  case regexp.scan(ctx.returning_re, sql) {
-    [match, ..] ->
-      case match.submatches {
-        [Some(columns_text)] -> {
-          let cols = case string.trim(columns_text) == "*" {
-            True -> [
-              ExtractedColumn(name: "*", source_table: None, expression: None),
-            ]
-            False ->
-              context.split_csv(columns_text)
-              |> list.map(fn(c) {
-                ExtractedColumn(
-                  name: string.trim(c),
-                  source_table: None,
-                  expression: None,
-                )
-              })
-          }
-          Some(cols)
-        }
-        _ -> None
-      }
+  case tok_find_returning_tokens(tokens) {
+    Some(col_tokens) ->
+      Some(
+        tok_split_on_commas(col_tokens)
+        |> list.map(tok_parse_column_item),
+      )
+    None -> None
+  }
+}
+
+/// Find tokens after the RETURNING keyword until end of statement.
+fn tok_find_returning_tokens(
+  tokens: List(lexer.Token),
+) -> Option(List(lexer.Token)) {
+  case tokens {
     [] -> None
+    [lexer.Keyword("returning"), ..rest] -> {
+      let filtered =
+        list.filter(rest, fn(tok) {
+          case tok {
+            lexer.Semicolon -> False
+            _ -> True
+          }
+        })
+      case filtered {
+        [] -> None
+        _ -> Some(filtered)
+      }
+    }
+    [_, ..rest] -> tok_find_returning_tokens(rest)
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1,5 +1,5 @@
 import gleam/list
-import gleam/option.{Some}
+import gleam/option.{None, Some}
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -427,6 +427,41 @@ pub fn returning_clause_result_columns_test() {
       source_table: Some("authors"),
     ),
   ])
+}
+
+pub fn returning_clause_with_function_expression_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: CreateAuthorCoalesce :one\nINSERT INTO authors (name, bio) VALUES ($1, $2) RETURNING id, COALESCE(bio, name) AS display;"
+  let assert Ok(queries) =
+    query_parser.parse_file("ret_fn.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [id_col, display_col] = query.result_columns
+  id_col
+  |> should.equal(model.ResultColumn(
+    name: "id",
+    scalar_type: model.IntType,
+    nullable: False,
+    source_table: Some("authors"),
+  ))
+  // COALESCE(bio, name) should resolve to StringType
+  display_col
+  |> should.equal(model.ResultColumn(
+    name: "display",
+    scalar_type: model.StringType,
+    nullable: False,
+    source_table: None,
+  ))
 }
 
 pub fn cte_select_from_real_table_test() {


### PR DESCRIPTION
## Summary
- Replaced regex-based RETURNING clause extraction with token-based analysis, correctly handling commas inside function calls and subqueries
- Reuses existing `tok_split_on_commas` and `tok_parse_column_item` infrastructure already proven for SELECT column extraction

## Changes
- **src/sqlode/query_analyzer/column_inferencer.gleam**: Replaced `extract_returning_columns` (regex + `split_csv`) with `tok_extract_returning_columns` and `tok_find_returning_tokens` (token-based). Removed `regexp` import. The `_ctx` parameter is kept for API compatibility but no longer used.
- **test/query_analyzer_test.gleam**: Added `returning_clause_with_function_expression_test` verifying `RETURNING id, COALESCE(bio, name) AS display` is correctly parsed with token-based analysis

## Design Decisions
- Followed the same pattern as `tok_extract_select_columns` / `tok_find_select_to_from` for consistency
- Semicolons are filtered from RETURNING tokens since the regex approach implicitly stripped them
- The `AnalyzerContext.returning_re` field is now unused but left in place to avoid a public API change in this PR

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of RETURNING clauses containing function expressions in query analysis.

* **Tests**
  * Added test coverage for RETURNING clauses with function expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->