### PR TITLE
fix(integration_test): remove stale package field from sqlode.yaml configs

### DIFF
--- a/integration_test/compile_test.sh
+++ b/integration_test/compile_test.sh
@@ -40,7 +40,7 @@ sql:
     engine: "postgresql"
     gen:
       gleam:
-        package: "db"
+
         out: "$INTEGRATION_DIR/src/db"
         runtime: "raw"
 YAML
@@ -80,7 +80,7 @@ sql:
     engine: "postgresql"
     gen:
       gleam:
-        package: "db"
+
         out: "$INTEGRATION_DIR/src/db"
         runtime: "raw"
 YAML
@@ -120,7 +120,7 @@ sql:
     engine: "postgresql"
     gen:
       gleam:
-        package: "db"
+
         out: "$INTEGRATION_DIR/src/db"
         runtime: "raw"
 YAML

--- a/integration_test/sqlite_test.sh
+++ b/integration_test/sqlite_test.sh
@@ -42,7 +42,6 @@ sql:
     engine: "sqlite"
     gen:
       gleam:
-        package: "db"
         out: "$INTEGRATION_DIR/src/db"
         runtime: "native"
 YAML


### PR DESCRIPTION
## Summary
- Remove the deprecated `package: "db"` field from integration test sqlode.yaml configs that causes `Unsupported config fields: sql.gen.gleam.package` errors

## Changes
- `integration_test/compile_test.sh`: Remove `package: "db"` from 3 inline sqlode.yaml configs (PostgreSQL raw-runtime compile tests)
- `integration_test/sqlite_test.sh`: Remove `package: "db"` from 1 inline sqlode.yaml config (SQLite native-runtime integration test)

## Design Decisions
- Minimal fix scoped to the regression only, as the issue specifies keeping broader harness cleanup in follow-up issues (#305, #306, #307)
- Verified that `sqlite_extended_test.sh` and `sqlite_advanced_test.sh` do not contain the stale field

Closes #300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test configurations to remove obsolete package specification fields from code generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->