### PR TITLE
refactor(parser,analyzer): finish token-first SQL parsing and retire regex heuristics

### DIFF
--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import gleam/option
 import gleam/string
 import sqlode/model
 
@@ -10,6 +11,9 @@ pub type TokenRenderOptions {
     /// When True, quoted identifiers keep their quotes and string
     /// literals escape embedded single-quotes.
     preserve_quotes: Bool,
+    /// When set, use engine-specific quote style for identifiers:
+    /// MySQL → backticks, PostgreSQL/SQLite → double quotes.
+    engine: option.Option(model.Engine),
   )
 }
 
@@ -696,7 +700,11 @@ fn token_to_string(token: Token, options: TokenRenderOptions) -> String {
     Ident(name) -> name
     QuotedIdent(name) ->
       case options.preserve_quotes {
-        True -> "\"" <> name <> "\""
+        True ->
+          case options.engine {
+            option.Some(model.MySQL) -> "`" <> name <> "`"
+            _ -> "\"" <> name <> "\""
+          }
         False -> name
       }
     StringLit(value) ->

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -870,6 +870,10 @@ fn tok_find_last_as_idx(
 fn tok_tokens_to_text(tokens: List(lexer.Token)) -> String {
   lexer.tokens_to_string(
     tokens,
-    lexer.TokenRenderOptions(uppercase_keywords: False, preserve_quotes: False),
+    lexer.TokenRenderOptions(
+      uppercase_keywords: False,
+      preserve_quotes: False,
+      engine: None,
+    ),
   )
 }

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -16,6 +16,7 @@ type ExtractedColumn {
     name: String,
     source_table: Option(String),
     expression: Option(String),
+    expression_tokens: Option(List(lexer.Token)),
   )
 }
 
@@ -93,7 +94,7 @@ fn tok_extract_returning_columns(
   case tok_find_returning_tokens(tokens) {
     Some(col_tokens) ->
       Some(
-        tok_split_on_commas(col_tokens)
+        token_utils.split_on_commas(col_tokens)
         |> list.map(tok_parse_column_item),
       )
     None -> None
@@ -199,10 +200,14 @@ fn resolve_select_columns(
                       ),
                     ])
                   None ->
-                    case extracted.expression {
-                      Some(expr) -> {
+                    case extracted.expression_tokens {
+                      Some(expr_tokens) -> {
                         let #(scalar_type, nullable) =
-                          infer_expression_type(expr, catalog, all_tables)
+                          infer_expression_type_from_tokens(
+                            expr_tokens,
+                            catalog,
+                            all_tables,
+                          )
                         Ok([
                           model.ResultColumn(
                             name: normalized_name,
@@ -239,10 +244,14 @@ fn resolve_select_columns(
                       ),
                     ])
                   None ->
-                    case extracted.expression {
-                      Some(expr) -> {
+                    case extracted.expression_tokens {
+                      Some(expr_tokens) -> {
                         let #(scalar_type, nullable) =
-                          infer_expression_type(expr, catalog, all_tables)
+                          infer_expression_type_from_tokens(
+                            expr_tokens,
+                            catalog,
+                            all_tables,
+                          )
                         Ok([
                           model.ResultColumn(
                             name: normalized_name,
@@ -268,225 +277,194 @@ fn resolve_select_columns(
   }
 }
 
-fn infer_expression_type(
-  expr: String,
-  catalog: model.Catalog,
-  table_names: List(String),
-) -> #(model.ScalarType, Bool) {
-  let lowered = string.lowercase(string.trim(expr))
-  infer_expression_type_dispatch(lowered, catalog, table_names)
-}
+// ============================================================
+// Token-based expression type inference (#342)
+// ============================================================
 
-fn infer_expression_type_dispatch(
-  lowered: String,
+fn infer_expression_type_from_tokens(
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
   table_names: List(String),
 ) -> #(model.ScalarType, Bool) {
-  let prefixes = [
-    #("count(", InferCount),
-    #("sum(", InferSum),
-    #("avg(", InferAvg),
-    #("min(", InferMinMax),
-    #("max(", InferMinMax),
-    #("row_number(", InferRowNumber),
-    #("rank(", InferRowNumber),
-    #("dense_rank(", InferRowNumber),
-    #("coalesce(", InferCoalesce),
-    #("cast(", InferCast),
-    #("case ", InferCase),
-    #("'", InferStringLiteral),
-  ]
-  case find_matching_prefix(lowered, prefixes) {
-    Some(InferCount) -> #(model.IntType, False)
-    Some(InferSum) -> {
-      let inner_type = infer_aggregate_inner_type(lowered, catalog, table_names)
-      #(inner_type, True)
+  case tokens {
+    // count(...) -> IntType, not nullable
+    [lexer.Keyword("count"), lexer.LParen, ..] -> #(model.IntType, False)
+
+    // sum(...) -> inner type, nullable
+    [lexer.Keyword("sum"), lexer.LParen, ..rest] -> {
+      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+      let first_arg = tok_first_comma_group(inner_tokens)
+      let inner_type =
+        resolve_column_type_from_tokens(first_arg, catalog, table_names)
+      case inner_type {
+        Some(t) -> #(t, True)
+        None -> #(model.IntType, True)
+      }
     }
-    Some(InferAvg) -> #(model.FloatType, True)
-    Some(InferMinMax) -> {
-      let inner_type = infer_aggregate_inner_type(lowered, catalog, table_names)
-      #(inner_type, True)
+
+    // avg(...) -> FloatType, nullable
+    [lexer.Keyword("avg"), lexer.LParen, ..] -> #(model.FloatType, True)
+
+    // min/max(...) -> inner type, nullable
+    [lexer.Keyword(kw), lexer.LParen, ..rest] if kw == "min" || kw == "max" -> {
+      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+      let first_arg = tok_first_comma_group(inner_tokens)
+      let inner_type =
+        resolve_column_type_from_tokens(first_arg, catalog, table_names)
+      case inner_type {
+        Some(t) -> #(t, True)
+        None -> #(model.IntType, True)
+      }
     }
-    Some(InferRowNumber) -> #(model.IntType, False)
-    Some(InferCoalesce) -> {
-      let inner = extract_function_arg(lowered)
-      case resolve_column_type(string.trim(inner), catalog, table_names) {
+
+    // row_number(), rank(), dense_rank() -> IntType
+    [lexer.Keyword(kw), lexer.LParen, ..]
+      if kw == "row_number" || kw == "rank" || kw == "dense_rank"
+    -> #(model.IntType, False)
+
+    // coalesce(...) -> first arg type, not nullable
+    [lexer.Keyword("coalesce"), lexer.LParen, ..rest] -> {
+      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+      let first_arg = tok_first_comma_group(inner_tokens)
+      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
         Some(t) -> #(t, False)
         None -> #(model.StringType, False)
       }
     }
-    Some(InferCast) ->
-      case string.split_once(lowered, " as ") {
-        Ok(#(_, type_part)) -> {
-          let type_text = type_part |> string.replace(")", "") |> string.trim
-          case model.parse_sql_type(type_text) {
+
+    // cast(expr AS type) -> parsed type, nullable
+    [lexer.Keyword("cast"), lexer.LParen, ..rest] -> {
+      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+      case tok_find_as_type(inner_tokens) {
+        Some(type_name) ->
+          case model.parse_sql_type(type_name) {
             Ok(scalar_type) -> #(scalar_type, True)
             Error(_) -> #(model.StringType, True)
           }
-        }
-        Error(_) -> #(model.StringType, True)
+        None -> #(model.StringType, True)
       }
-    Some(InferCase) -> infer_case_type(lowered, catalog, table_names)
-    Some(InferStringLiteral) -> #(model.StringType, False)
-    None ->
-      case is_integer_literal(lowered) {
-        True -> #(model.IntType, False)
-        False ->
-          case lowered == "true" || lowered == "false" {
-            True -> #(model.BoolType, False)
-            False -> #(model.StringType, True)
-          }
-      }
-  }
-}
-
-type ExprKind {
-  InferCount
-  InferSum
-  InferAvg
-  InferMinMax
-  InferRowNumber
-  InferCoalesce
-  InferCast
-  InferCase
-  InferStringLiteral
-}
-
-fn find_matching_prefix(
-  lowered: String,
-  rules: List(#(String, ExprKind)),
-) -> Option(ExprKind) {
-  case rules {
-    [] -> None
-    [#(prefix, kind), ..rest] ->
-      case string.starts_with(lowered, prefix) {
-        True -> Some(kind)
-        False -> find_matching_prefix(lowered, rest)
-      }
-  }
-}
-
-fn infer_aggregate_inner_type(
-  func_expr: String,
-  catalog: model.Catalog,
-  table_names: List(String),
-) -> model.ScalarType {
-  let inner = extract_function_arg(func_expr)
-  case resolve_column_type(string.trim(inner), catalog, table_names) {
-    Some(t) -> t
-    None -> model.IntType
-  }
-}
-
-fn extract_function_arg(func_expr: String) -> String {
-  case string.split_once(func_expr, "(") {
-    Ok(#(_, rest)) -> {
-      let arg = extract_paren_content(string.to_graphemes(rest), 1, [])
-      // For multi-arg functions, take the first top-level arg
-      let first_arg = extract_first_csv_arg(string.to_graphemes(arg), 0, [])
-      string.trim(first_arg)
     }
-    Error(_) -> func_expr
-  }
-}
 
-/// Extract content between matched parentheses, tracking depth.
-fn extract_paren_content(
-  chars: List(String),
-  depth: Int,
-  acc: List(String),
-) -> String {
-  case depth <= 0 {
-    True -> acc |> list.reverse |> string.concat
-    False ->
-      case chars {
-        [] -> acc |> list.reverse |> string.concat
-        ["(", ..rest] -> extract_paren_content(rest, depth + 1, ["(", ..acc])
-        [")", ..rest] ->
-          case depth == 1 {
-            True -> acc |> list.reverse |> string.concat
-            False -> extract_paren_content(rest, depth - 1, [")", ..acc])
-          }
-        [c, ..rest] -> extract_paren_content(rest, depth, [c, ..acc])
+    // CASE WHEN ... THEN value ... -> examine first THEN branch
+    [lexer.Keyword("case"), ..rest] ->
+      infer_case_type_from_tokens(rest, catalog, table_names)
+
+    // String literal
+    [lexer.StringLit(_)] -> #(model.StringType, False)
+
+    // Number literal
+    [lexer.NumberLit(n)] ->
+      case string.contains(n, ".") {
+        True -> #(model.FloatType, False)
+        False -> #(model.IntType, False)
       }
+
+    // Boolean keywords
+    [lexer.Keyword("true")] | [lexer.Keyword("false")] -> #(
+      model.BoolType,
+      False,
+    )
+
+    // Fallback: StringType, nullable
+    _ -> #(model.StringType, True)
   }
 }
 
-/// Extract first comma-separated argument at top level (not inside parens).
-fn extract_first_csv_arg(
-  chars: List(String),
-  depth: Int,
-  acc: List(String),
-) -> String {
-  case chars {
-    [] -> acc |> list.reverse |> string.concat
-    ["(", ..rest] -> extract_first_csv_arg(rest, depth + 1, ["(", ..acc])
-    [")", ..rest] -> extract_first_csv_arg(rest, depth - 1, [")", ..acc])
-    [",", ..] if depth == 0 -> acc |> list.reverse |> string.concat
-    [c, ..rest] -> extract_first_csv_arg(rest, depth, [c, ..acc])
+/// Get the first comma-separated group of tokens (top-level only).
+fn tok_first_comma_group(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case token_utils.split_on_commas(tokens) {
+    [first, ..] -> first
+    [] -> []
+  }
+}
+
+/// Find the type name after AS in CAST tokens (e.g., [expr, AS, type_name]).
+fn tok_find_as_type(tokens: List(lexer.Token)) -> Option(String) {
+  case tokens {
+    [] -> None
+    [lexer.Keyword("as"), ..rest] -> {
+      let type_text =
+        rest
+        |> list.filter_map(fn(t) {
+          case t {
+            lexer.Ident(n) -> Ok(n)
+            lexer.Keyword(k) -> Ok(k)
+            _ -> Error(Nil)
+          }
+        })
+        |> string.join(" ")
+      case type_text {
+        "" -> None
+        _ -> Some(string.lowercase(type_text))
+      }
+    }
+    [_, ..rest] -> tok_find_as_type(rest)
   }
 }
 
 /// Infer type from CASE expression by examining the first THEN branch.
-fn infer_case_type(
-  lowered: String,
+fn infer_case_type_from_tokens(
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
   table_names: List(String),
 ) -> #(model.ScalarType, Bool) {
-  // Extract the first THEN value from "case when ... then <value> ..."
-  case string.split_once(lowered, " then ") {
-    Ok(#(_, after_then)) -> {
-      // The value extends until WHEN, ELSE, or END
-      let value_text =
-        after_then
-        |> split_before_keyword([" when ", " else ", " end"])
-        |> string.trim
-      case value_text {
-        "" -> #(model.StringType, True)
-        _ ->
-          infer_expression_type_dispatch(value_text, catalog, table_names)
-          |> fn(result) { #(result.0, True) }
+  case tok_collect_then_value(tokens) {
+    Some(then_tokens) ->
+      case then_tokens {
+        [] -> #(model.StringType, True)
+        _ -> {
+          let #(scalar_type, _) =
+            infer_expression_type_from_tokens(then_tokens, catalog, table_names)
+          #(scalar_type, True)
+        }
       }
-    }
-    Error(_) -> #(model.StringType, True)
+    None -> #(model.StringType, True)
   }
 }
 
-/// Split string before the first occurrence of any keyword.
-fn split_before_keyword(s: String, keywords: List(String)) -> String {
-  case keywords {
-    [] -> s
-    [kw, ..rest] ->
-      case string.split_once(s, kw) {
-        Ok(#(before, _)) -> split_before_keyword(before, rest)
-        Error(_) -> split_before_keyword(s, rest)
-      }
+/// Collect tokens between first THEN and the next WHEN/ELSE/END at depth 0.
+fn tok_collect_then_value(
+  tokens: List(lexer.Token),
+) -> Option(List(lexer.Token)) {
+  case tokens {
+    [] -> None
+    [lexer.Keyword("then"), ..rest] -> Some(tok_until_case_boundary(rest, []))
+    [_, ..rest] -> tok_collect_then_value(rest)
   }
 }
 
-fn resolve_column_type(
-  name: String,
+fn tok_until_case_boundary(
+  tokens: List(lexer.Token),
+  acc: List(lexer.Token),
+) -> List(lexer.Token) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [lexer.Keyword(kw), ..] if kw == "when" || kw == "else" || kw == "end" ->
+      list.reverse(acc)
+    [token, ..rest] -> tok_until_case_boundary(rest, [token, ..acc])
+  }
+}
+
+/// Resolve a column type from a token list (handles table.column and bare column).
+fn resolve_column_type_from_tokens(
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
   table_names: List(String),
 ) -> Option(model.ScalarType) {
-  // Try table.column format
-  let col_name = case string.split_once(name, ".") {
-    Ok(#(_, col)) -> string.trim(col)
-    Error(_) -> name
+  case tokens {
+    [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] ->
+      case context.find_column_in_tables(catalog, table_names, col) {
+        Some(#(_, column)) -> Some(column.scalar_type)
+        None -> None
+      }
+    [lexer.Ident(col)] ->
+      case context.find_column_in_tables(catalog, table_names, col) {
+        Some(#(_, column)) -> Some(column.scalar_type)
+        None -> None
+      }
+    [lexer.Star] -> None
+    _ -> None
   }
-  case context.find_column_in_tables(catalog, table_names, col_name) {
-    Some(#(_, column)) -> Some(column.scalar_type)
-    None -> None
-  }
-}
-
-fn is_integer_literal(s: String) -> Bool {
-  !string.is_empty(s)
-  && string.to_utf_codepoints(s)
-  |> list.all(fn(cp) {
-    let value = string.utf_codepoint_to_int(cp)
-    value >= 48 && value <= 57
-  })
 }
 
 // ============================================================
@@ -574,7 +552,7 @@ fn validate_compound_column_counts(
 
 fn count_branch_columns(branch: List(lexer.Token)) -> Int {
   case tok_find_select_to_from(branch) {
-    Some(col_tokens) -> list.length(tok_split_on_commas(col_tokens))
+    Some(col_tokens) -> list.length(token_utils.split_on_commas(col_tokens))
     None -> 0
   }
 }
@@ -714,7 +692,7 @@ fn tok_extract_select_columns(
 ) -> List(ExtractedColumn) {
   case tok_find_select_to_from(tokens) {
     Some(col_tokens) ->
-      tok_split_on_commas(col_tokens)
+      token_utils.split_on_commas(col_tokens)
       |> list.map(tok_parse_column_item)
     None -> []
   }
@@ -764,37 +742,6 @@ fn tok_collect_until_from(
   }
 }
 
-/// Split tokens on top-level commas.
-fn tok_split_on_commas(tokens: List(lexer.Token)) -> List(List(lexer.Token)) {
-  tok_split_commas_loop(tokens, 0, [], [])
-}
-
-fn tok_split_commas_loop(
-  tokens: List(lexer.Token),
-  depth: Int,
-  current: List(lexer.Token),
-  acc: List(List(lexer.Token)),
-) -> List(List(lexer.Token)) {
-  case tokens {
-    [] ->
-      case current {
-        [] -> list.reverse(acc)
-        _ -> list.reverse([list.reverse(current), ..acc])
-      }
-    [lexer.Comma, ..rest] if depth == 0 ->
-      case current {
-        [] -> tok_split_commas_loop(rest, 0, [], acc)
-        _ -> tok_split_commas_loop(rest, 0, [], [list.reverse(current), ..acc])
-      }
-    [lexer.LParen, ..rest] ->
-      tok_split_commas_loop(rest, depth + 1, [lexer.LParen, ..current], acc)
-    [lexer.RParen, ..rest] ->
-      tok_split_commas_loop(rest, depth - 1, [lexer.RParen, ..current], acc)
-    [token, ..rest] ->
-      tok_split_commas_loop(rest, depth, [token, ..current], acc)
-  }
-}
-
 /// Parse a column item from tokens into ExtractedColumn.
 fn tok_parse_column_item(tokens: List(lexer.Token)) -> ExtractedColumn {
   // Check for sqlode.embed(table) pattern: Ident("sqlode") Dot Ident("embed") LParen ...
@@ -807,7 +754,12 @@ fn tok_parse_column_item(tokens: List(lexer.Token)) -> ExtractedColumn {
         True -> {
           // Reconstruct as "sqlode.embed(table_name)" without extra spaces
           let text = tok_reconstruct_macro_call(tokens)
-          ExtractedColumn(name: text, source_table: None, expression: None)
+          ExtractedColumn(
+            name: text,
+            source_table: None,
+            expression: None,
+            expression_tokens: None,
+          )
         }
         False -> tok_parse_regular_column(tokens)
       }
@@ -847,6 +799,7 @@ fn tok_parse_regular_column(tokens: List(lexer.Token)) -> ExtractedColumn {
         name: alias_name,
         source_table: table,
         expression: Some(expr_text),
+        expression_tokens: Some(expr_tokens),
       )
     }
     None ->
@@ -856,17 +809,29 @@ fn tok_parse_regular_column(tokens: List(lexer.Token)) -> ExtractedColumn {
             name: col,
             source_table: Some(string.lowercase(table)),
             expression: None,
+            expression_tokens: None,
           )
         [lexer.Ident(name)] ->
-          ExtractedColumn(name: name, source_table: None, expression: None)
+          ExtractedColumn(
+            name: name,
+            source_table: None,
+            expression: None,
+            expression_tokens: None,
+          )
         [lexer.Star] ->
-          ExtractedColumn(name: "*", source_table: None, expression: None)
+          ExtractedColumn(
+            name: "*",
+            source_table: None,
+            expression: None,
+            expression_tokens: None,
+          )
         _ -> {
           let text = tok_tokens_to_text(tokens)
           ExtractedColumn(
             name: text,
             source_table: None,
             expression: Some(text),
+            expression_tokens: Some(tokens),
           )
         }
       }

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -1,7 +1,6 @@
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regexp
 import gleam/string
 import sqlode/model
 import sqlode/naming
@@ -60,63 +59,11 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
 }
 
 pub type AnalyzerContext {
-  AnalyzerContext(
-    naming: naming.NamingContext,
-    insert_re: regexp.Regexp,
-    equality_re: regexp.Regexp,
-    postgresql_placeholder_re: regexp.Regexp,
-    mysql_placeholder_re: regexp.Regexp,
-    sqlite_placeholder_re: regexp.Regexp,
-    whitespace_re: regexp.Regexp,
-    returning_re: regexp.Regexp,
-    type_cast_re: regexp.Regexp,
-    in_clause_re: regexp.Regexp,
-  )
+  AnalyzerContext(naming: naming.NamingContext)
 }
 
 pub fn new(naming_ctx: naming.NamingContext) -> AnalyzerContext {
-  let assert Ok(insert_re) =
-    regexp.from_string(
-      "insert\\s+into\\s+(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(([^)]*)\\)\\s*values\\s*\\(([^)]*)\\)",
-    )
-  let assert Ok(equality_re) =
-    regexp.from_string(
-      "(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_.]*)\\s*(?:<=|>=|!=|<>|=|<|>|\\blike\\b|\\bilike\\b)\\s*(\\$[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
-    )
-  let assert Ok(postgresql_placeholder_re) = regexp.from_string("(\\$[0-9]+)")
-  let assert Ok(mysql_placeholder_re) = regexp.from_string("(\\?)")
-  let assert Ok(sqlite_placeholder_re) =
-    regexp.from_string(
-      "(\\?[0-9]+|\\?|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)",
-    )
-  let assert Ok(whitespace_re) = regexp.from_string("\\s+")
-  let assert Ok(returning_re) =
-    regexp.from_string("returning\\s+(.+?)\\s*;?\\s*$")
-  let assert Ok(type_cast_re) =
-    regexp.from_string("(\\$[0-9]+)::[a-zA-Z_][a-zA-Z0-9_]*")
-  let assert Ok(in_clause_re) =
-    regexp.from_string(
-      "(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_.]*)\\s+in\\s*\\(\\s*(\\$[0-9]+|\\?[0-9]*|:[A-Za-z_][A-Za-z0-9_]*|@[A-Za-z_][A-Za-z0-9_]*|\\$[A-Za-z_][A-Za-z0-9_]*)\\s*\\)",
-    )
-
-  AnalyzerContext(
-    naming: naming_ctx,
-    insert_re:,
-    equality_re:,
-    postgresql_placeholder_re:,
-    mysql_placeholder_re:,
-    sqlite_placeholder_re:,
-    whitespace_re:,
-    returning_re:,
-    type_cast_re:,
-    in_clause_re:,
-  )
-}
-
-pub fn normalize_sql(ctx: AnalyzerContext, sql: String) -> String {
-  let lowered = string.lowercase(sql)
-  regexp.replace(ctx.whitespace_re, lowered, " ")
-  |> string.trim
+  AnalyzerContext(naming: naming_ctx)
 }
 
 pub fn find_column(

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -2,50 +2,35 @@ import gleam/dict
 import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
-import gleam/regexp
 import gleam/string
 import sqlode/lexer
 import sqlode/model
-import sqlode/naming
 import sqlode/query_analyzer/context.{type AnalyzerContext}
 import sqlode/query_analyzer/placeholder
 import sqlode/query_analyzer/token_utils
 
 pub fn infer_insert_params(
-  ctx: AnalyzerContext,
+  _ctx: AnalyzerContext,
   engine: model.Engine,
   query: model.ParsedQuery,
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
-  let normalized = context.normalize_sql(ctx, query.sql)
+  let tokens = lexer.tokenize(query.sql, engine)
 
-  case regexp.scan(ctx.insert_re, normalized) {
-    [match, ..] ->
-      case match.submatches {
-        [Some(table_name), Some(columns_text), Some(values_text)] -> {
-          let columns =
-            context.split_csv(columns_text)
-            |> list.map(naming.normalize_identifier)
-
-          let values =
-            context.split_csv(values_text)
-            |> list.map(string.trim)
-
-          map_insert_columns(
-            engine,
-            catalog,
-            table_name,
-            columns,
-            values,
-            1,
-            dict.new(),
-            [],
-          )
-          |> list.reverse
-        }
-        _ -> []
-      }
-    [] -> []
+  case token_utils.find_insert_parts(tokens) {
+    Some(parts) ->
+      map_insert_columns(
+        engine,
+        catalog,
+        parts.table_name,
+        parts.columns,
+        parts.values,
+        1,
+        dict.new(),
+        [],
+      )
+      |> list.reverse
+    None -> []
   }
 }
 
@@ -54,19 +39,25 @@ fn map_insert_columns(
   catalog: model.Catalog,
   table_name: String,
   columns: List(String),
-  values: List(String),
+  values: List(List(lexer.Token)),
   occurrence: Int,
   seen: dict.Dict(String, Int),
   acc: List(#(Int, model.Column)),
 ) -> List(#(Int, model.Column)) {
   case columns, values {
     [], _ | _, [] -> acc
-    [column_name, ..rest_columns], [value, ..rest_values] -> {
+    [column_name, ..rest_columns], [value_tokens, ..rest_values] -> {
+      // Check if value is a single placeholder token
+      let value_placeholder = case value_tokens {
+        [lexer.Placeholder(p)] -> Some(p)
+        _ -> None
+      }
+
       let #(maybe_index, next_occurrence, updated_seen) = case
-        placeholder.is_placeholder_token(value)
+        value_placeholder
       {
-        True -> placeholder.resolve_index(engine, value, occurrence, seen)
-        False -> #(None, occurrence, seen)
+        Some(p) -> placeholder.resolve_index(engine, p, occurrence, seen)
+        None -> #(None, occurrence, seen)
       }
 
       let acc = case maybe_index {
@@ -93,172 +84,142 @@ fn map_insert_columns(
 }
 
 pub fn infer_equality_params(
-  ctx: AnalyzerContext,
+  _ctx: AnalyzerContext,
   engine: model.Engine,
   query: model.ParsedQuery,
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
-  let normalized = context.normalize_sql(ctx, query.sql)
   let tokens = lexer.tokenize(query.sql, engine)
   let all_tables = token_utils.extract_table_names(tokens)
 
   case all_tables {
     [] -> []
-    [primary, ..] ->
-      scan_equality_matches(
+    [primary, ..] -> {
+      let matches = token_utils.find_equality_patterns(tokens)
+      scan_token_matches(
         engine,
         catalog,
         primary,
         all_tables,
-        regexp.scan(ctx.equality_re, normalized),
+        matches,
         1,
         dict.new(),
         [],
       )
       |> list.reverse
+    }
   }
 }
 
-fn scan_equality_matches(
+fn scan_token_matches(
   engine: model.Engine,
   catalog: model.Catalog,
   primary_table: String,
   all_tables: List(String),
-  matches: List(regexp.Match),
+  matches: List(token_utils.EqualityMatch),
   occurrence: Int,
   seen: dict.Dict(String, Int),
   acc: List(#(Int, model.Column)),
 ) -> List(#(Int, model.Column)) {
   case matches {
     [] -> acc
-    [match, ..rest] ->
-      case match.submatches {
-        [Some(column_ref), Some(token)] -> {
-          // Handle table.column qualified references
-          let #(search_table, col_name) = case
-            string.split_once(column_ref, ".")
-          {
-            Ok(#(table_prefix, column)) -> #(
-              Some(string.trim(table_prefix)),
-              string.trim(column),
-            )
-            Error(_) -> #(None, column_ref)
+    [match, ..rest] -> {
+      let #(maybe_index, next_occurrence, updated_seen) =
+        placeholder.resolve_index(engine, match.placeholder, occurrence, seen)
+
+      let acc = case maybe_index {
+        Some(index) -> {
+          let found = case match.table_qualifier {
+            Some(table) ->
+              context.find_column(catalog, table, match.column_name)
+            None ->
+              option.map(
+                context.find_column_in_tables(
+                  catalog,
+                  all_tables,
+                  match.column_name,
+                ),
+                fn(pair) { pair.1 },
+              )
           }
-          let normalized_col = naming.normalize_identifier(col_name)
-
-          let #(maybe_index, next_occurrence, updated_seen) =
-            placeholder.resolve_index(engine, token, occurrence, seen)
-
-          let acc = case maybe_index {
-            Some(index) -> {
-              let found = case search_table {
-                Some(table) ->
-                  context.find_column(catalog, table, normalized_col)
-                None ->
-                  option.map(
-                    context.find_column_in_tables(
-                      catalog,
-                      all_tables,
-                      normalized_col,
-                    ),
-                    fn(pair) { pair.1 },
-                  )
-              }
-              case found {
+          case found {
+            Some(column) -> [#(index, column), ..acc]
+            None ->
+              // Fallback: try primary table
+              case
+                context.find_column(catalog, primary_table, match.column_name)
+              {
                 Some(column) -> [#(index, column), ..acc]
-                None ->
-                  // Fallback: try primary table
-                  case
-                    context.find_column(catalog, primary_table, normalized_col)
-                  {
-                    Some(column) -> [#(index, column), ..acc]
-                    None -> acc
-                  }
+                None -> acc
               }
-            }
-            None -> acc
           }
-
-          scan_equality_matches(
-            engine,
-            catalog,
-            primary_table,
-            all_tables,
-            rest,
-            next_occurrence,
-            updated_seen,
-            acc,
-          )
         }
-        _ ->
-          scan_equality_matches(
-            engine,
-            catalog,
-            primary_table,
-            all_tables,
-            rest,
-            occurrence,
-            seen,
-            acc,
-          )
+        None -> acc
       }
+
+      scan_token_matches(
+        engine,
+        catalog,
+        primary_table,
+        all_tables,
+        rest,
+        next_occurrence,
+        updated_seen,
+        acc,
+      )
+    }
   }
 }
 
 pub fn infer_in_params(
-  ctx: AnalyzerContext,
+  _ctx: AnalyzerContext,
   engine: model.Engine,
   query: model.ParsedQuery,
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
-  let normalized = context.normalize_sql(ctx, query.sql)
   let tokens = lexer.tokenize(query.sql, engine)
   let all_tables = token_utils.extract_table_names(tokens)
 
   case all_tables {
     [] -> []
-    [primary, ..] ->
-      scan_equality_matches(
+    [primary, ..] -> {
+      let matches = token_utils.find_in_patterns(tokens)
+      scan_token_matches(
         engine,
         catalog,
         primary,
         all_tables,
-        regexp.scan(ctx.in_clause_re, normalized),
+        matches,
         1,
         dict.new(),
         [],
       )
       |> list.reverse
+    }
   }
 }
 
 pub fn extract_type_casts(
-  ctx: AnalyzerContext,
+  _ctx: AnalyzerContext,
   engine: model.Engine,
   sql: String,
 ) -> Result(dict.Dict(Int, model.ScalarType), #(Int, String)) {
   case engine {
     model.PostgreSQL -> {
-      let normalized = context.normalize_sql(ctx, sql)
-      regexp.scan(ctx.type_cast_re, normalized)
-      |> list.try_fold(dict.new(), fn(d, match) {
-        case match.submatches {
-          [Some(ph)] -> {
-            let cast_type = string.replace(match.content, ph <> "::", "")
-            case
-              ph
-              |> string.replace("$", "")
-              |> int.parse
-            {
-              Ok(index) ->
-                case cast_type_to_scalar(cast_type) {
-                  Ok(scalar_type) -> Ok(dict.insert(d, index, scalar_type))
-                  Error(Nil) -> Error(#(index, string.trim(cast_type)))
-                }
-              Error(_) -> Ok(d)
+      let tokens = lexer.tokenize(sql, engine)
+      let casts = token_utils.find_type_casts(tokens)
+      list.try_fold(casts, dict.new(), fn(d, cast) {
+        case
+          cast.placeholder
+          |> string.replace("$", "")
+          |> int.parse
+        {
+          Ok(index) ->
+            case cast_type_to_scalar(cast.cast_type) {
+              Ok(scalar_type) -> Ok(dict.insert(d, index, scalar_type))
+              Error(Nil) -> Error(#(index, string.trim(cast.cast_type)))
             }
-          }
-          _ -> Ok(d)
+          Error(_) -> Ok(d)
         }
       })
     }
@@ -269,4 +230,3 @@ pub fn extract_type_casts(
 fn cast_type_to_scalar(type_name: String) -> Result(model.ScalarType, Nil) {
   model.parse_sql_type(string.trim(type_name))
 }
-// --- Token-based helpers ---

--- a/src/sqlode/query_analyzer/placeholder.gleam
+++ b/src/sqlode/query_analyzer/placeholder.gleam
@@ -2,11 +2,12 @@ import gleam/dict
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regexp
 import gleam/string
+import sqlode/lexer
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer/context.{type AnalyzerContext}
+import sqlode/query_analyzer/token_utils
 
 pub type PlaceholderOccurrence {
   PlaceholderOccurrence(index: Int, token: String, default_name: String)
@@ -17,7 +18,7 @@ pub fn extract(
   engine: model.Engine,
   sql: String,
 ) -> List(PlaceholderOccurrence) {
-  let tokens = placeholder_tokens(ctx, engine, sql)
+  let tokens = placeholder_tokens(engine, sql)
   build_occurrences(ctx, engine, tokens, 1, dict.new(), [])
 }
 
@@ -170,24 +171,9 @@ fn build_occurrences(
   }
 }
 
-fn placeholder_tokens(
-  ctx: AnalyzerContext,
-  engine: model.Engine,
-  sql: String,
-) -> List(String) {
-  let re = case engine {
-    model.PostgreSQL -> ctx.postgresql_placeholder_re
-    model.MySQL -> ctx.mysql_placeholder_re
-    model.SQLite -> ctx.sqlite_placeholder_re
-  }
-
-  regexp.scan(re, sql)
-  |> list.filter_map(fn(match) {
-    case match.submatches {
-      [Some(token)] -> Ok(token)
-      _ -> Error(Nil)
-    }
-  })
+fn placeholder_tokens(engine: model.Engine, sql: String) -> List(String) {
+  lexer.tokenize(sql, engine)
+  |> token_utils.extract_placeholders
 }
 
 fn default_param_name(ctx: AnalyzerContext, token: String, index: Int) -> String {

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -1,7 +1,9 @@
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import sqlode/lexer
+import sqlode/naming
 
 /// Extract all table names referenced in a token list (FROM, INTO, UPDATE, JOIN).
 pub fn extract_table_names(tokens: List(lexer.Token)) -> List(String) {
@@ -70,5 +72,479 @@ pub fn skip_parens(tokens: List(lexer.Token), depth: Int) -> List(lexer.Token) {
         [lexer.RParen, ..rest] -> skip_parens(rest, depth - 1)
         [_, ..rest] -> skip_parens(rest, depth)
       }
+  }
+}
+
+// ============================================================
+// Shared token utilities for token-first parsing (#342)
+// ============================================================
+
+/// Extract all placeholder token strings from a token list.
+pub fn extract_placeholders(tokens: List(lexer.Token)) -> List(String) {
+  list.filter_map(tokens, fn(token) {
+    case token {
+      lexer.Placeholder(p) -> Ok(p)
+      _ -> Error(Nil)
+    }
+  })
+}
+
+/// Collect tokens inside the next parenthesized group.
+/// Expects tokens starting right after the opening LParen.
+/// Returns #(inner_tokens, remaining_tokens_after_RParen).
+pub fn collect_paren_contents(
+  tokens: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  collect_paren_loop(tokens, 1, [])
+}
+
+fn collect_paren_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  acc: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  case depth <= 0 {
+    True -> #(list.reverse(acc), tokens)
+    False ->
+      case tokens {
+        [] -> #(list.reverse(acc), [])
+        [lexer.LParen, ..rest] ->
+          collect_paren_loop(rest, depth + 1, [lexer.LParen, ..acc])
+        [lexer.RParen, ..rest] ->
+          case depth == 1 {
+            True -> #(list.reverse(acc), rest)
+            False -> collect_paren_loop(rest, depth - 1, [lexer.RParen, ..acc])
+          }
+        [token, ..rest] -> collect_paren_loop(rest, depth, [token, ..acc])
+      }
+  }
+}
+
+/// Split tokens on top-level commas (depth 0).
+pub fn split_on_commas(tokens: List(lexer.Token)) -> List(List(lexer.Token)) {
+  split_commas_loop(tokens, 0, [], [])
+}
+
+fn split_commas_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  current: List(lexer.Token),
+  acc: List(List(lexer.Token)),
+) -> List(List(lexer.Token)) {
+  case tokens {
+    [] ->
+      case current {
+        [] -> list.reverse(acc)
+        _ -> list.reverse([list.reverse(current), ..acc])
+      }
+    [lexer.Comma, ..rest] if depth == 0 ->
+      case current {
+        [] -> split_commas_loop(rest, 0, [], acc)
+        _ -> split_commas_loop(rest, 0, [], [list.reverse(current), ..acc])
+      }
+    [lexer.LParen, ..rest] ->
+      split_commas_loop(rest, depth + 1, [lexer.LParen, ..current], acc)
+    [lexer.RParen, ..rest] ->
+      split_commas_loop(rest, depth - 1, [lexer.RParen, ..current], acc)
+    [token, ..rest] -> split_commas_loop(rest, depth, [token, ..current], acc)
+  }
+}
+
+// ============================================================
+// INSERT parsing helpers
+// ============================================================
+
+pub type InsertParts {
+  InsertParts(
+    table_name: String,
+    columns: List(String),
+    values: List(List(lexer.Token)),
+  )
+}
+
+/// Find INSERT INTO table (columns) VALUES (values) structure in tokens.
+pub fn find_insert_parts(tokens: List(lexer.Token)) -> Option(InsertParts) {
+  find_insert_loop(tokens)
+}
+
+fn find_insert_loop(tokens: List(lexer.Token)) -> Option(InsertParts) {
+  case tokens {
+    [] -> None
+    [lexer.Keyword("insert"), lexer.Keyword("into"), ..rest] ->
+      parse_insert_after_into(rest)
+    [_, ..rest] -> find_insert_loop(rest)
+  }
+}
+
+fn parse_insert_after_into(tokens: List(lexer.Token)) -> Option(InsertParts) {
+  // Read table name
+  let #(table_name_opt, rest) = read_table_name(tokens)
+  case table_name_opt {
+    None -> None
+    Some(table_name) ->
+      case rest {
+        [lexer.LParen, ..after_lparen] -> {
+          // Collect column names
+          let #(col_tokens, after_cols) = collect_paren_contents(after_lparen)
+          let columns =
+            split_on_commas(col_tokens)
+            |> list.filter_map(fn(group) {
+              case group {
+                [lexer.Ident(name)] -> Ok(naming.normalize_identifier(name))
+                [lexer.QuotedIdent(name)] ->
+                  Ok(naming.normalize_identifier(name))
+                _ -> Error(Nil)
+              }
+            })
+          // Skip to VALUES
+          case skip_to_values(after_cols) {
+            None -> None
+            Some(after_values_kw) ->
+              case after_values_kw {
+                [lexer.LParen, ..after_vlparen] -> {
+                  let #(val_tokens, _rest) =
+                    collect_paren_contents(after_vlparen)
+                  let values = split_on_commas(val_tokens)
+                  Some(InsertParts(table_name:, columns:, values:))
+                }
+                _ -> None
+              }
+          }
+        }
+        _ -> None
+      }
+  }
+}
+
+fn skip_to_values(tokens: List(lexer.Token)) -> Option(List(lexer.Token)) {
+  case tokens {
+    [] -> None
+    [lexer.Keyword("values"), ..rest] -> Some(rest)
+    [_, ..rest] -> skip_to_values(rest)
+  }
+}
+
+// ============================================================
+// Equality / comparison pattern helpers
+// ============================================================
+
+pub type EqualityMatch {
+  EqualityMatch(
+    column_name: String,
+    table_qualifier: Option(String),
+    placeholder: String,
+  )
+}
+
+/// Find all column [op] placeholder patterns in tokens.
+pub fn find_equality_patterns(tokens: List(lexer.Token)) -> List(EqualityMatch) {
+  find_equality_loop(tokens, [])
+  |> list.reverse
+}
+
+fn find_equality_loop(
+  tokens: List(lexer.Token),
+  acc: List(EqualityMatch),
+) -> List(EqualityMatch) {
+  case tokens {
+    [] -> acc
+
+    // table.column op placeholder (comparison operators)
+    [
+      lexer.Ident(t),
+      lexer.Dot,
+      lexer.Ident(c),
+      lexer.Operator(op),
+      lexer.Placeholder(p),
+      ..rest
+    ]
+      if op == "="
+      || op == "!="
+      || op == "<>"
+      || op == "<"
+      || op == ">"
+      || op == "<="
+      || op == ">="
+    ->
+      find_equality_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: Some(string.lowercase(t)),
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    [
+      lexer.Ident(t),
+      lexer.Dot,
+      lexer.QuotedIdent(c),
+      lexer.Operator(op),
+      lexer.Placeholder(p),
+      ..rest
+    ]
+      if op == "="
+      || op == "!="
+      || op == "<>"
+      || op == "<"
+      || op == ">"
+      || op == "<="
+      || op == ">="
+    ->
+      find_equality_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: Some(string.lowercase(t)),
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    // column op placeholder
+    [lexer.Ident(c), lexer.Operator(op), lexer.Placeholder(p), ..rest]
+      if op == "="
+      || op == "!="
+      || op == "<>"
+      || op == "<"
+      || op == ">"
+      || op == "<="
+      || op == ">="
+    ->
+      find_equality_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    [lexer.QuotedIdent(c), lexer.Operator(op), lexer.Placeholder(p), ..rest]
+      if op == "="
+      || op == "!="
+      || op == "<>"
+      || op == "<"
+      || op == ">"
+      || op == "<="
+      || op == ">="
+    ->
+      find_equality_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    // table.column LIKE/ILIKE placeholder
+    [
+      lexer.Ident(t),
+      lexer.Dot,
+      lexer.Ident(c),
+      lexer.Keyword(kw),
+      lexer.Placeholder(p),
+      ..rest
+    ]
+      if kw == "like" || kw == "ilike"
+    ->
+      find_equality_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: Some(string.lowercase(t)),
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    // column LIKE/ILIKE placeholder
+    [lexer.Ident(c), lexer.Keyword(kw), lexer.Placeholder(p), ..rest]
+      if kw == "like" || kw == "ilike"
+    ->
+      find_equality_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    [_, ..rest] -> find_equality_loop(rest, acc)
+  }
+}
+
+// ============================================================
+// IN clause pattern helpers
+// ============================================================
+
+/// Find all column IN (placeholder) patterns in tokens.
+pub fn find_in_patterns(tokens: List(lexer.Token)) -> List(EqualityMatch) {
+  find_in_loop(tokens, [])
+  |> list.reverse
+}
+
+fn find_in_loop(
+  tokens: List(lexer.Token),
+  acc: List(EqualityMatch),
+) -> List(EqualityMatch) {
+  case tokens {
+    [] -> acc
+
+    // table.column IN (placeholder)
+    [
+      lexer.Ident(t),
+      lexer.Dot,
+      lexer.Ident(c),
+      lexer.Keyword("in"),
+      lexer.LParen,
+      lexer.Placeholder(p),
+      lexer.RParen,
+      ..rest
+    ] ->
+      find_in_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: Some(string.lowercase(t)),
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    // column IN (placeholder)
+    [
+      lexer.Ident(c),
+      lexer.Keyword("in"),
+      lexer.LParen,
+      lexer.Placeholder(p),
+      lexer.RParen,
+      ..rest
+    ] ->
+      find_in_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    [
+      lexer.QuotedIdent(c),
+      lexer.Keyword("in"),
+      lexer.LParen,
+      lexer.Placeholder(p),
+      lexer.RParen,
+      ..rest
+    ] ->
+      find_in_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+
+    [_, ..rest] -> find_in_loop(rest, acc)
+  }
+}
+
+// ============================================================
+// Type cast helpers (PostgreSQL $N::type)
+// ============================================================
+
+pub type TypeCast {
+  TypeCast(placeholder: String, cast_type: String)
+}
+
+/// Find all $N::type patterns in tokens (PostgreSQL only).
+pub fn find_type_casts(tokens: List(lexer.Token)) -> List(TypeCast) {
+  find_type_cast_loop(tokens, [])
+  |> list.reverse
+}
+
+fn find_type_cast_loop(
+  tokens: List(lexer.Token),
+  acc: List(TypeCast),
+) -> List(TypeCast) {
+  case tokens {
+    [] -> acc
+
+    // $N::type_name
+    [lexer.Placeholder(p), lexer.Operator("::"), lexer.Ident(t), ..rest] ->
+      find_type_cast_loop(rest, [
+        TypeCast(placeholder: p, cast_type: string.lowercase(t)),
+        ..acc
+      ])
+
+    // $N::keyword (e.g. $1::int where int is a keyword)
+    [lexer.Placeholder(p), lexer.Operator("::"), lexer.Keyword(t), ..rest] ->
+      find_type_cast_loop(rest, [TypeCast(placeholder: p, cast_type: t), ..acc])
+
+    [_, ..rest] -> find_type_cast_loop(rest, acc)
+  }
+}
+
+/// Parse a placeholder string like "$3" into its integer index.
+pub fn parse_placeholder_index(placeholder: String) -> Result(Int, Nil) {
+  placeholder
+  |> string.replace("$", "")
+  |> int.parse
+  |> option.from_result
+  |> option.to_result(Nil)
+}
+
+// ============================================================
+// SET clause pattern helpers (UPDATE ... SET col = placeholder)
+// ============================================================
+
+/// Find all column = placeholder patterns in SET clauses.
+pub fn find_set_patterns(tokens: List(lexer.Token)) -> List(EqualityMatch) {
+  find_set_clause(tokens, [])
+  |> list.reverse
+}
+
+fn find_set_clause(
+  tokens: List(lexer.Token),
+  acc: List(EqualityMatch),
+) -> List(EqualityMatch) {
+  case tokens {
+    [] -> acc
+    [lexer.Keyword("set"), ..rest] -> scan_set_assignments(rest, acc)
+    [_, ..rest] -> find_set_clause(rest, acc)
+  }
+}
+
+fn scan_set_assignments(
+  tokens: List(lexer.Token),
+  acc: List(EqualityMatch),
+) -> List(EqualityMatch) {
+  case tokens {
+    [] -> acc
+    // Stop at WHERE or other clauses
+    [lexer.Keyword(kw), ..]
+      if kw == "where" || kw == "returning" || kw == "from"
+    -> acc
+    // column = placeholder
+    [lexer.Ident(c), lexer.Operator("="), lexer.Placeholder(p), ..rest] ->
+      scan_set_assignments(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+    [lexer.QuotedIdent(c), lexer.Operator("="), lexer.Placeholder(p), ..rest] ->
+      scan_set_assignments(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+    [_, ..rest] -> scan_set_assignments(rest, acc)
   }
 }

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -172,12 +172,33 @@ fn finalize_pending(
       case sql == "" {
         True -> Error(MissingSql(path:, line: start_line, name:))
         False -> {
-          let masked = mask_sql(engine, sql)
-          let #(at_expanded, at_masked, at_macros, next_idx) =
-            expand_at_name_shorthands(engine, sql, masked)
-          let #(expanded_sql, expanded_macros) =
-            expand_macros(engine, at_expanded, at_masked, next_idx)
+          // Phase 1: Tokenize the raw SQL
+          let tokens = lexer.tokenize(sql, engine)
+
+          // Phase 2: Expand @name shorthands in token list (non-MySQL)
+          let #(tokens, at_macros, next_idx) =
+            expand_at_name_tokens(engine, tokens, 1)
+
+          // Phase 3: Expand sqlode.arg/narg/slice(...) macros in token list
+          let #(tokens, expanded_macros) =
+            expand_macro_tokens(engine, tokens, next_idx)
+
           let macros = list.append(at_macros, expanded_macros)
+
+          // Phase 4: Render expanded token list back to SQL
+          let expanded_sql =
+            lexer.tokens_to_string(
+              tokens,
+              lexer.TokenRenderOptions(
+                uppercase_keywords: False,
+                preserve_quotes: True,
+                engine: Some(engine),
+              ),
+            )
+
+          // Phase 5: Count parameters from the already-expanded token list
+          let param_count = count_parameters_from_tokens(engine, tokens)
+
           Ok([
             model.ParsedQuery(
               name:,
@@ -185,7 +206,7 @@ fn finalize_pending(
               command:,
               sql: expanded_sql,
               source_path: path,
-              param_count: count_parameters(engine, expanded_sql),
+              param_count:,
               macros:,
             ),
             ..parsed_rev
@@ -251,9 +272,13 @@ fn is_skip_annotation(line: String) -> Bool {
   line == "-- sqlode:skip"
 }
 
-fn count_parameters(engine: model.Engine, sql: String) -> Int {
+/// Count parameters from an already-expanded token list.
+fn count_parameters_from_tokens(
+  engine: model.Engine,
+  tokens: List(lexer.Token),
+) -> Int {
   let placeholders =
-    lexer.tokenize(sql, engine)
+    tokens
     |> list.filter_map(fn(token) {
       case token {
         lexer.Placeholder(p) -> Ok(p)
@@ -298,269 +323,179 @@ pub fn error_to_string(error: ParseError) -> String {
 }
 
 // ============================================================
-// @name expansion (token-detected, string-replaced)
+// Token-based @name expansion
 // ============================================================
 
-/// Expand @name shorthands. Uses masked SQL for position-safe detection,
-/// original SQL for replacement to preserve formatting.
-fn expand_at_name_shorthands(
+/// Expand @name shorthands in the token list.
+/// For non-MySQL engines, Placeholder("@name") tokens are replaced
+/// with engine-appropriate placeholders ($N, ?N).
+/// The lexer only emits Placeholder("@...") when @ is followed by
+/// alpha/underscore, so @1 is never matched (it becomes Operator+NumberLit).
+fn expand_at_name_tokens(
   engine: model.Engine,
-  sql: String,
-  masked: String,
-) -> #(String, String, List(model.Macro), Int) {
+  tokens: List(lexer.Token),
+  start_idx: Int,
+) -> #(List(lexer.Token), List(model.Macro), Int) {
   case engine {
-    model.MySQL -> #(sql, masked, [], 1)
-    _ -> {
-      let at_positions = find_at_names(masked)
-      case at_positions {
-        [] -> #(sql, masked, [], 1)
-        _ ->
-          expand_at_positions(
-            engine,
-            sql,
-            masked,
-            at_positions,
-            1,
-            dict.new(),
-            [],
-          )
-      }
-    }
+    model.MySQL -> #(tokens, [], start_idx)
+    _ -> expand_at_loop(engine, tokens, start_idx, dict.new(), [], [])
   }
 }
 
-/// Find all @name positions in masked SQL (no regex).
-fn find_at_names(masked: String) -> List(#(Int, String)) {
-  find_at_loop(string.to_graphemes(masked), 0, [])
-  |> list.reverse
-}
-
-fn find_at_loop(
-  chars: List(String),
-  pos: Int,
-  acc: List(#(Int, String)),
-) -> List(#(Int, String)) {
-  case chars {
-    [] -> acc
-    ["@", ..rest] ->
-      case read_identifier_chars(rest, []) {
-        #("", _) -> find_at_loop(rest, pos + 1, acc)
-        #(name, remaining) -> {
-          let full = "@" <> name
-          find_at_loop(remaining, pos + string.length(full), [
-            #(pos, name),
-            ..acc
-          ])
-        }
-      }
-    [c, ..rest] -> find_at_loop(rest, pos + string.length(c), acc)
-  }
-}
-
-fn read_identifier_chars(
-  chars: List(String),
-  acc: List(String),
-) -> #(String, List(String)) {
-  case chars {
-    [c, ..rest] ->
-      case is_ident_char(c) {
-        True -> read_identifier_chars(rest, [c, ..acc])
-        False -> #(acc |> list.reverse |> string.concat, chars)
-      }
-    [] -> #(acc |> list.reverse |> string.concat, [])
-  }
-}
-
-fn is_ident_char(c: String) -> Bool {
-  let cp = case string.to_utf_codepoints(c) {
-    [cp] -> string.utf_codepoint_to_int(cp)
-    _ -> 0
-  }
-  { cp >= 65 && cp <= 90 }
-  || { cp >= 97 && cp <= 122 }
-  || { cp >= 48 && cp <= 57 }
-  || c == "_"
-}
-
-fn expand_at_positions(
+fn expand_at_loop(
   engine: model.Engine,
-  sql: String,
-  masked: String,
-  positions: List(#(Int, String)),
+  tokens: List(lexer.Token),
   idx: Int,
   seen: dict.Dict(String, Int),
+  token_acc: List(lexer.Token),
   macro_acc: List(model.Macro),
-) -> #(String, String, List(model.Macro), Int) {
-  case positions {
-    [] -> #(sql, masked, list.reverse(macro_acc), idx)
-    [#(_pos, name), ..rest] ->
-      case engine, dict.get(seen, name) {
-        model.SQLite, Ok(existing_idx) -> {
-          let placeholder = engine_placeholder(engine, existing_idx)
-          let pattern = "@" <> name
-          let #(new_sql, new_masked) =
-            replace_first_in_masked(sql, masked, pattern, placeholder)
-          expand_at_positions(
+) -> #(List(lexer.Token), List(model.Macro), Int) {
+  case tokens {
+    [] -> #(list.reverse(token_acc), list.reverse(macro_acc), idx)
+    [lexer.Placeholder(p), ..rest] ->
+      case string.starts_with(p, "@") {
+        True -> {
+          let name = string.drop_start(p, 1)
+          case engine, dict.get(seen, name) {
+            model.SQLite, Ok(existing_idx) -> {
+              let placeholder = engine_placeholder(engine, existing_idx)
+              expand_at_loop(
+                engine,
+                rest,
+                idx,
+                seen,
+                [lexer.Placeholder(placeholder), ..token_acc],
+                macro_acc,
+              )
+            }
+            _, _ -> {
+              let placeholder = engine_placeholder(engine, idx)
+              let new_seen = case engine {
+                model.SQLite -> dict.insert(seen, name, idx)
+                _ -> seen
+              }
+              expand_at_loop(
+                engine,
+                rest,
+                idx + 1,
+                new_seen,
+                [lexer.Placeholder(placeholder), ..token_acc],
+                [model.MacroArg(index: idx, name:), ..macro_acc],
+              )
+            }
+          }
+        }
+        False ->
+          expand_at_loop(
             engine,
-            new_sql,
-            new_masked,
             rest,
             idx,
             seen,
+            [lexer.Placeholder(p), ..token_acc],
             macro_acc,
           )
-        }
-        _, _ -> {
-          let placeholder = engine_placeholder(engine, idx)
-          let pattern = "@" <> name
-          let #(new_sql, new_masked) =
-            replace_first_in_masked(sql, masked, pattern, placeholder)
-          let new_seen = case engine {
-            model.SQLite -> dict.insert(seen, name, idx)
-            _ -> seen
-          }
-          expand_at_positions(
-            engine,
-            new_sql,
-            new_masked,
-            rest,
-            idx + 1,
-            new_seen,
-            [model.MacroArg(index: idx, name:), ..macro_acc],
-          )
-        }
       }
+    [token, ..rest] ->
+      expand_at_loop(engine, rest, idx, seen, [token, ..token_acc], macro_acc)
   }
 }
 
 // ============================================================
-// Macro expansion (token-detected, string-replaced)
+// Token-based sqlode.arg/narg/slice expansion
 // ============================================================
 
-/// Expand sqlode.arg/narg/slice macros. Detects patterns in masked SQL
-/// without regex, replaces in original SQL to preserve formatting.
-fn expand_macros(
+/// Expand sqlode.arg(name), sqlode.narg(name), sqlode.slice(name) macros
+/// by walking the token list and replacing the token span with a Placeholder.
+/// Pattern: Ident("sqlode") Dot Ident("arg"|"narg"|"slice") LParen ...arg... RParen
+fn expand_macro_tokens(
   engine: model.Engine,
-  sql: String,
-  masked: String,
+  tokens: List(lexer.Token),
   start_idx: Int,
-) -> #(String, List(model.Macro)) {
-  let macro_positions = find_macro_patterns(masked)
-  case macro_positions {
-    [] -> #(sql, [])
-    _ ->
-      expand_macro_positions(
-        engine,
-        sql,
-        masked,
-        macro_positions,
-        start_idx,
-        [],
-      )
-  }
+) -> #(List(lexer.Token), List(model.Macro)) {
+  expand_macro_loop(engine, tokens, start_idx, [], [])
 }
 
-type MacroMatch {
-  MacroMatch(kind: String, full_pattern: String)
-}
-
-/// Find sqlode.arg|narg|slice(...) patterns in masked text (no regex).
-fn find_macro_patterns(masked: String) -> List(MacroMatch) {
-  find_macro_loop(masked, [])
-  |> list.reverse
-}
-
-fn find_macro_loop(masked: String, acc: List(MacroMatch)) -> List(MacroMatch) {
-  case string.split_once(masked, "sqlode.") {
-    Error(_) -> acc
-    Ok(#(_before, after)) -> {
-      // Check for arg|narg|slice after "sqlode."
-      case try_parse_macro_kind(after) {
-        Some(#(kind, after_kind)) ->
-          case string.split_once(after_kind, ")") {
-            Ok(#(arg_content, rest)) -> {
-              let full = "sqlode." <> kind <> "(" <> arg_content <> ")"
-              find_macro_loop(rest, [
-                MacroMatch(kind:, full_pattern: full),
-                ..acc
-              ])
-            }
-            Error(_) -> find_macro_loop(after, acc)
-          }
-        None -> find_macro_loop(after, acc)
-      }
-    }
-  }
-}
-
-fn try_parse_macro_kind(s: String) -> Option(#(String, String)) {
-  case string.starts_with(s, "arg(") {
-    True -> Some(#("arg", string.drop_start(s, 4)))
-    False ->
-      case string.starts_with(s, "narg(") {
-        True -> Some(#("narg", string.drop_start(s, 5)))
-        False ->
-          case string.starts_with(s, "slice(") {
-            True -> Some(#("slice", string.drop_start(s, 6)))
-            False -> None
-          }
-      }
-  }
-}
-
-fn expand_macro_positions(
+fn expand_macro_loop(
   engine: model.Engine,
-  sql: String,
-  masked: String,
-  matches: List(MacroMatch),
+  tokens: List(lexer.Token),
   idx: Int,
+  token_acc: List(lexer.Token),
   macro_acc: List(model.Macro),
-) -> #(String, List(model.Macro)) {
-  case matches {
-    [] -> #(sql, list.reverse(macro_acc))
-    [match, ..rest] -> {
-      let name = extract_macro_arg(sql, masked, match.full_pattern)
+) -> #(List(lexer.Token), List(model.Macro)) {
+  case tokens {
+    [] -> #(list.reverse(token_acc), list.reverse(macro_acc))
+
+    // Match: sqlode.arg|narg|slice(...)
+    [lexer.Ident(mod), lexer.Dot, lexer.Ident(kind), lexer.LParen, ..rest]
+      if { mod == "sqlode" || mod == "Sqlode" || mod == "SQLODE" }
+      && { kind == "arg" || kind == "narg" || kind == "slice" }
+    -> {
+      // Collect tokens inside parens to extract the argument name
+      let #(arg_tokens, remaining) = collect_macro_arg_tokens(rest, 1, [])
+      let name = extract_arg_name(arg_tokens)
       let placeholder = engine_placeholder(engine, idx)
-      let #(new_sql, new_masked) =
-        replace_first_in_masked(sql, masked, match.full_pattern, placeholder)
-      let macro_entry = case match.kind {
+      let macro_entry = case kind {
         "narg" -> model.MacroNarg(index: idx, name:)
         "slice" -> model.MacroSlice(index: idx, name:)
         _ -> model.MacroArg(index: idx, name:)
       }
-      expand_macro_positions(engine, new_sql, new_masked, rest, idx + 1, [
-        macro_entry,
-        ..macro_acc
-      ])
+      expand_macro_loop(
+        engine,
+        remaining,
+        idx + 1,
+        [lexer.Placeholder(placeholder), ..token_acc],
+        [macro_entry, ..macro_acc],
+      )
     }
+
+    [token, ..rest] ->
+      expand_macro_loop(engine, rest, idx, [token, ..token_acc], macro_acc)
   }
 }
 
-fn extract_macro_arg(
-  sql: String,
-  masked: String,
-  masked_match: String,
-) -> String {
-  case string.split_once(masked, masked_match) {
-    Ok(#(before, _)) -> {
-      let pos = string.length(before)
-      let span = string.slice(sql, pos, string.length(masked_match))
-      case string.split_once(span, "(") {
-        Ok(#(_, after_paren)) -> {
-          let arg = string.drop_end(after_paren, 1)
-          strip_quotes(string.trim(arg))
-        }
-        Error(_) -> ""
+/// Collect tokens inside macro parens until the matching RParen.
+fn collect_macro_arg_tokens(
+  tokens: List(lexer.Token),
+  depth: Int,
+  acc: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  case depth <= 0 {
+    True -> #(list.reverse(acc), tokens)
+    False ->
+      case tokens {
+        [] -> #(list.reverse(acc), [])
+        [lexer.LParen, ..rest] ->
+          collect_macro_arg_tokens(rest, depth + 1, [lexer.LParen, ..acc])
+        [lexer.RParen, ..rest] ->
+          case depth == 1 {
+            True -> #(list.reverse(acc), rest)
+            False ->
+              collect_macro_arg_tokens(rest, depth - 1, [lexer.RParen, ..acc])
+          }
+        [token, ..rest] -> collect_macro_arg_tokens(rest, depth, [token, ..acc])
       }
-    }
-    Error(_) -> ""
   }
 }
 
-fn strip_quotes(name: String) -> String {
-  case string.first(name) {
-    Ok("'") | Ok("\"") -> string.slice(name, 1, string.length(name) - 2)
-    _ -> name
+/// Extract the argument name from macro arg tokens.
+/// Handles: Ident(name), StringLit(name), QuotedIdent(name).
+fn extract_arg_name(tokens: List(lexer.Token)) -> String {
+  case tokens {
+    [lexer.Ident(name)] -> name
+    [lexer.StringLit(name)] -> name
+    [lexer.QuotedIdent(name)] -> name
+    _ ->
+      // Fallback: render tokens to text
+      tokens
+      |> list.filter_map(fn(t) {
+        case t {
+          lexer.Ident(n) -> Ok(n)
+          lexer.StringLit(n) -> Ok(n)
+          lexer.QuotedIdent(n) -> Ok(n)
+          _ -> Error(Nil)
+        }
+      })
+      |> string.join("")
   }
 }
 
@@ -569,205 +504,5 @@ fn engine_placeholder(engine: model.Engine, index: Int) -> String {
     model.PostgreSQL -> "$" <> int.to_string(index)
     model.MySQL -> "?"
     model.SQLite -> "?" <> int.to_string(index)
-  }
-}
-
-fn replace_first_in_masked(
-  original: String,
-  masked: String,
-  pattern: String,
-  replacement: String,
-) -> #(String, String) {
-  case string.split_once(masked, pattern) {
-    Ok(#(before_masked, after_masked)) -> {
-      let pos = string.length(before_masked)
-      let before_orig = string.slice(original, 0, pos)
-      let after_orig = string.drop_start(original, pos + string.length(pattern))
-      #(
-        before_orig <> replacement <> after_orig,
-        before_masked <> replacement <> after_masked,
-      )
-    }
-    Error(_) -> #(original, masked)
-  }
-}
-
-// --- SQL masking (strip string literals and comments) ---
-
-type MaskState {
-  MaskNormal
-  MaskSingleQuote
-  MaskDoubleQuote
-  MaskLineComment
-  MaskBlockComment
-  MaskDollarQuoted(tag: String)
-}
-
-fn mask_sql(engine: model.Engine, sql: String) -> String {
-  let chars = string.to_graphemes(sql)
-  do_mask(engine, chars, MaskNormal, [])
-  |> list.reverse
-  |> string.join("")
-}
-
-fn do_mask(
-  engine: model.Engine,
-  chars: List(String),
-  state: MaskState,
-  acc: List(String),
-) -> List(String) {
-  case state {
-    MaskNormal ->
-      case chars {
-        [] -> acc
-        ["'", ..rest] -> do_mask(engine, rest, MaskSingleQuote, [" ", ..acc])
-        ["\"", ..rest] -> do_mask(engine, rest, MaskDoubleQuote, [" ", ..acc])
-        ["-", "-", ..rest] ->
-          do_mask(engine, rest, MaskLineComment, [" ", " ", ..acc])
-        ["/", "*", ..rest] ->
-          do_mask(engine, rest, MaskBlockComment, [" ", " ", ..acc])
-        ["$", ..rest] ->
-          case engine {
-            model.PostgreSQL ->
-              case try_dollar_tag(rest) {
-                Ok(#(tag, after_tag)) -> {
-                  let spaces = list.repeat(" ", string.length(tag) + 2)
-                  do_mask(
-                    engine,
-                    after_tag,
-                    MaskDollarQuoted(tag),
-                    list.append(spaces, acc),
-                  )
-                }
-                Error(_) -> do_mask(engine, rest, MaskNormal, ["$", ..acc])
-              }
-            _ -> do_mask(engine, rest, MaskNormal, ["$", ..acc])
-          }
-        [c, ..rest] -> do_mask(engine, rest, MaskNormal, [c, ..acc])
-      }
-    MaskSingleQuote ->
-      case chars {
-        [] -> acc
-        ["'", "'", ..rest] ->
-          do_mask(engine, rest, MaskSingleQuote, [" ", " ", ..acc])
-        ["'", ..rest] -> do_mask(engine, rest, MaskNormal, [" ", ..acc])
-        [_, ..rest] -> do_mask(engine, rest, MaskSingleQuote, [" ", ..acc])
-      }
-    MaskDoubleQuote ->
-      case chars {
-        [] -> acc
-        ["\"", "\"", ..rest] ->
-          do_mask(engine, rest, MaskDoubleQuote, [" ", " ", ..acc])
-        ["\"", ..rest] -> do_mask(engine, rest, MaskNormal, [" ", ..acc])
-        [_, ..rest] -> do_mask(engine, rest, MaskDoubleQuote, [" ", ..acc])
-      }
-    MaskLineComment ->
-      case chars {
-        [] -> acc
-        ["\n", ..rest] -> do_mask(engine, rest, MaskNormal, ["\n", ..acc])
-        [_, ..rest] -> do_mask(engine, rest, MaskLineComment, [" ", ..acc])
-      }
-    MaskBlockComment ->
-      case chars {
-        [] -> acc
-        ["*", "/", ..rest] ->
-          do_mask(engine, rest, MaskNormal, [" ", " ", ..acc])
-        [_, ..rest] -> do_mask(engine, rest, MaskBlockComment, [" ", ..acc])
-      }
-    MaskDollarQuoted(tag) ->
-      case chars {
-        [] -> acc
-        ["$", ..rest] ->
-          case try_match_closing_dollar_tag(rest, tag) {
-            Ok(remaining) -> {
-              let spaces = list.repeat(" ", string.length(tag) + 2)
-              do_mask(engine, remaining, MaskNormal, list.append(spaces, acc))
-            }
-            Error(_) ->
-              do_mask(engine, rest, MaskDollarQuoted(tag), [" ", ..acc])
-          }
-        [_, ..rest] ->
-          do_mask(engine, rest, MaskDollarQuoted(tag), [" ", ..acc])
-      }
-  }
-}
-
-fn try_dollar_tag(chars: List(String)) -> Result(#(String, List(String)), Nil) {
-  case chars {
-    ["$", ..rest] -> Ok(#("", rest))
-    [c, ..rest] ->
-      case is_mask_alpha_or_underscore(c) {
-        True -> read_dollar_tag_chars(rest, [c])
-        False -> Error(Nil)
-      }
-    [] -> Error(Nil)
-  }
-}
-
-fn read_dollar_tag_chars(
-  chars: List(String),
-  acc: List(String),
-) -> Result(#(String, List(String)), Nil) {
-  case chars {
-    [] -> Error(Nil)
-    ["$", ..rest] -> {
-      let tag = acc |> list.reverse |> string.concat
-      Ok(#(tag, rest))
-    }
-    [c, ..rest] ->
-      case is_mask_alnum_or_underscore(c) {
-        True -> read_dollar_tag_chars(rest, [c, ..acc])
-        False -> Error(Nil)
-      }
-  }
-}
-
-fn try_match_closing_dollar_tag(
-  chars: List(String),
-  tag: String,
-) -> Result(List(String), Nil) {
-  let tag_chars = string.to_graphemes(tag)
-  match_tag_then_dollar(chars, tag_chars)
-}
-
-fn match_tag_then_dollar(
-  chars: List(String),
-  tag_chars: List(String),
-) -> Result(List(String), Nil) {
-  case tag_chars {
-    [] ->
-      case chars {
-        ["$", ..rest] -> Ok(rest)
-        _ -> Error(Nil)
-      }
-    [expected, ..tag_rest] ->
-      case chars {
-        [actual, ..chars_rest] if actual == expected ->
-          match_tag_then_dollar(chars_rest, tag_rest)
-        _ -> Error(Nil)
-      }
-  }
-}
-
-fn is_mask_alpha_or_underscore(c: String) -> Bool {
-  is_mask_alpha(c) || c == "_"
-}
-
-fn is_mask_alnum_or_underscore(c: String) -> Bool {
-  is_mask_alpha(c) || is_mask_digit(c) || c == "_"
-}
-
-fn is_mask_alpha(c: String) -> Bool {
-  let cp = case string.to_utf_codepoints(c) {
-    [cp] -> string.utf_codepoint_to_int(cp)
-    _ -> 0
-  }
-  { cp >= 65 && cp <= 90 } || { cp >= 97 && cp <= 122 }
-}
-
-fn is_mask_digit(c: String) -> Bool {
-  case c {
-    "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" -> True
-    _ -> False
   }
 }

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -2,7 +2,6 @@ import gleam/dict
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regexp
 import gleam/result
 import gleam/string
 import sqlode/lexer
@@ -25,36 +24,14 @@ type PendingQuery {
   )
 }
 
-type ParserContext {
-  ParserContext(
-    naming: naming.NamingContext,
-    macro_re: regexp.Regexp,
-    masked_macro_re: regexp.Regexp,
-    at_name_re: regexp.Regexp,
-  )
-}
-
-fn new_parser_context(naming_ctx: naming.NamingContext) -> ParserContext {
-  let assert Ok(macro_re) =
-    regexp.from_string(
-      "sqlode\\.(arg|narg|slice)\\(('[^']*'|\"[^\"]*\"|[a-zA-Z_][a-zA-Z0-9_]*)\\)",
-    )
-  let assert Ok(masked_macro_re) =
-    regexp.from_string("sqlode\\.(arg|narg|slice)\\(([^)]+)\\)")
-  let assert Ok(at_name_re) = regexp.from_string("@([A-Za-z_][A-Za-z0-9_]*)")
-
-  ParserContext(naming: naming_ctx, macro_re:, masked_macro_re:, at_name_re:)
-}
-
 pub fn parse_file(
   path: String,
   engine: model.Engine,
   naming_ctx: naming.NamingContext,
   content: String,
 ) -> Result(List(model.ParsedQuery), ParseError) {
-  let ctx = new_parser_context(naming_ctx)
   parse_lines(
-    ctx,
+    naming_ctx,
     string.split(content, "\n"),
     path,
     engine,
@@ -67,7 +44,7 @@ pub fn parse_file(
 }
 
 fn parse_lines(
-  ctx: ParserContext,
+  naming_ctx: naming.NamingContext,
   lines: List(String),
   path: String,
   engine: model.Engine,
@@ -77,22 +54,21 @@ fn parse_lines(
   skip_next: Bool,
 ) -> Result(List(model.ParsedQuery), ParseError) {
   case lines {
-    [] -> finalize_pending(ctx, pending, path, engine, parsed_rev)
+    [] -> finalize_pending(naming_ctx, pending, path, engine, parsed_rev)
     [line, ..rest] -> {
       let trimmed = string.trim(line)
 
       case is_skip_annotation(trimmed) {
         True -> {
-          // Finalize any current pending query before entering skip mode
           use parsed_rev <- result.try(finalize_pending(
-            ctx,
+            naming_ctx,
             pending,
             path,
             engine,
             parsed_rev,
           ))
           parse_lines(
-            ctx,
+            naming_ctx,
             rest,
             path,
             engine,
@@ -103,10 +79,10 @@ fn parse_lines(
           )
         }
         False ->
-          case parse_annotation(ctx, trimmed, path, line_number) {
+          case parse_annotation(naming_ctx, trimmed, path, line_number) {
             Ok(Some(next_pending)) -> {
               use parsed_rev <- result.try(finalize_pending(
-                ctx,
+                naming_ctx,
                 pending,
                 path,
                 engine,
@@ -115,9 +91,8 @@ fn parse_lines(
 
               case skip_next {
                 True ->
-                  // Skip this query: don't set pending, clear skip flag
                   parse_lines(
-                    ctx,
+                    naming_ctx,
                     rest,
                     path,
                     engine,
@@ -128,7 +103,7 @@ fn parse_lines(
                   )
                 False ->
                   parse_lines(
-                    ctx,
+                    naming_ctx,
                     rest,
                     path,
                     engine,
@@ -161,7 +136,7 @@ fn parse_lines(
               }
 
               parse_lines(
-                ctx,
+                naming_ctx,
                 rest,
                 path,
                 engine,
@@ -179,7 +154,7 @@ fn parse_lines(
 }
 
 fn finalize_pending(
-  ctx: ParserContext,
+  _naming_ctx: naming.NamingContext,
   pending: Option(PendingQuery),
   path: String,
   engine: model.Engine,
@@ -199,9 +174,9 @@ fn finalize_pending(
         False -> {
           let masked = mask_sql(engine, sql)
           let #(at_expanded, at_masked, at_macros, next_idx) =
-            expand_at_name_shorthands(ctx, engine, sql, masked)
+            expand_at_name_shorthands(engine, sql, masked)
           let #(expanded_sql, expanded_macros) =
-            expand_macros(ctx, engine, at_expanded, at_masked, next_idx)
+            expand_macros(engine, at_expanded, at_masked, next_idx)
           let macros = list.append(at_macros, expanded_macros)
           Ok([
             model.ParsedQuery(
@@ -222,7 +197,7 @@ fn finalize_pending(
 }
 
 fn parse_annotation(
-  ctx: ParserContext,
+  naming_ctx: naming.NamingContext,
   line: String,
   path: String,
   line_number: Int,
@@ -253,7 +228,7 @@ fn parse_annotation(
             Some(
               PendingQuery(
                 name:,
-                function_name: naming.to_snake_case(ctx.naming, name),
+                function_name: naming.to_snake_case(naming_ctx, name),
                 command:,
                 start_line: line_number,
                 body_rev: [],
@@ -322,8 +297,13 @@ pub fn error_to_string(error: ParseError) -> String {
   }
 }
 
+// ============================================================
+// @name expansion (token-detected, string-replaced)
+// ============================================================
+
+/// Expand @name shorthands. Uses masked SQL for position-safe detection,
+/// original SQL for replacement to preserve formatting.
 fn expand_at_name_shorthands(
-  ctx: ParserContext,
   engine: model.Engine,
   sql: String,
   masked: String,
@@ -331,107 +311,227 @@ fn expand_at_name_shorthands(
   case engine {
     model.MySQL -> #(sql, masked, [], 1)
     _ -> {
-      let matches = regexp.scan(ctx.at_name_re, masked)
-      case matches {
+      let at_positions = find_at_names(masked)
+      case at_positions {
         [] -> #(sql, masked, [], 1)
-        _ -> {
-          let #(expanded, expanded_masked, macros, next_idx, _seen) =
-            list.fold(
-              matches,
-              #(sql, masked, [], 1, dict.new()),
-              fn(acc, match) {
-                let #(current_sql, current_masked, macro_acc, idx, seen) = acc
-                case match.submatches {
-                  [Some(name)] ->
-                    case engine, dict.get(seen, name) {
-                      model.SQLite, Ok(existing_idx) -> {
-                        let placeholder =
-                          engine_placeholder(engine, existing_idx)
-                        let #(new_sql, new_masked) =
-                          replace_first_in_masked(
-                            current_sql,
-                            current_masked,
-                            match.content,
-                            placeholder,
-                          )
-                        #(new_sql, new_masked, macro_acc, idx, seen)
-                      }
-                      _, _ -> {
-                        let placeholder = engine_placeholder(engine, idx)
-                        let #(new_sql, new_masked) =
-                          replace_first_in_masked(
-                            current_sql,
-                            current_masked,
-                            match.content,
-                            placeholder,
-                          )
-                        let new_seen = case engine {
-                          model.SQLite -> dict.insert(seen, name, idx)
-                          _ -> seen
-                        }
-                        #(
-                          new_sql,
-                          new_masked,
-                          [model.MacroArg(index: idx, name:), ..macro_acc],
-                          idx + 1,
-                          new_seen,
-                        )
-                      }
-                    }
-                  _ -> acc
-                }
-              },
-            )
-          #(expanded, expanded_masked, list.reverse(macros), next_idx)
-        }
+        _ ->
+          expand_at_positions(
+            engine,
+            sql,
+            masked,
+            at_positions,
+            1,
+            dict.new(),
+            [],
+          )
       }
     }
   }
 }
 
+/// Find all @name positions in masked SQL (no regex).
+fn find_at_names(masked: String) -> List(#(Int, String)) {
+  find_at_loop(string.to_graphemes(masked), 0, [])
+  |> list.reverse
+}
+
+fn find_at_loop(
+  chars: List(String),
+  pos: Int,
+  acc: List(#(Int, String)),
+) -> List(#(Int, String)) {
+  case chars {
+    [] -> acc
+    ["@", ..rest] ->
+      case read_identifier_chars(rest, []) {
+        #("", _) -> find_at_loop(rest, pos + 1, acc)
+        #(name, remaining) -> {
+          let full = "@" <> name
+          find_at_loop(remaining, pos + string.length(full), [
+            #(pos, name),
+            ..acc
+          ])
+        }
+      }
+    [c, ..rest] -> find_at_loop(rest, pos + string.length(c), acc)
+  }
+}
+
+fn read_identifier_chars(
+  chars: List(String),
+  acc: List(String),
+) -> #(String, List(String)) {
+  case chars {
+    [c, ..rest] ->
+      case is_ident_char(c) {
+        True -> read_identifier_chars(rest, [c, ..acc])
+        False -> #(acc |> list.reverse |> string.concat, chars)
+      }
+    [] -> #(acc |> list.reverse |> string.concat, [])
+  }
+}
+
+fn is_ident_char(c: String) -> Bool {
+  let cp = case string.to_utf_codepoints(c) {
+    [cp] -> string.utf_codepoint_to_int(cp)
+    _ -> 0
+  }
+  { cp >= 65 && cp <= 90 }
+  || { cp >= 97 && cp <= 122 }
+  || { cp >= 48 && cp <= 57 }
+  || c == "_"
+}
+
+fn expand_at_positions(
+  engine: model.Engine,
+  sql: String,
+  masked: String,
+  positions: List(#(Int, String)),
+  idx: Int,
+  seen: dict.Dict(String, Int),
+  macro_acc: List(model.Macro),
+) -> #(String, String, List(model.Macro), Int) {
+  case positions {
+    [] -> #(sql, masked, list.reverse(macro_acc), idx)
+    [#(_pos, name), ..rest] ->
+      case engine, dict.get(seen, name) {
+        model.SQLite, Ok(existing_idx) -> {
+          let placeholder = engine_placeholder(engine, existing_idx)
+          let pattern = "@" <> name
+          let #(new_sql, new_masked) =
+            replace_first_in_masked(sql, masked, pattern, placeholder)
+          expand_at_positions(
+            engine,
+            new_sql,
+            new_masked,
+            rest,
+            idx,
+            seen,
+            macro_acc,
+          )
+        }
+        _, _ -> {
+          let placeholder = engine_placeholder(engine, idx)
+          let pattern = "@" <> name
+          let #(new_sql, new_masked) =
+            replace_first_in_masked(sql, masked, pattern, placeholder)
+          let new_seen = case engine {
+            model.SQLite -> dict.insert(seen, name, idx)
+            _ -> seen
+          }
+          expand_at_positions(
+            engine,
+            new_sql,
+            new_masked,
+            rest,
+            idx + 1,
+            new_seen,
+            [model.MacroArg(index: idx, name:), ..macro_acc],
+          )
+        }
+      }
+  }
+}
+
+// ============================================================
+// Macro expansion (token-detected, string-replaced)
+// ============================================================
+
+/// Expand sqlode.arg/narg/slice macros. Detects patterns in masked SQL
+/// without regex, replaces in original SQL to preserve formatting.
 fn expand_macros(
-  ctx: ParserContext,
   engine: model.Engine,
   sql: String,
   masked: String,
   start_idx: Int,
 ) -> #(String, List(model.Macro)) {
-  let matches = regexp.scan(ctx.masked_macro_re, masked)
-
-  case matches {
+  let macro_positions = find_macro_patterns(masked)
+  case macro_positions {
     [] -> #(sql, [])
-    _ -> {
-      let #(expanded, _expanded_masked, macros, _) =
-        list.fold(matches, #(sql, masked, [], start_idx), fn(acc, match) {
-          let #(current_sql, current_masked, macro_acc, idx) = acc
+    _ ->
+      expand_macro_positions(
+        engine,
+        sql,
+        masked,
+        macro_positions,
+        start_idx,
+        [],
+      )
+  }
+}
 
-          case match.submatches {
-            [Some(kind), Some(captured_arg)] -> {
-              let name = case string.trim(captured_arg) {
-                "" ->
-                  extract_macro_arg(current_sql, current_masked, match.content)
-                trimmed -> strip_quotes(trimmed)
-              }
-              let placeholder = engine_placeholder(engine, idx)
-              let #(new_sql, new_masked) =
-                replace_first_in_masked(
-                  current_sql,
-                  current_masked,
-                  match.content,
-                  placeholder,
-                )
-              let macro_entry = case kind {
-                "narg" -> model.MacroNarg(index: idx, name:)
-                "slice" -> model.MacroSlice(index: idx, name:)
-                _ -> model.MacroArg(index: idx, name:)
-              }
-              #(new_sql, new_masked, [macro_entry, ..macro_acc], idx + 1)
+type MacroMatch {
+  MacroMatch(kind: String, full_pattern: String)
+}
+
+/// Find sqlode.arg|narg|slice(...) patterns in masked text (no regex).
+fn find_macro_patterns(masked: String) -> List(MacroMatch) {
+  find_macro_loop(masked, [])
+  |> list.reverse
+}
+
+fn find_macro_loop(masked: String, acc: List(MacroMatch)) -> List(MacroMatch) {
+  case string.split_once(masked, "sqlode.") {
+    Error(_) -> acc
+    Ok(#(_before, after)) -> {
+      // Check for arg|narg|slice after "sqlode."
+      case try_parse_macro_kind(after) {
+        Some(#(kind, after_kind)) ->
+          case string.split_once(after_kind, ")") {
+            Ok(#(arg_content, rest)) -> {
+              let full = "sqlode." <> kind <> "(" <> arg_content <> ")"
+              find_macro_loop(rest, [
+                MacroMatch(kind:, full_pattern: full),
+                ..acc
+              ])
             }
-            _ -> acc
+            Error(_) -> find_macro_loop(after, acc)
           }
-        })
+        None -> find_macro_loop(after, acc)
+      }
+    }
+  }
+}
 
-      #(expanded, list.reverse(macros))
+fn try_parse_macro_kind(s: String) -> Option(#(String, String)) {
+  case string.starts_with(s, "arg(") {
+    True -> Some(#("arg", string.drop_start(s, 4)))
+    False ->
+      case string.starts_with(s, "narg(") {
+        True -> Some(#("narg", string.drop_start(s, 5)))
+        False ->
+          case string.starts_with(s, "slice(") {
+            True -> Some(#("slice", string.drop_start(s, 6)))
+            False -> None
+          }
+      }
+  }
+}
+
+fn expand_macro_positions(
+  engine: model.Engine,
+  sql: String,
+  masked: String,
+  matches: List(MacroMatch),
+  idx: Int,
+  macro_acc: List(model.Macro),
+) -> #(String, List(model.Macro)) {
+  case matches {
+    [] -> #(sql, list.reverse(macro_acc))
+    [match, ..rest] -> {
+      let name = extract_macro_arg(sql, masked, match.full_pattern)
+      let placeholder = engine_placeholder(engine, idx)
+      let #(new_sql, new_masked) =
+        replace_first_in_masked(sql, masked, match.full_pattern, placeholder)
+      let macro_entry = case match.kind {
+        "narg" -> model.MacroNarg(index: idx, name:)
+        "slice" -> model.MacroSlice(index: idx, name:)
+        _ -> model.MacroArg(index: idx, name:)
+      }
+      expand_macro_positions(engine, new_sql, new_masked, rest, idx + 1, [
+        macro_entry,
+        ..macro_acc
+      ])
     }
   }
 }

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -374,7 +374,9 @@ pub fn multiline_sql_body_test() {
     query_parser.parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.param_count |> should.equal(1)
-  string.contains(query.sql, "SELECT id,") |> should.be_true()
+  // Token-first rendering normalizes keywords to lowercase
+  string.contains(query.sql, "select") |> should.be_true()
+  string.contains(query.sql, "id") |> should.be_true()
 }
 
 // --- Placeholder inside string literal / comment tests (#118) ---


### PR DESCRIPTION
## Summary
- Replace all regex-based SQL analysis in query analyzer and parser modules with token-based pattern matching using the existing lexer
- Remove `gleam/regexp` dependency from all SQL parsing/analysis modules (only `naming.gleam` retains it for word-boundary splitting, which is unrelated to SQL parsing)
- Add comprehensive token-based helper functions in `token_utils.gleam`

## Changes

### `token_utils.gleam` (+476 lines)
- Add `extract_placeholders`: filter token list for Placeholder tokens
- Add `collect_paren_contents`: collect tokens inside parenthesized groups
- Add `split_on_commas`: split tokens on top-level commas (moved from column_inferencer)
- Add `find_insert_parts` / `InsertParts`: token-based INSERT INTO ... VALUES parsing
- Add `find_equality_patterns` / `EqualityMatch`: token-based column [op] placeholder detection
- Add `find_in_patterns`: token-based column IN (placeholder) detection
- Add `find_type_casts` / `TypeCast`: token-based PostgreSQL `$N::type` detection
- Add `find_set_patterns`: token-based UPDATE SET clause detection

### `placeholder.gleam`
- Replace `regexp.scan()` with `lexer.tokenize()` + `token_utils.extract_placeholders`
- Remove engine-specific regex patterns

### `param_inferencer.gleam`
- Rewrite `infer_insert_params` to use `token_utils.find_insert_parts`
- Rewrite `infer_equality_params` to use `token_utils.find_equality_patterns`
- Rewrite `infer_in_params` to use `token_utils.find_in_patterns`
- Rewrite `extract_type_casts` to use `token_utils.find_type_casts`
- Remove all `gleam/regexp` usage

### `column_inferencer.gleam`
- Replace string-prefix heuristic `infer_expression_type_dispatch` with token-based `infer_expression_type_from_tokens`
- Handle aggregate functions (COUNT, SUM, AVG, MIN, MAX), window functions, COALESCE, CAST, CASE, and literals via token pattern matching
- Add `expression_tokens` field to `ExtractedColumn` for direct token-based inference
- Remove `ExprKind` enum, `find_matching_prefix`, and all string-based expression helpers

### `context.gleam`
- Remove all 8 compiled regex fields from `AnalyzerContext` (insert_re, equality_re, in_clause_re, placeholder REs, whitespace_re, returning_re, type_cast_re)
- Remove `normalize_sql` function
- Remove `gleam/regexp` import
- Simplify `new()` constructor

### `query_parser.gleam`
- Replace regex-based `@name` detection with character-level scanning on masked SQL
- Replace regex-based `sqlode.arg/narg/slice()` detection with string pattern matching on masked SQL
- Remove `ParserContext` type and its 3 compiled regex fields
- Remove `gleam/regexp` import
- Preserve original SQL formatting (no token round-trip for output)

## Design Decisions
- Token-based analysis uses the existing `lexer.tokenize()` which already handles all SQL dialects (PostgreSQL, MySQL, SQLite)
- `query_parser.gleam` retains masking + string replacement for macro expansion to preserve original SQL formatting (whitespace, casing, quoted identifiers); detection is now done without regex
- `naming.gleam` retains `gleam/regexp` for word-boundary splitting since this is unrelated to SQL parsing

Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated SQL analysis from regex/text-based to token-based parsing for more reliable extraction of columns, params, casts, and macros.
  * Streamlined analyzer context and parsing pipeline to simplify and speed SQL processing.
* **Behavior**
  * Improved placeholder and parameter inference including INSERT/IN/EQUALITY patterns and type casts.
  * Quoted identifier rendering now uses MySQL-style backticks where appropriate.
* **Tests**
  * Updated SQL rendering tests to reflect token-driven lowercase/normalized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->