### PR TITLE
refactor(naming,schema_parser): flatten deeply nested case expressions (#314)

### DIFF
--- a/src/sqlode/naming.gleam
+++ b/src/sqlode/naming.gleam
@@ -170,30 +170,40 @@ fn singularize_regular(word: String, lower: String) -> String {
 }
 
 fn singularize_by_suffix(word: String, lower: String) -> String {
-  case string.ends_with(lower, "ies") {
-    True -> string.drop_end(word, 3) <> apply_suffix_case(word, "y")
-    False ->
-      case string.ends_with(lower, "ves") {
-        True -> string.drop_end(word, 3) <> apply_suffix_case(word, "f")
-        False ->
-          case
-            string.ends_with(lower, "sses")
-            || string.ends_with(lower, "shes")
-            || string.ends_with(lower, "ches")
-            || string.ends_with(lower, "xes")
-            || string.ends_with(lower, "zes")
-          {
-            True -> string.drop_end(word, 2)
-            False ->
-              case string.ends_with(lower, "ss") {
-                True -> word
-                False ->
-                  case string.ends_with(lower, "s") {
-                    True -> string.drop_end(word, 1)
-                    False -> word
-                  }
+  let suffix_rules = [
+    #("ies", 3, "y"),
+    #("ves", 3, "f"),
+    #("sses", 2, ""),
+    #("shes", 2, ""),
+    #("ches", 2, ""),
+    #("xes", 2, ""),
+    #("zes", 2, ""),
+    #("ss", 0, ""),
+    #("s", 1, ""),
+  ]
+  apply_first_suffix_rule(word, lower, suffix_rules)
+}
+
+fn apply_first_suffix_rule(
+  word: String,
+  lower: String,
+  rules: List(#(String, Int, String)),
+) -> String {
+  case rules {
+    [] -> word
+    [#(suffix, drop, replacement), ..rest] ->
+      case string.ends_with(lower, suffix) {
+        True ->
+          case drop {
+            0 -> word
+            _ ->
+              string.drop_end(word, drop)
+              <> case replacement {
+                "" -> ""
+                r -> apply_suffix_case(word, r)
               }
           }
+        False -> apply_first_suffix_rule(word, lower, rest)
       }
   }
 }

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -192,6 +192,35 @@ fn parse_create_view_from_tokens(
   tokens: List(lexer.Token),
   tables: List(model.Table),
 ) -> Option(model.Table) {
+  use #(view_name, after_name) <- extract_view_name(tokens)
+  let after_as = skip_to_keyword(after_name, "as")
+  use after_select <- extract_after_select(after_as)
+
+  let #(select_tokens, from_tokens) = split_at_from(after_select, 0, [])
+  let source_tables =
+    token_utils.extract_table_names([lexer.Keyword("from"), ..from_tokens])
+
+  let columns = case select_tokens {
+    [lexer.Star] ->
+      list.flat_map(source_tables, fn(table_name) {
+        case list.find(tables, fn(t) { t.name == table_name }) {
+          Ok(table) -> table.columns
+          Error(_) -> []
+        }
+      })
+    _ -> resolve_view_columns(select_tokens, tables)
+  }
+
+  case columns {
+    [] -> None
+    _ -> Some(model.Table(name: view_name, columns:))
+  }
+}
+
+fn extract_view_name(
+  tokens: List(lexer.Token),
+  cont: fn(#(String, List(lexer.Token))) -> Option(model.Table),
+) -> Option(model.Table) {
   let remaining = case tokens {
     [
       lexer.Keyword("create"),
@@ -203,103 +232,63 @@ fn parse_create_view_from_tokens(
     [lexer.Keyword("create"), lexer.Keyword("view"), ..rest] -> rest
     _ -> []
   }
-
-  // Extract view name
-  let #(view_name, after_name) = case remaining {
-    [lexer.Ident(n), ..rest] -> #(string.lowercase(n), rest)
-    [lexer.QuotedIdent(n), ..rest] -> #(string.lowercase(n), rest)
-    _ -> #("", [])
+  case remaining {
+    [lexer.Ident(n), ..rest] -> cont(#(string.lowercase(n), rest))
+    [lexer.QuotedIdent(n), ..rest] -> cont(#(string.lowercase(n), rest))
+    _ -> None
   }
+}
 
-  case view_name {
-    "" -> None
-    _ -> {
-      // Skip to AS keyword
-      let after_as = skip_to_keyword(after_name, "as")
-      // Skip past SELECT keyword
-      let after_select = case after_as {
-        [lexer.Keyword("select"), ..rest] -> rest
-        _ -> []
-      }
-
-      case after_select {
+fn extract_after_select(
+  tokens: List(lexer.Token),
+  cont: fn(List(lexer.Token)) -> Option(model.Table),
+) -> Option(model.Table) {
+  case tokens {
+    [lexer.Keyword("select"), ..rest] ->
+      case rest {
         [] -> None
-        _ -> {
-          // Find FROM keyword at depth 0 to split SELECT columns from FROM clause
-          let #(select_tokens, from_tokens) = split_at_from(after_select, 0, [])
+        _ -> cont(rest)
+      }
+    _ -> None
+  }
+}
 
-          // Extract table names from FROM clause (prepend "from" keyword
-          // because split_at_from already consumed it)
-          let source_tables =
-            token_utils.extract_table_names([
-              lexer.Keyword("from"),
-              ..from_tokens
-            ])
+fn resolve_view_columns(
+  select_tokens: List(lexer.Token),
+  tables: List(model.Table),
+) -> List(model.Column) {
+  let view_cols = extract_view_columns(select_tokens)
+  list.filter_map(view_cols, fn(view_col) {
+    let normalized = naming.normalize_identifier(view_col.name)
+    resolve_single_view_column(normalized, view_col.expr_tokens, tables)
+  })
+}
 
-          case select_tokens {
-            [lexer.Star] -> {
-              let columns =
-                list.flat_map(source_tables, fn(table_name) {
-                  case list.find(tables, fn(t) { t.name == table_name }) {
-                    Ok(table) -> table.columns
-                    Error(_) -> []
-                  }
-                })
-              case columns {
-                [] -> None
-                _ -> Some(model.Table(name: view_name, columns: columns))
-              }
-            }
-            _ -> {
-              let view_cols = extract_view_columns(select_tokens)
-              let columns =
-                list.filter_map(view_cols, fn(view_col) {
-                  let normalized = naming.normalize_identifier(view_col.name)
-                  case find_column_in_tables(tables, normalized) {
-                    Some(col) -> Ok(model.Column(..col, name: normalized))
-                    None ->
-                      case
-                        resolve_column_from_expr_tokens(
-                          view_col.expr_tokens,
-                          tables,
-                        )
-                      {
-                        Some(col) -> Ok(model.Column(..col, name: normalized))
-                        None ->
-                          case
-                            infer_view_expression_type(
-                              view_col.expr_tokens,
-                              tables,
-                            )
-                          {
-                            Some(#(scalar_type, nullable)) ->
-                              Ok(model.Column(
-                                name: normalized,
-                                scalar_type: scalar_type,
-                                nullable: nullable,
-                              ))
-                            None -> {
-                              io.println_error(
-                                "Warning: view column \""
-                                <> normalized
-                                <> "\" could not be resolved from source tables"
-                                <> " — skipping column.",
-                              )
-                              Error(Nil)
-                            }
-                          }
-                      }
-                  }
-                })
-              case columns {
-                [] -> None
-                _ -> Some(model.Table(name: view_name, columns:))
-              }
+fn resolve_single_view_column(
+  name: String,
+  expr_tokens: List(lexer.Token),
+  tables: List(model.Table),
+) -> Result(model.Column, Nil) {
+  case find_column_in_tables(tables, name) {
+    Some(col) -> Ok(model.Column(..col, name:))
+    None ->
+      case resolve_column_from_expr_tokens(expr_tokens, tables) {
+        Some(col) -> Ok(model.Column(..col, name:))
+        None ->
+          case infer_view_expression_type(expr_tokens, tables) {
+            Some(#(scalar_type, nullable)) ->
+              Ok(model.Column(name:, scalar_type:, nullable:))
+            None -> {
+              io.println_error(
+                "Warning: view column \""
+                <> name
+                <> "\" could not be resolved from source tables"
+                <> " — skipping column.",
+              )
+              Error(Nil)
             }
           }
-        }
       }
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Flattened 5-level nested case expressions in `singularize_by_suffix` using a data-driven suffix rule table
- Decomposed 7+ level nested `parse_create_view_from_tokens` into smaller focused functions using `use` expressions

## Changes
- **src/sqlode/naming.gleam**: Replaced nested `case string.ends_with` pyramid in `singularize_by_suffix` with a list of `#(suffix, drop_count, replacement)` rules processed by `apply_first_suffix_rule`
- **src/sqlode/schema_parser.gleam**: Extracted `extract_view_name`, `extract_after_select`, `resolve_view_columns`, and `resolve_single_view_column` from `parse_create_view_from_tokens`, reducing max nesting from 7+ to 3 levels

## Design Decisions
- Used continuation-passing style (`use`) for `extract_view_name` and `extract_after_select` to enable early return on failure without deep nesting
- The suffix rule table approach makes it trivial to add new singularization rules in the future

Closes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured singularization logic for improved code organization.
  * Reorganized SQL view parsing and column resolution handling to enhance code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->