### PR TITLE
refactor(model): replace Option-based scalar_type_info with exhaustive TypeResolution dispatch

### DIFF
--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -286,10 +286,17 @@ type ScalarTypeInfo {
   )
 }
 
-fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
+type TypeResolution {
+  LeafType(ScalarTypeInfo)
+  EnumResolution(name: String)
+  CustomResolution(name: String, module: option.Option(String), underlying: ScalarType)
+  ArrayResolution(element: ScalarType)
+}
+
+fn resolve_type(scalar_type: ScalarType) -> TypeResolution {
   case scalar_type {
     IntType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "Int",
         rich_type: option.None,
         runtime_fn: "runtime.int",
@@ -299,7 +306,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.None,
       ))
     FloatType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "Float",
         rich_type: option.None,
         runtime_fn: "runtime.float",
@@ -309,7 +316,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.None,
       ))
     BoolType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "Bool",
         rich_type: option.None,
         runtime_fn: "runtime.bool",
@@ -319,7 +326,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.None,
       ))
     StringType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "String",
         rich_type: option.None,
         runtime_fn: "runtime.string",
@@ -329,7 +336,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.None,
       ))
     BytesType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "BitArray",
         rich_type: option.None,
         runtime_fn: "runtime.bytes",
@@ -339,7 +346,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.None,
       ))
     DateTimeType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "String",
         rich_type: option.Some("SqlTimestamp"),
         runtime_fn: "runtime.string",
@@ -349,7 +356,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.Some("sql_timestamp_to_string"),
       ))
     DateType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "String",
         rich_type: option.Some("SqlDate"),
         runtime_fn: "runtime.string",
@@ -359,7 +366,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.Some("sql_date_to_string"),
       ))
     TimeType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "String",
         rich_type: option.Some("SqlTime"),
         runtime_fn: "runtime.string",
@@ -369,7 +376,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.Some("sql_time_to_string"),
       ))
     UuidType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "String",
         rich_type: option.Some("SqlUuid"),
         runtime_fn: "runtime.string",
@@ -379,7 +386,7 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         unwrap_fn: option.Some("sql_uuid_to_string"),
       ))
     JsonType ->
-      option.Some(ScalarTypeInfo(
+      LeafType(ScalarTypeInfo(
         gleam_type: "String",
         rich_type: option.Some("SqlJson"),
         runtime_fn: "runtime.string",
@@ -388,7 +395,10 @@ fn scalar_type_info(scalar_type: ScalarType) -> option.Option(ScalarTypeInfo) {
         decoder: "decode.string",
         unwrap_fn: option.Some("sql_json_to_string"),
       ))
-    EnumType(_) | CustomType(_, _, _) | ArrayType(_) -> option.None
+    EnumType(name) -> EnumResolution(name)
+    CustomType(name, module, underlying) ->
+      CustomResolution(name, module, underlying)
+    ArrayType(element) -> ArrayResolution(element)
   }
 }
 
@@ -398,92 +408,51 @@ pub fn scalar_type_to_gleam_type(
   scalar_type: ScalarType,
   type_mapping: TypeMapping,
 ) -> String {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) ->
+  case resolve_type(scalar_type) {
+    LeafType(info) ->
       case type_mapping, info.rich_type {
         RichMapping, option.Some(rich) | StrongMapping, option.Some(rich) ->
           rich
         _, _ -> info.gleam_type
       }
-    option.None ->
-      case scalar_type {
-        EnumType(name) -> enum_type_name(name)
-        CustomType(name, _, _) -> name
-        ArrayType(element) ->
-          "List(" <> scalar_type_to_gleam_type(element, type_mapping) <> ")"
-        IntType
-        | FloatType
-        | BoolType
-        | StringType
-        | BytesType
-        | DateTimeType
-        | DateType
-        | TimeType
-        | UuidType
-        | JsonType ->
-          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
-      }
+    EnumResolution(name) -> enum_type_name(name)
+    CustomResolution(name, _, _) -> name
+    ArrayResolution(element) ->
+      "List(" <> scalar_type_to_gleam_type(element, type_mapping) <> ")"
   }
 }
 
 pub fn is_rich_type(scalar_type: ScalarType) -> Bool {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) -> option.is_some(info.rich_type)
-    option.None -> False
+  case resolve_type(scalar_type) {
+    LeafType(info) -> option.is_some(info.rich_type)
+    EnumResolution(_) | CustomResolution(_, _, _) | ArrayResolution(_) -> False
   }
 }
 
 pub fn strong_type_unwrap_fn(scalar_type: ScalarType) -> option.Option(String) {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) -> info.unwrap_fn
-    option.None -> option.None
+  case resolve_type(scalar_type) {
+    LeafType(info) -> info.unwrap_fn
+    EnumResolution(_) | CustomResolution(_, _, _) | ArrayResolution(_) ->
+      option.None
   }
 }
 
 pub fn scalar_type_to_runtime_function(scalar_type: ScalarType) -> String {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) -> info.runtime_fn
-    option.None ->
-      case scalar_type {
-        EnumType(_) -> "runtime.string"
-        CustomType(_, _, underlying) ->
-          scalar_type_to_runtime_function(underlying)
-        ArrayType(element) -> scalar_type_to_runtime_function(element)
-        IntType
-        | FloatType
-        | BoolType
-        | StringType
-        | BytesType
-        | DateTimeType
-        | DateType
-        | TimeType
-        | UuidType
-        | JsonType ->
-          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
-      }
+  case resolve_type(scalar_type) {
+    LeafType(info) -> info.runtime_fn
+    EnumResolution(_) -> "runtime.string"
+    CustomResolution(_, _, underlying) ->
+      scalar_type_to_runtime_function(underlying)
+    ArrayResolution(element) -> scalar_type_to_runtime_function(element)
   }
 }
 
 pub fn scalar_type_to_db_name(scalar_type: ScalarType) -> String {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) -> info.db_name
-    option.None ->
-      case scalar_type {
-        EnumType(name) -> name
-        CustomType(_, _, underlying) -> scalar_type_to_db_name(underlying)
-        ArrayType(element) -> scalar_type_to_db_name(element) <> "[]"
-        IntType
-        | FloatType
-        | BoolType
-        | StringType
-        | BytesType
-        | DateTimeType
-        | DateType
-        | TimeType
-        | UuidType
-        | JsonType ->
-          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
-      }
+  case resolve_type(scalar_type) {
+    LeafType(info) -> info.db_name
+    EnumResolution(name) -> name
+    CustomResolution(_, _, underlying) -> scalar_type_to_db_name(underlying)
+    ArrayResolution(element) -> scalar_type_to_db_name(element) <> "[]"
   }
 }
 
@@ -491,8 +460,8 @@ pub fn scalar_type_to_value_function(
   engine: Engine,
   scalar_type: ScalarType,
 ) -> String {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) ->
+  case resolve_type(scalar_type) {
+    LeafType(info) ->
       case scalar_type {
         BytesType ->
           case engine {
@@ -501,31 +470,17 @@ pub fn scalar_type_to_value_function(
           }
         _ -> info.value_fn
       }
-    option.None ->
-      case scalar_type {
-        EnumType(_) -> "text"
-        CustomType(_, _, underlying) ->
-          scalar_type_to_value_function(engine, underlying)
-        ArrayType(element) ->
-          "array(pog." <> scalar_type_to_value_function(engine, element) <> ")"
-        IntType
-        | FloatType
-        | BoolType
-        | StringType
-        | BytesType
-        | DateTimeType
-        | DateType
-        | TimeType
-        | UuidType
-        | JsonType ->
-          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
-      }
+    EnumResolution(_) -> "text"
+    CustomResolution(_, _, underlying) ->
+      scalar_type_to_value_function(engine, underlying)
+    ArrayResolution(element) ->
+      "array(pog." <> scalar_type_to_value_function(engine, element) <> ")"
   }
 }
 
 pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String {
-  case scalar_type_info(scalar_type) {
-    option.Some(info) ->
+  case resolve_type(scalar_type) {
+    LeafType(info) ->
       case scalar_type {
         BoolType ->
           case engine {
@@ -535,25 +490,11 @@ pub fn scalar_type_to_decoder(engine: Engine, scalar_type: ScalarType) -> String
           }
         _ -> info.decoder
       }
-    option.None ->
-      case scalar_type {
-        EnumType(_) -> "decode.string"
-        CustomType(_, _, underlying) ->
-          scalar_type_to_decoder(engine, underlying)
-        ArrayType(element) ->
-          "decode.list(" <> scalar_type_to_decoder(engine, element) <> ")"
-        IntType
-        | FloatType
-        | BoolType
-        | StringType
-        | BytesType
-        | DateTimeType
-        | DateType
-        | TimeType
-        | UuidType
-        | JsonType ->
-          panic as "unreachable: all leaf ScalarType variants handled by scalar_type_info"
-      }
+    EnumResolution(_) -> "decode.string"
+    CustomResolution(_, _, underlying) ->
+      scalar_type_to_decoder(engine, underlying)
+    ArrayResolution(element) ->
+      "decode.list(" <> scalar_type_to_decoder(engine, element) <> ")"
   }
 }
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -289,7 +289,11 @@ type ScalarTypeInfo {
 type TypeResolution {
   LeafType(ScalarTypeInfo)
   EnumResolution(name: String)
-  CustomResolution(name: String, module: option.Option(String), underlying: ScalarType)
+  CustomResolution(
+    name: String,
+    module: option.Option(String),
+    underlying: ScalarType,
+  )
   ArrayResolution(element: ScalarType)
 }
 


### PR DESCRIPTION
## Summary

- Introduce a private `TypeResolution` sum type (`LeafType`, `EnumResolution`, `CustomResolution`, `ArrayResolution`) that replaces `Option(ScalarTypeInfo)` as the return type of the central type lookup function
- Rename `scalar_type_info` to `resolve_type` with exhaustive pattern matching across all 13 `ScalarType` variants
- Eliminate 5 duplicated `option.None -> case scalar_type { ... panic }` fallback branches (each listing all 10 leaf variants) from public API functions

## Changes

- **`src/sqlode/model.gleam`**: Define `TypeResolution` type; rewrite `resolve_type` to return it directly; update all 7 callers (`scalar_type_to_gleam_type`, `is_rich_type`, `strong_type_unwrap_fn`, `scalar_type_to_runtime_function`, `scalar_type_to_db_name`, `scalar_type_to_value_function`, `scalar_type_to_decoder`) to match on `TypeResolution` variants instead of `Option`

## Design Decisions

- `TypeResolution` is kept private since all callers are within `model.gleam`
- Engine-specific overrides (BytesType value function, BoolType SQLite decoder) remain as nested matches inside the `LeafType` arm, preserving existing behavior
- Net reduction of ~60 lines by removing boilerplate panic branches

Closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type resolution logic for better error handling and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->