### PR TITLE
fix(column_inferencer): stop defaulting unresolved SELECT expressions to String

### DIFF
--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -6,7 +6,7 @@ import sqlode/lexer
 import sqlode/model
 import sqlode/query_analyzer/context.{
   type AnalysisError, type AnalyzerContext, ColumnNotFound,
-  CompoundColumnCountMismatch, TableNotFound,
+  CompoundColumnCountMismatch, TableNotFound, UnsupportedExpression,
 }
 import sqlode/query_analyzer/token_utils
 import sqlode/runtime
@@ -202,12 +202,14 @@ fn resolve_select_columns(
                   None ->
                     case extracted.expression_tokens {
                       Some(expr_tokens) -> {
-                        let #(scalar_type, nullable) =
+                        use #(scalar_type, nullable) <- result.try(
                           infer_expression_type_from_tokens(
                             expr_tokens,
                             catalog,
                             all_tables,
-                          )
+                            query_name,
+                          ),
+                        )
                         Ok([
                           model.ResultColumn(
                             name: normalized_name,
@@ -246,12 +248,14 @@ fn resolve_select_columns(
                   None ->
                     case extracted.expression_tokens {
                       Some(expr_tokens) -> {
-                        let #(scalar_type, nullable) =
+                        use #(scalar_type, nullable) <- result.try(
                           infer_expression_type_from_tokens(
                             expr_tokens,
                             catalog,
                             all_tables,
-                          )
+                            query_name,
+                          ),
+                        )
                         Ok([
                           model.ResultColumn(
                             name: normalized_name,
@@ -278,97 +282,362 @@ fn resolve_select_columns(
 }
 
 // ============================================================
-// Token-based expression type inference (#342)
+// Token-based expression type inference (#342, #298)
 // ============================================================
 
 fn infer_expression_type_from_tokens(
   tokens: List(lexer.Token),
   catalog: model.Catalog,
   table_names: List(String),
-) -> #(model.ScalarType, Bool) {
+  query_name: String,
+) -> Result(#(model.ScalarType, Bool), AnalysisError) {
   case tokens {
-    // count(...) -> IntType, not nullable
-    [lexer.Keyword("count"), lexer.LParen, ..] -> #(model.IntType, False)
+    // --- Aggregate functions ---
+    [lexer.Keyword("count"), lexer.LParen, ..] -> Ok(#(model.IntType, False))
 
-    // sum(...) -> inner type, nullable
     [lexer.Keyword("sum"), lexer.LParen, ..rest] -> {
       let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
       let first_arg = tok_first_comma_group(inner_tokens)
-      let inner_type =
-        resolve_column_type_from_tokens(first_arg, catalog, table_names)
-      case inner_type {
-        Some(t) -> #(t, True)
-        None -> #(model.IntType, True)
+      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
+        Some(t) -> Ok(#(t, True))
+        None -> Ok(#(model.IntType, True))
       }
     }
 
-    // avg(...) -> FloatType, nullable
-    [lexer.Keyword("avg"), lexer.LParen, ..] -> #(model.FloatType, True)
+    [lexer.Keyword("avg"), lexer.LParen, ..] -> Ok(#(model.FloatType, True))
 
-    // min/max(...) -> inner type, nullable
     [lexer.Keyword(kw), lexer.LParen, ..rest] if kw == "min" || kw == "max" -> {
       let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
       let first_arg = tok_first_comma_group(inner_tokens)
-      let inner_type =
-        resolve_column_type_from_tokens(first_arg, catalog, table_names)
-      case inner_type {
-        Some(t) -> #(t, True)
-        None -> #(model.IntType, True)
+      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
+        Some(t) -> Ok(#(t, True))
+        None -> Ok(#(model.IntType, True))
       }
     }
 
-    // row_number(), rank(), dense_rank() -> IntType
+    // --- Window functions ---
     [lexer.Keyword(kw), lexer.LParen, ..]
       if kw == "row_number" || kw == "rank" || kw == "dense_rank"
-    -> #(model.IntType, False)
+    -> Ok(#(model.IntType, False))
 
-    // coalesce(...) -> first arg type, not nullable
+    // --- Null-handling functions ---
     [lexer.Keyword("coalesce"), lexer.LParen, ..rest] -> {
       let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
       let first_arg = tok_first_comma_group(inner_tokens)
       case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
-        Some(t) -> #(t, False)
-        None -> #(model.StringType, False)
+        Some(t) -> Ok(#(t, False))
+        None -> Ok(#(model.StringType, False))
       }
     }
 
-    // cast(expr AS type) -> parsed type, nullable
+    // greatest/least(...) → same type as first arg, nullable
+    [lexer.Keyword(kw), lexer.LParen, ..rest]
+      if kw == "greatest" || kw == "least"
+    -> {
+      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+      let first_arg = tok_first_comma_group(inner_tokens)
+      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
+        Some(t) -> Ok(#(t, True))
+        None -> Ok(#(model.StringType, True))
+      }
+    }
+
+    // --- Type conversion ---
     [lexer.Keyword("cast"), lexer.LParen, ..rest] -> {
       let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
       case tok_find_as_type(inner_tokens) {
         Some(type_name) ->
           case model.parse_sql_type(type_name) {
-            Ok(scalar_type) -> #(scalar_type, True)
-            Error(_) -> #(model.StringType, True)
+            Ok(scalar_type) -> Ok(#(scalar_type, True))
+            Error(_) -> Ok(#(model.StringType, True))
           }
-        None -> #(model.StringType, True)
+        None -> Ok(#(model.StringType, True))
       }
     }
 
-    // CASE WHEN ... THEN value ... -> examine first THEN branch
+    // --- Boolean-producing patterns ---
+    [lexer.Keyword("exists"), lexer.LParen, ..] -> Ok(#(model.BoolType, False))
+
+    [lexer.Keyword("not"), ..rest] ->
+      infer_expression_type_from_tokens(rest, catalog, table_names, query_name)
+
+    // --- CASE ---
     [lexer.Keyword("case"), ..rest] ->
-      infer_case_type_from_tokens(rest, catalog, table_names)
+      infer_case_type_from_tokens(rest, catalog, table_names, query_name)
 
-    // String literal
-    [lexer.StringLit(_)] -> #(model.StringType, False)
+    // --- Function calls via Keyword that are also function names ---
+    [lexer.Keyword("replace"), lexer.LParen, ..] ->
+      Ok(#(model.StringType, False))
 
-    // Number literal
+    // --- Function calls via Ident (SQL functions not in keyword list) ---
+    [lexer.Ident(fn_name), lexer.LParen, ..rest] -> {
+      let lowered = string.lowercase(fn_name)
+      case classify_function(lowered) {
+        FnString -> Ok(#(model.StringType, False))
+        FnLength -> Ok(#(model.IntType, False))
+        FnMath -> {
+          let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+          let first_arg = tok_first_comma_group(inner_tokens)
+          case
+            resolve_column_type_from_tokens(first_arg, catalog, table_names)
+          {
+            Some(t) -> Ok(#(t, False))
+            None -> Ok(#(model.FloatType, False))
+          }
+        }
+        FnDatetime -> Ok(#(infer_datetime_return_type(lowered), False))
+        FnNullif -> {
+          let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+          let first_arg = tok_first_comma_group(inner_tokens)
+          case
+            resolve_column_type_from_tokens(first_arg, catalog, table_names)
+          {
+            Some(t) -> Ok(#(t, True))
+            None -> Ok(#(model.StringType, True))
+          }
+        }
+        FnUnknown ->
+          // Unknown function call — fall through to scan-based inference
+          infer_by_scanning(tokens, query_name)
+      }
+    }
+
+    // --- Bare date/time identifiers (no parens) ---
+    [lexer.Ident(fn_name)] -> {
+      let lowered = string.lowercase(fn_name)
+      case is_datetime_identifier(lowered) {
+        True -> Ok(#(infer_datetime_return_type(lowered), False))
+        False ->
+          Error(UnsupportedExpression(
+            query_name:,
+            expression: tok_tokens_to_text(tokens),
+          ))
+      }
+    }
+
+    // --- Literals ---
+    [lexer.StringLit(_)] -> Ok(#(model.StringType, False))
+
     [lexer.NumberLit(n)] ->
       case string.contains(n, ".") {
-        True -> #(model.FloatType, False)
-        False -> #(model.IntType, False)
+        True -> Ok(#(model.FloatType, False))
+        False -> Ok(#(model.IntType, False))
       }
 
-    // Boolean keywords
-    [lexer.Keyword("true")] | [lexer.Keyword("false")] -> #(
-      model.BoolType,
-      False,
-    )
+    [lexer.Keyword("true")] | [lexer.Keyword("false")] ->
+      Ok(#(model.BoolType, False))
 
-    // Fallback: StringType, nullable
-    _ -> #(model.StringType, True)
+    [lexer.Keyword("null")] -> Ok(#(model.StringType, True))
+
+    // --- Scan-based inference for compound expressions ---
+    _ -> infer_by_scanning(tokens, query_name)
   }
 }
+
+// ============================================================
+// Function classification helpers
+// ============================================================
+
+type FunctionClass {
+  FnString
+  FnLength
+  FnMath
+  FnDatetime
+  FnNullif
+  FnUnknown
+}
+
+fn classify_function(lowered_name: String) -> FunctionClass {
+  case lowered_name {
+    "lower"
+    | "upper"
+    | "trim"
+    | "ltrim"
+    | "rtrim"
+    | "substr"
+    | "substring"
+    | "concat"
+    | "reverse"
+    | "lpad"
+    | "rpad"
+    | "left"
+    | "right"
+    | "repeat"
+    | "initcap"
+    | "translate"
+    | "to_char"
+    | "format"
+    | "quote_literal"
+    | "quote_ident"
+    | "md5"
+    | "encode"
+    | "decode" -> FnString
+    "length"
+    | "char_length"
+    | "character_length"
+    | "octet_length"
+    | "bit_length"
+    | "position"
+    | "strpos"
+    | "ascii" -> FnLength
+    "abs"
+    | "round"
+    | "floor"
+    | "ceil"
+    | "ceiling"
+    | "mod"
+    | "power"
+    | "sqrt"
+    | "sign"
+    | "trunc"
+    | "log"
+    | "ln"
+    | "exp"
+    | "random"
+    | "pi"
+    | "degrees"
+    | "radians"
+    | "div" -> FnMath
+    "now"
+    | "current_timestamp"
+    | "current_date"
+    | "current_time"
+    | "date"
+    | "time"
+    | "timestamp"
+    | "date_trunc"
+    | "date_part"
+    | "extract"
+    | "age"
+    | "make_date"
+    | "make_time"
+    | "make_timestamp"
+    | "to_timestamp"
+    | "to_date"
+    | "clock_timestamp"
+    | "statement_timestamp"
+    | "timeofday"
+    | "localtime"
+    | "localtimestamp" -> FnDatetime
+    "nullif" | "ifnull" | "nvl" -> FnNullif
+    _ -> FnUnknown
+  }
+}
+
+fn is_datetime_identifier(lowered: String) -> Bool {
+  case lowered {
+    "now"
+    | "current_timestamp"
+    | "current_date"
+    | "current_time"
+    | "localtime"
+    | "localtimestamp" -> True
+    _ -> False
+  }
+}
+
+fn infer_datetime_return_type(lowered: String) -> model.ScalarType {
+  case lowered {
+    "current_date" | "date" | "make_date" | "to_date" -> model.DateType
+    "current_time" | "time" | "make_time" | "localtime" -> model.TimeType
+    "date_part" | "extract" -> model.FloatType
+    "to_char" -> model.StringType
+    _ -> model.DateTimeType
+  }
+}
+
+// ============================================================
+// Scan-based inference for compound expressions
+// ============================================================
+
+type TopLevelPattern {
+  PatBool
+  PatConcat
+  PatArithmetic
+  PatNone
+}
+
+fn infer_by_scanning(
+  tokens: List(lexer.Token),
+  query_name: String,
+) -> Result(#(model.ScalarType, Bool), AnalysisError) {
+  case find_top_level_pattern(tokens) {
+    PatBool -> Ok(#(model.BoolType, False))
+    PatConcat -> Ok(#(model.StringType, False))
+    PatArithmetic -> Ok(#(model.IntType, False))
+    PatNone ->
+      Error(UnsupportedExpression(
+        query_name:,
+        expression: tok_tokens_to_text(tokens),
+      ))
+  }
+}
+
+fn find_top_level_pattern(tokens: List(lexer.Token)) -> TopLevelPattern {
+  find_pattern_loop(tokens, 0, PatNone)
+}
+
+fn find_pattern_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  found: TopLevelPattern,
+) -> TopLevelPattern {
+  case tokens {
+    [] -> found
+    [lexer.LParen, ..rest] -> find_pattern_loop(rest, depth + 1, found)
+    [lexer.RParen, ..rest] -> find_pattern_loop(rest, depth - 1, found)
+    [token, ..rest] if depth == 0 -> {
+      case classify_top_level_token(token) {
+        PatBool -> PatBool
+        PatConcat ->
+          find_pattern_loop(rest, depth, case found {
+            PatNone -> PatConcat
+            _ -> found
+          })
+        PatArithmetic ->
+          find_pattern_loop(rest, depth, case found {
+            PatNone -> PatArithmetic
+            _ -> found
+          })
+        PatNone -> find_pattern_loop(rest, depth, found)
+      }
+    }
+    [_, ..rest] -> find_pattern_loop(rest, depth, found)
+  }
+}
+
+fn classify_top_level_token(token: lexer.Token) -> TopLevelPattern {
+  case token {
+    lexer.Operator(op)
+      if op == "="
+      || op == "!="
+      || op == "<>"
+      || op == "<"
+      || op == ">"
+      || op == "<="
+      || op == ">="
+    -> PatBool
+    lexer.Keyword(kw)
+      if kw == "and"
+      || kw == "or"
+      || kw == "between"
+      || kw == "in"
+      || kw == "like"
+      || kw == "ilike"
+      || kw == "is"
+      || kw == "not"
+      || kw == "exists"
+    -> PatBool
+    lexer.Operator("||") -> PatConcat
+    lexer.Operator(op) if op == "+" || op == "-" || op == "*" || op == "/" ->
+      PatArithmetic
+    _ -> PatNone
+  }
+}
+
+// ============================================================
+// Expression helpers
+// ============================================================
 
 /// Get the first comma-separated group of tokens (top-level only).
 fn tok_first_comma_group(tokens: List(lexer.Token)) -> List(lexer.Token) {
@@ -407,18 +676,23 @@ fn infer_case_type_from_tokens(
   tokens: List(lexer.Token),
   catalog: model.Catalog,
   table_names: List(String),
-) -> #(model.ScalarType, Bool) {
+  query_name: String,
+) -> Result(#(model.ScalarType, Bool), AnalysisError) {
   case tok_collect_then_value(tokens) {
     Some(then_tokens) ->
       case then_tokens {
-        [] -> #(model.StringType, True)
+        [] -> Ok(#(model.StringType, True))
         _ -> {
-          let #(scalar_type, _) =
-            infer_expression_type_from_tokens(then_tokens, catalog, table_names)
-          #(scalar_type, True)
+          use #(scalar_type, _) <- result.try(infer_expression_type_from_tokens(
+            then_tokens,
+            catalog,
+            table_names,
+            query_name,
+          ))
+          Ok(#(scalar_type, True))
         }
       }
-    None -> #(model.StringType, True)
+    None -> Ok(#(model.StringType, True))
   }
 }
 

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -15,6 +15,7 @@ pub type AnalysisError {
     first_count: Int,
     branch_count: Int,
   )
+  UnsupportedExpression(query_name: String, expression: String)
 }
 
 pub fn analysis_error_to_string(error: AnalysisError) -> String {
@@ -55,6 +56,12 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
       <> int.to_string(branch_count)
       <> " columns, but the first branch has "
       <> int.to_string(first_count)
+    UnsupportedExpression(query_name:, expression:) ->
+      "Query \""
+      <> query_name
+      <> "\": unsupported expression \""
+      <> expression
+      <> "\", cannot infer result type. Use CAST to specify the type explicitly"
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1023,3 +1023,259 @@ pub fn literal_expression_test() {
     ..,
   ) = greeting_col
 }
+
+// --- New expression type inference tests ---
+
+pub fn exists_subquery_infers_bool_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: HasAuthor :one\nSELECT EXISTS(SELECT 1 FROM authors WHERE id = $1) AS present FROM authors LIMIT 1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("exists.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "present",
+    scalar_type: model.BoolType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn boolean_comparison_infers_bool_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: IsAdult :one\nSELECT authors.id > 0 AS is_positive FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("cmp.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "is_positive",
+    scalar_type: model.BoolType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn string_concat_infers_string_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: FullName :one\nSELECT name || ' - ' || bio AS display FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("concat.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "display",
+    scalar_type: model.StringType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn arithmetic_expression_infers_int_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: NextId :one\nSELECT id + 1 AS next_id FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("arith.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "next_id",
+    scalar_type: model.IntType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn lower_function_infers_string_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: LowerName :one\nSELECT lower(name) AS lower_name FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("lower.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "lower_name",
+    scalar_type: model.StringType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn length_function_infers_int_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: NameLen :one\nSELECT length(name) AS name_len FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("length.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "name_len",
+    scalar_type: model.IntType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn abs_function_resolves_inner_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: AbsVal :one\nSELECT abs(id) AS abs_id FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("abs.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "abs_id",
+    scalar_type: model.IntType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn unsupported_expression_error_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: Unknown :one\nSELECT my_custom_udf(id) AS result FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("udf.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  result |> should.be_error()
+}
+
+pub fn not_exists_infers_bool_type_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: NotExists :one\nSELECT NOT EXISTS(SELECT 1 FROM authors WHERE id = 0) AS no_match FROM authors LIMIT 1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("notexists.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "no_match",
+    scalar_type: model.BoolType,
+    nullable: False,
+    ..,
+  ) = col
+}
+
+pub fn greatest_infers_first_arg_type_nullable_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: MaxId :one\nSELECT GREATEST(id, 0) AS max_id FROM authors WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("greatest.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  let assert [col] = query.result_columns
+  let assert model.ResultColumn(
+    name: "max_id",
+    scalar_type: model.IntType,
+    nullable: True,
+    ..,
+  ) = col
+}
+
+pub fn unsupported_expression_error_message_test() {
+  let error =
+    context.UnsupportedExpression(
+      query_name: "BadQuery",
+      expression: "my_custom_udf(id)",
+    )
+  let msg = query_analyzer.analysis_error_to_string(error)
+  string.contains(msg, "unsupported expression") |> should.be_true()
+  string.contains(msg, "BadQuery") |> should.be_true()
+}


### PR DESCRIPTION
## Summary
- Replace the silent `StringType` fallback in expression type inference with explicit inference for common SQL expression families
- Add `UnsupportedExpression` error variant so unrecognized expressions fail with a targeted error instead of generating wrong types
- Add 11 new tests covering the new expression patterns and the error behavior

## Changes

### `column_inferencer.gleam`
- Change `infer_expression_type_from_tokens` return type from `#(ScalarType, Bool)` to `Result(#(ScalarType, Bool), AnalysisError)` with `query_name` parameter for error construction
- Add prefix-match patterns for: `EXISTS(...)`, `NOT expr`, `GREATEST/LEAST(...)`, `REPLACE(...)`, `NULL` keyword, bare datetime identifiers
- Add function classification system (`classify_function`) covering 60+ SQL functions across categories: string, length, math, datetime, nullif
- Add scan-based inference (`infer_by_scanning`) that walks tokens at depth 0 to detect boolean operators, string concatenation (`||`), and arithmetic operators in compound expressions
- Replace `_ -> #(model.StringType, True)` fallback with `Error(UnsupportedExpression(...))`
- Update both call sites in `resolve_select_columns` to propagate the `Result` via `result.try`

### `context.gleam`
- Add `UnsupportedExpression(query_name, expression)` variant to `AnalysisError`
- Add error message: includes expression text and suggests using `CAST`

### `query_analyzer_test.gleam` (+11 tests)
- `exists_subquery_infers_bool_type_test` — EXISTS → BoolType
- `boolean_comparison_infers_bool_type_test` — `id > 0` → BoolType
- `string_concat_infers_string_type_test` — `||` → StringType
- `arithmetic_expression_infers_int_type_test` — `id + 1` → IntType
- `lower_function_infers_string_type_test` — `lower()` → StringType
- `length_function_infers_int_type_test` — `length()` → IntType
- `abs_function_resolves_inner_type_test` — `abs(id)` → resolves inner column type
- `unsupported_expression_error_test` — unknown UDF → Error
- `not_exists_infers_bool_type_test` — `NOT EXISTS(...)` → BoolType
- `greatest_infers_first_arg_type_nullable_test` — `GREATEST(id, 0)` → IntType, nullable
- `unsupported_expression_error_message_test` — error message validation

## Design Decisions
- **Scan-based inference** for compound expressions walks tokens at depth 0, giving priority: bool > concat > arithmetic. This handles `a > b`, `a || b`, `a + b` without requiring a full expression parser
- **Function classification** uses a lowercased name lookup covering PostgreSQL, MySQL, and SQLite function names. Unknown functions fall through to scan-based inference, then to the error
- **Math functions** resolve inner argument type from the catalog when possible, defaulting to FloatType
- **CASE WHEN** now propagates Result from recursive inference of THEN branch

## Limitations
- Subquery expressions (scalar subqueries) in SELECT are not yet supported and will produce an UnsupportedExpression error
- PostgreSQL-specific `::` type cast in expressions (as opposed to on placeholders) is not handled in expression inference
- Nested function calls like `lower(upper(name))` — the outer function is classified but inner function result type is not recursively resolved

Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved expression type inference for SQL queries, now supporting logical operations, comparisons, arithmetic, and additional built-in functions.
  * Enhanced error messages for unsupported expressions, directing users to use CAST for explicit type specification.

* **Tests**
  * Added comprehensive test suite for expression type inference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->