### PR TITLE
refactor(lexer): distinguish SQL reserved words from function names in keyword list

### DIFF
--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -532,24 +532,7 @@ fn is_sql_keyword(word: String) -> Bool {
     | "some"
     | "array"
     | "of"
-    | "collate"
-    | "coalesce"
-    | "greatest"
-    | "least"
-    | "count"
-    | "sum"
-    | "avg"
-    | "min"
-    | "max"
-    | "row_number"
-    | "rank"
-    | "dense_rank"
-    | "ntile"
-    | "lag"
-    | "lead"
-    | "first_value"
-    | "last_value"
-    | "nth_value" -> True
+    | "collate" -> True
     _ -> False
   }
 }

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -292,57 +292,7 @@ fn infer_expression_type_from_tokens(
   query_name: String,
 ) -> Result(#(model.ScalarType, Bool), AnalysisError) {
   case tokens {
-    // --- Aggregate functions ---
-    [lexer.Keyword("count"), lexer.LParen, ..] -> Ok(#(model.IntType, False))
-
-    [lexer.Keyword("sum"), lexer.LParen, ..rest] -> {
-      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
-      let first_arg = tok_first_comma_group(inner_tokens)
-      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
-        Some(t) -> Ok(#(t, True))
-        None -> Ok(#(model.IntType, True))
-      }
-    }
-
-    [lexer.Keyword("avg"), lexer.LParen, ..] -> Ok(#(model.FloatType, True))
-
-    [lexer.Keyword(kw), lexer.LParen, ..rest] if kw == "min" || kw == "max" -> {
-      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
-      let first_arg = tok_first_comma_group(inner_tokens)
-      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
-        Some(t) -> Ok(#(t, True))
-        None -> Ok(#(model.IntType, True))
-      }
-    }
-
-    // --- Window functions ---
-    [lexer.Keyword(kw), lexer.LParen, ..]
-      if kw == "row_number" || kw == "rank" || kw == "dense_rank"
-    -> Ok(#(model.IntType, False))
-
-    // --- Null-handling functions ---
-    [lexer.Keyword("coalesce"), lexer.LParen, ..rest] -> {
-      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
-      let first_arg = tok_first_comma_group(inner_tokens)
-      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
-        Some(t) -> Ok(#(t, False))
-        None -> Ok(#(model.StringType, False))
-      }
-    }
-
-    // greatest/least(...) → same type as first arg, nullable
-    [lexer.Keyword(kw), lexer.LParen, ..rest]
-      if kw == "greatest" || kw == "least"
-    -> {
-      let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
-      let first_arg = tok_first_comma_group(inner_tokens)
-      case resolve_column_type_from_tokens(first_arg, catalog, table_names) {
-        Some(t) -> Ok(#(t, True))
-        None -> Ok(#(model.StringType, True))
-      }
-    }
-
-    // --- Type conversion ---
+    // --- Type conversion (SQL reserved syntax) ---
     [lexer.Keyword("cast"), lexer.LParen, ..rest] -> {
       let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
       case tok_find_as_type(inner_tokens) {
@@ -355,7 +305,7 @@ fn infer_expression_type_from_tokens(
       }
     }
 
-    // --- Boolean-producing patterns ---
+    // --- Boolean-producing patterns (SQL reserved syntax) ---
     [lexer.Keyword("exists"), lexer.LParen, ..] -> Ok(#(model.BoolType, False))
 
     [lexer.Keyword("not"), ..rest] ->
@@ -365,14 +315,47 @@ fn infer_expression_type_from_tokens(
     [lexer.Keyword("case"), ..rest] ->
       infer_case_type_from_tokens(rest, catalog, table_names, query_name)
 
-    // --- Function calls via Keyword that are also function names ---
+    // --- REPLACE is both a keyword (CREATE OR REPLACE) and a function ---
     [lexer.Keyword("replace"), lexer.LParen, ..] ->
       Ok(#(model.StringType, False))
 
-    // --- Function calls via Ident (SQL functions not in keyword list) ---
+    // --- SQL function calls (now Ident tokens after #319) ---
     [lexer.Ident(fn_name), lexer.LParen, ..rest] -> {
       let lowered = string.lowercase(fn_name)
       case classify_function(lowered) {
+        FnCount -> Ok(#(model.IntType, False))
+        FnAvg -> Ok(#(model.FloatType, True))
+        FnAggregateInner -> {
+          let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+          let first_arg = tok_first_comma_group(inner_tokens)
+          case
+            resolve_column_type_from_tokens(first_arg, catalog, table_names)
+          {
+            Some(t) -> Ok(#(t, True))
+            None -> Ok(#(model.IntType, True))
+          }
+        }
+        FnWindow -> Ok(#(model.IntType, False))
+        FnCoalesce -> {
+          let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+          let first_arg = tok_first_comma_group(inner_tokens)
+          case
+            resolve_column_type_from_tokens(first_arg, catalog, table_names)
+          {
+            Some(t) -> Ok(#(t, False))
+            None -> Ok(#(model.StringType, False))
+          }
+        }
+        FnGreatestLeast -> {
+          let #(inner_tokens, _) = token_utils.collect_paren_contents(rest)
+          let first_arg = tok_first_comma_group(inner_tokens)
+          case
+            resolve_column_type_from_tokens(first_arg, catalog, table_names)
+          {
+            Some(t) -> Ok(#(t, True))
+            None -> Ok(#(model.StringType, True))
+          }
+        }
         FnString -> Ok(#(model.StringType, False))
         FnLength -> Ok(#(model.IntType, False))
         FnMath -> {
@@ -439,6 +422,12 @@ fn infer_expression_type_from_tokens(
 // ============================================================
 
 type FunctionClass {
+  FnCount
+  FnAggregateInner
+  FnAvg
+  FnWindow
+  FnCoalesce
+  FnGreatestLeast
   FnString
   FnLength
   FnMath
@@ -449,7 +438,22 @@ type FunctionClass {
 
 fn classify_function(lowered_name: String) -> FunctionClass {
   case lowered_name {
-    "lower"
+    "count" -> FnCount
+    "sum" | "min" | "max" -> FnAggregateInner
+    "avg" -> FnAvg
+    "row_number"
+    | "rank"
+    | "dense_rank"
+    | "ntile"
+    | "lag"
+    | "lead"
+    | "first_value"
+    | "last_value"
+    | "nth_value" -> FnWindow
+    "coalesce" -> FnCoalesce
+    "greatest" | "least" -> FnGreatestLeast
+    "replace"
+    | "lower"
     | "upper"
     | "trim"
     | "ltrim"

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -370,40 +370,47 @@ fn infer_view_expression_type(
   tables: List(model.Table),
 ) -> Option(#(model.ScalarType, Bool)) {
   case expr_tokens {
-    [lexer.Keyword("count"), lexer.LParen, ..] -> Some(#(model.IntType, False))
-    [lexer.Keyword("avg"), lexer.LParen, ..rest] ->
-      Some(#(
-        case extract_aggregate_inner_type(rest, tables) {
-          Some(col) ->
-            case col.scalar_type {
-              model.IntType | model.FloatType -> model.FloatType
-              other -> other
-            }
-          None -> model.FloatType
-        },
-        True,
-      ))
-    [lexer.Keyword("sum"), lexer.LParen, ..rest] ->
-      case extract_aggregate_inner_type(rest, tables) {
-        Some(col) -> Some(#(col.scalar_type, True))
-        None -> Some(#(model.FloatType, True))
-      }
-    [lexer.Keyword(fn_name), lexer.LParen, ..rest]
-      if fn_name == "min" || fn_name == "max"
-    ->
-      case extract_aggregate_inner_type(rest, tables) {
-        Some(col) -> Some(#(col.scalar_type, True))
-        None -> None
-      }
-    [lexer.Keyword("coalesce"), lexer.LParen, ..rest] ->
-      case extract_aggregate_inner_type(rest, tables) {
-        Some(col) -> Some(#(col.scalar_type, False))
-        None -> None
-      }
+    // SQL syntax keywords
     [lexer.Keyword("cast"), lexer.LParen, ..rest] -> infer_cast_type(rest)
-    [lexer.Keyword(fn_name), lexer.LParen, ..]
-      if fn_name == "row_number" || fn_name == "rank" || fn_name == "dense_rank"
-    -> Some(#(model.IntType, False))
+
+    // SQL function calls (now Ident tokens after #319)
+    [lexer.Ident(fn_name), lexer.LParen, ..rest] -> {
+      let lowered = string.lowercase(fn_name)
+      case lowered {
+        "count" -> Some(#(model.IntType, False))
+        "avg" ->
+          Some(#(
+            case extract_aggregate_inner_type(rest, tables) {
+              Some(col) ->
+                case col.scalar_type {
+                  model.IntType | model.FloatType -> model.FloatType
+                  other -> other
+                }
+              None -> model.FloatType
+            },
+            True,
+          ))
+        "sum" ->
+          case extract_aggregate_inner_type(rest, tables) {
+            Some(col) -> Some(#(col.scalar_type, True))
+            None -> Some(#(model.FloatType, True))
+          }
+        "min" | "max" ->
+          case extract_aggregate_inner_type(rest, tables) {
+            Some(col) -> Some(#(col.scalar_type, True))
+            None -> None
+          }
+        "coalesce" ->
+          case extract_aggregate_inner_type(rest, tables) {
+            Some(col) -> Some(#(col.scalar_type, False))
+            None -> None
+          }
+        "row_number" | "rank" | "dense_rank" -> Some(#(model.IntType, False))
+        _ -> None
+      }
+    }
+
+    // Literals
     [lexer.StringLit(_), ..] -> Some(#(model.StringType, False))
     [lexer.NumberLit(n), ..] ->
       case string.contains(n, ".") {


### PR DESCRIPTION
## Summary
- Remove SQL function names (aggregates, window functions, coalesce/greatest/least) from the lexer keyword list so they tokenize as `Ident` instead of `Keyword`
- Update all downstream consumers to match function calls via `Ident` tokens
- Consolidate function inference in column_inferencer through a single `classify_function` dispatch

## Changes

### `lexer.gleam`
- Remove 16 function names from `is_sql_keyword`: count, sum, avg, min, max, row_number, rank, dense_rank, ntile, lag, lead, first_value, last_value, nth_value, coalesce, greatest, least
- Keep `cast`, `exists`, `replace` as keywords (they serve dual roles as SQL syntax: `CAST ... AS`, `EXISTS(subquery)`, `CREATE OR REPLACE`)

### `column_inferencer.gleam`
- Remove 7 separate `Keyword("count"|"sum"|"avg"|...)` pattern arms from `infer_expression_type_from_tokens`
- Add `FnCount`, `FnAggregateInner`, `FnAvg`, `FnWindow`, `FnCoalesce`, `FnGreatestLeast` classes to `FunctionClass` enum
- Add these functions to `classify_function` dispatch, routing all function inference through the single `Ident(fn_name), LParen` pattern arm
- Keep `Keyword("replace")` special case since `replace` remains a keyword

### `schema_parser.gleam`
- Rewrite `infer_view_expression_type` to match `Ident(fn_name), LParen` instead of separate `Keyword(...)` arms
- Use lowercased name dispatch for count/avg/sum/min/max/coalesce/row_number/rank/dense_rank

## Design Decisions
- `replace` stays as a keyword because `CREATE OR REPLACE VIEW` requires it in the token stream. A `Keyword("replace"), LParen` arm handles `REPLACE()` function calls in column_inferencer
- `cast` and `exists` stay as keywords because they are SQL syntax constructs, not function calls
- All removed functions are now handled uniformly through `classify_function`, which also covers 60+ other SQL function names added in #298

Closes #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the SQL analysis system by consolidating how it recognizes and processes SQL functions. Improved type inference and classification for aggregate functions (count, sum, avg, min, max) and window functions (row_number, rank, dense_rank, lag, lead, first_value, last_value, and others) across all query analysis modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->