### PR TITLE
refactor(model): eliminate catch-all wildcard fallbacks in ScalarType matches (#312)

### DIFF
--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -388,8 +388,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         decoder: "decode.string",
         unwrap_fn: option.Some("sql_json_to_string"),
       ))
-    // EnumType, CustomType, ArrayType need special handling
-    _ -> option.None
+    EnumType(_) | CustomType(_, _, _) | ArrayType(_) -> option.None
   }
 }
 
@@ -412,7 +411,17 @@ pub fn scalar_type_to_gleam_type(
         CustomType(name, _, _) -> name
         ArrayType(element) ->
           "List(" <> scalar_type_to_gleam_type(element, type_mapping) <> ")"
-        _ -> "String"
+        IntType
+        | FloatType
+        | BoolType
+        | StringType
+        | BytesType
+        | DateTimeType
+        | DateType
+        | TimeType
+        | UuidType
+        | JsonType ->
+          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
       }
   }
 }
@@ -440,7 +449,17 @@ pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
         CustomType(_, _, underlying) ->
           scalar_type_to_runtime_function(underlying)
         ArrayType(element) -> scalar_type_to_runtime_function(element)
-        _ -> "runtime.string"
+        IntType
+        | FloatType
+        | BoolType
+        | StringType
+        | BytesType
+        | DateTimeType
+        | DateType
+        | TimeType
+        | UuidType
+        | JsonType ->
+          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
       }
   }
 }
@@ -453,7 +472,17 @@ pub fn scalar_type_to_db_name(scalar_type: ScalarType) -> String {
         EnumType(name) -> name
         CustomType(_, _, underlying) -> scalar_type_to_db_name(underlying)
         ArrayType(element) -> scalar_type_to_db_name(element) <> "[]"
-        _ -> "string"
+        IntType
+        | FloatType
+        | BoolType
+        | StringType
+        | BytesType
+        | DateTimeType
+        | DateType
+        | TimeType
+        | UuidType
+        | JsonType ->
+          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
       }
   }
 }
@@ -479,7 +508,17 @@ pub fn scalar_type_to_value_function(
           scalar_type_to_value_function(engine, underlying)
         ArrayType(element) ->
           "array(pog." <> scalar_type_to_value_function(engine, element) <> ")"
-        _ -> "text"
+        IntType
+        | FloatType
+        | BoolType
+        | StringType
+        | BytesType
+        | DateTimeType
+        | DateType
+        | TimeType
+        | UuidType
+        | JsonType ->
+          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
       }
   }
 }
@@ -503,7 +542,17 @@ pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String
           scalar_type_to_decoder(engine, underlying)
         ArrayType(element) ->
           "decode.list(" <> scalar_type_to_decoder(engine, element) <> ")"
-        _ -> "decode.string"
+        IntType
+        | FloatType
+        | BoolType
+        | StringType
+        | BytesType
+        | DateTimeType
+        | DateType
+        | TimeType
+        | UuidType
+        | JsonType ->
+          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
       }
   }
 }


### PR DESCRIPTION
## Summary
- Replaced `_ -> "String"` / `_ -> "runtime.string"` catch-all patterns with exhaustive matches that panic on unreachable branches
- Ensures the compiler will catch missing branches when new ScalarType variants are added

## Changes
- **src/sqlode/model.gleam**: In `scalar_type_info`, replaced `_ -> option.None` with explicit `EnumType(_) | CustomType(_, _, _) | ArrayType(_) -> option.None`. In 5 public functions (`scalar_type_to_gleam_type`, `scalar_type_to_runtime_function`, `scalar_type_to_db_name`, `scalar_type_to_value_function`, `scalar_type_to_decoder`), replaced the unreachable `_ ->` fallback with exhaustive leaf type matches that panic with a clear message.

## Design Decisions
- Used `panic as "unreachable: ..."` instead of silently defaulting to String, following the project principle of preferring early errors over silent fallback
- Listed all 10 leaf types explicitly so the compiler enforces completeness when new variants are added

Closes #312