### PR TITLE
refactor(schema_parser): replace io.println_error with structured SchemaWarning type

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -257,10 +257,18 @@ fn load_catalog(
     }),
   )
 
-  schema_parser.parse_files_with_engine(entries, engine)
-  |> result.map_error(fn(error) {
-    SchemaParseError(detail: schema_parser.error_to_string(error))
+  use #(catalog, warnings) <- result.try(
+    schema_parser.parse_files_with_engine(entries, engine)
+    |> result.map_error(fn(error) {
+      SchemaParseError(detail: schema_parser.error_to_string(error))
+    }),
+  )
+
+  list.each(warnings, fn(w) {
+    io.println_error(schema_parser.warning_to_string(w))
   })
+
+  Ok(catalog)
 }
 
 fn load_queries(

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -1,4 +1,3 @@
-import gleam/io
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -13,8 +12,16 @@ pub type ParseError {
   InvalidColumn(table: String, detail: String)
 }
 
+pub type SchemaWarning {
+  UnresolvableViewColumn(column: String)
+}
+
 type ParsedSchema {
-  ParsedSchema(tables: List(model.Table), enums: List(model.EnumDef))
+  ParsedSchema(
+    tables: List(model.Table),
+    enums: List(model.EnumDef),
+    warnings: List(SchemaWarning),
+  )
 }
 
 type ViewColumn {
@@ -23,25 +30,32 @@ type ViewColumn {
 
 pub fn parse_files(
   entries: List(#(String, String)),
-) -> Result(model.Catalog, ParseError) {
+) -> Result(#(model.Catalog, List(SchemaWarning)), ParseError) {
   parse_files_with_engine(entries, model.PostgreSQL)
 }
 
 pub fn parse_files_with_engine(
   entries: List(#(String, String)),
   engine: model.Engine,
-) -> Result(model.Catalog, ParseError) {
+) -> Result(#(model.Catalog, List(SchemaWarning)), ParseError) {
   entries
-  |> list.try_fold(ParsedSchema(tables: [], enums: []), fn(acc, entry) {
-    let #(_path, content) = entry
-    use parsed <- result.try(parse_content(content, acc.enums, engine))
-    Ok(ParsedSchema(
-      tables: list.append(acc.tables, parsed.tables),
-      enums: list.append(acc.enums, parsed.enums),
-    ))
-  })
+  |> list.try_fold(
+    ParsedSchema(tables: [], enums: [], warnings: []),
+    fn(acc, entry) {
+      let #(_path, content) = entry
+      use parsed <- result.try(parse_content(content, acc.enums, engine))
+      Ok(ParsedSchema(
+        tables: list.append(acc.tables, parsed.tables),
+        enums: list.append(acc.enums, parsed.enums),
+        warnings: list.append(acc.warnings, parsed.warnings),
+      ))
+    },
+  )
   |> result.map(fn(schema) {
-    model.Catalog(tables: schema.tables, enums: schema.enums)
+    #(
+      model.Catalog(tables: schema.tables, enums: schema.enums),
+      schema.warnings,
+    )
   })
 }
 
@@ -64,38 +78,47 @@ fn parse_content(
 
   let all_enums = list.append(known_enums, enums)
 
-  use tables <- result.try(
+  use #(tables, warnings) <- result.try(
     statements
-    |> list.try_fold([], fn(tables, stmt_tokens) {
+    |> list.try_fold(#([], []), fn(acc, stmt_tokens) {
+      let #(tables, warnings) = acc
       case is_create_view_tokens(stmt_tokens) {
         True -> {
-          let maybe_table =
+          let #(maybe_table, view_warnings) =
             parse_create_view_from_tokens(stmt_tokens, list.reverse(tables))
+          let new_warnings = list.append(warnings, view_warnings)
           Ok(case maybe_table {
-            Some(table) -> [table, ..tables]
-            None -> tables
+            Some(table) -> #([table, ..tables], new_warnings)
+            None -> #(tables, new_warnings)
           })
         }
         False ->
           case is_alter_table_add_column_tokens(stmt_tokens) {
-            True -> apply_alter_table_add_column(stmt_tokens, all_enums, tables)
+            True -> {
+              use new_tables <- result.try(apply_alter_table_add_column(
+                stmt_tokens,
+                all_enums,
+                tables,
+              ))
+              Ok(#(new_tables, warnings))
+            }
             False -> {
               use maybe_table <- result.try(parse_statement_tokens(
                 stmt_tokens,
                 all_enums,
               ))
               Ok(case maybe_table {
-                Some(table) -> [table, ..tables]
-                None -> tables
+                Some(table) -> #([table, ..tables], warnings)
+                None -> #(tables, warnings)
               })
             }
           }
       }
     })
-    |> result.map(list.reverse),
+    |> result.map(fn(pair) { #(list.reverse(pair.0), pair.1) }),
   )
 
-  Ok(ParsedSchema(tables:, enums:))
+  Ok(ParsedSchema(tables:, enums:, warnings:))
 }
 
 // --- Lexer-based helpers ---
@@ -191,36 +214,47 @@ fn is_create_view_tokens(tokens: List(lexer.Token)) -> Bool {
 fn parse_create_view_from_tokens(
   tokens: List(lexer.Token),
   tables: List(model.Table),
-) -> Option(model.Table) {
-  use #(view_name, after_name) <- extract_view_name(tokens)
-  let after_as = skip_to_keyword(after_name, "as")
-  use after_select <- extract_after_select(after_as)
+) -> #(Option(model.Table), List(SchemaWarning)) {
+  case extract_view_name_result(tokens) {
+    None -> #(None, [])
+    Some(#(view_name, after_name)) -> {
+      let after_as = skip_to_keyword(after_name, "as")
+      case extract_after_select_result(after_as) {
+        None -> #(None, [])
+        Some(after_select) -> {
+          let #(select_tokens, from_tokens) = split_at_from(after_select, 0, [])
+          let source_tables =
+            token_utils.extract_table_names([
+              lexer.Keyword("from"),
+              ..from_tokens
+            ])
 
-  let #(select_tokens, from_tokens) = split_at_from(after_select, 0, [])
-  let source_tables =
-    token_utils.extract_table_names([lexer.Keyword("from"), ..from_tokens])
+          let #(columns, warnings) = case select_tokens {
+            [lexer.Star] -> #(
+              list.flat_map(source_tables, fn(table_name) {
+                case list.find(tables, fn(t) { t.name == table_name }) {
+                  Ok(table) -> table.columns
+                  Error(_) -> []
+                }
+              }),
+              [],
+            )
+            _ -> resolve_view_columns(select_tokens, tables)
+          }
 
-  let columns = case select_tokens {
-    [lexer.Star] ->
-      list.flat_map(source_tables, fn(table_name) {
-        case list.find(tables, fn(t) { t.name == table_name }) {
-          Ok(table) -> table.columns
-          Error(_) -> []
+          case columns {
+            [] -> #(None, warnings)
+            _ -> #(Some(model.Table(name: view_name, columns:)), warnings)
+          }
         }
-      })
-    _ -> resolve_view_columns(select_tokens, tables)
-  }
-
-  case columns {
-    [] -> None
-    _ -> Some(model.Table(name: view_name, columns:))
+      }
+    }
   }
 }
 
-fn extract_view_name(
+fn extract_view_name_result(
   tokens: List(lexer.Token),
-  cont: fn(#(String, List(lexer.Token))) -> Option(model.Table),
-) -> Option(model.Table) {
+) -> Option(#(String, List(lexer.Token))) {
   let remaining = case tokens {
     [
       lexer.Keyword("create"),
@@ -233,21 +267,20 @@ fn extract_view_name(
     _ -> []
   }
   case remaining {
-    [lexer.Ident(n), ..rest] -> cont(#(string.lowercase(n), rest))
-    [lexer.QuotedIdent(n), ..rest] -> cont(#(string.lowercase(n), rest))
+    [lexer.Ident(n), ..rest] -> Some(#(string.lowercase(n), rest))
+    [lexer.QuotedIdent(n), ..rest] -> Some(#(string.lowercase(n), rest))
     _ -> None
   }
 }
 
-fn extract_after_select(
+fn extract_after_select_result(
   tokens: List(lexer.Token),
-  cont: fn(List(lexer.Token)) -> Option(model.Table),
-) -> Option(model.Table) {
+) -> Option(List(lexer.Token)) {
   case tokens {
     [lexer.Keyword("select"), ..rest] ->
       case rest {
         [] -> None
-        _ -> cont(rest)
+        _ -> Some(rest)
       }
     _ -> None
   }
@@ -256,11 +289,15 @@ fn extract_after_select(
 fn resolve_view_columns(
   select_tokens: List(lexer.Token),
   tables: List(model.Table),
-) -> List(model.Column) {
+) -> #(List(model.Column), List(SchemaWarning)) {
   let view_cols = extract_view_columns(select_tokens)
-  list.filter_map(view_cols, fn(view_col) {
+  list.fold(view_cols, #([], []), fn(acc, view_col) {
+    let #(columns, warnings) = acc
     let normalized = naming.normalize_identifier(view_col.name)
-    resolve_single_view_column(normalized, view_col.expr_tokens, tables)
+    case resolve_single_view_column(normalized, view_col.expr_tokens, tables) {
+      Ok(col) -> #(list.append(columns, [col]), warnings)
+      Error(warning) -> #(columns, list.append(warnings, [warning]))
+    }
   })
 }
 
@@ -268,7 +305,7 @@ fn resolve_single_view_column(
   name: String,
   expr_tokens: List(lexer.Token),
   tables: List(model.Table),
-) -> Result(model.Column, Nil) {
+) -> Result(model.Column, SchemaWarning) {
   case find_column_in_tables(tables, name) {
     Some(col) -> Ok(model.Column(..col, name:))
     None ->
@@ -278,15 +315,7 @@ fn resolve_single_view_column(
           case infer_view_expression_type(expr_tokens, tables) {
             Some(#(scalar_type, nullable)) ->
               Ok(model.Column(name:, scalar_type:, nullable:))
-            None -> {
-              io.println_error(
-                "Warning: view column \""
-                <> name
-                <> "\" could not be resolved from source tables"
-                <> " — skipping column.",
-              )
-              Error(Nil)
-            }
+            None -> Error(UnresolvableViewColumn(column: name))
           }
       }
   }
@@ -921,5 +950,14 @@ pub fn error_to_string(error: ParseError) -> String {
     InvalidCreateTable(detail:) -> "Invalid CREATE TABLE statement: " <> detail
     InvalidColumn(table:, detail:) ->
       "Invalid column definition in table " <> table <> ": " <> detail
+  }
+}
+
+pub fn warning_to_string(warning: SchemaWarning) -> String {
+  case warning {
+    UnresolvableViewColumn(column:) ->
+      "Warning: view column \""
+      <> column
+      <> "\" could not be resolved from source tables — skipping column."
   }
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -183,7 +183,7 @@ pub fn render_sqlight_adapter_test() {
     )
 
   let assert Ok(schema_content) = simplifile.read("test/fixtures/schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/schema.sql", schema_content)])
   let assert Ok(content) = simplifile.read("test/fixtures/query.sql")
   let assert Ok(queries) =
@@ -424,7 +424,7 @@ pub fn render_adapter_uses_table_constructor_for_match_test() {
 fn analyzed_slice_queries(engine: model.Engine) -> List(model.AnalyzedQuery) {
   let naming_ctx = naming.new()
   let assert Ok(schema_content) = simplifile.read("test/fixtures/schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/schema.sql", schema_content)])
   let sql =
     "-- name: GetByIds :many\nSELECT id, name FROM authors WHERE id IN (sqlode.slice(ids));"
@@ -471,7 +471,7 @@ fn test_block_native() -> model.SqlBlock {
 
 fn test_catalog() -> model.Catalog {
   let assert Ok(schema_content) = simplifile.read("test/fixtures/schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/schema.sql", schema_content)])
   catalog
 }
@@ -571,7 +571,7 @@ pub fn render_enum_decoder_uses_decode_then_test() {
 fn enum_test_catalog() -> model.Catalog {
   let assert Ok(schema_content) =
     simplifile.read("test/fixtures/enum_schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([
       #("test/fixtures/enum_schema.sql", schema_content),
     ])
@@ -781,7 +781,7 @@ pub fn readme_queries_snapshot_test() {
 fn readme_test_catalog() -> model.Catalog {
   let assert Ok(schema_content) =
     simplifile.read("test/fixtures/readme_schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([
       #("test/fixtures/readme_schema.sql", schema_content),
     ])
@@ -925,7 +925,7 @@ pub fn render_pog_adapter_with_array_columns_test() {
 fn array_test_catalog() -> model.Catalog {
   let assert Ok(schema_content) =
     simplifile.read("test/fixtures/array_schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([
       #("test/fixtures/array_schema.sql", schema_content),
     ])

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -298,7 +298,7 @@ pub fn exec_last_id_command_test() {
 
 fn load_catalog(path: String) -> model.Catalog {
   let assert Ok(content) = simplifile.read(path)
-  let assert Ok(catalog) = schema_parser.parse_files([#(path, content)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#(path, content)])
   catalog
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -324,7 +324,8 @@ pub fn parse_enum_column_type_test() {
     <> "  status status NOT NULL\n"
     <> ");"
 
-  let assert Ok(catalog) = schema_parser.parse_files([#("enum.sql", schema)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("enum.sql", schema)])
 
   let assert [table] = catalog.tables
   let assert [_id, _name, status_col] = table.columns
@@ -556,7 +557,7 @@ pub fn compound_query_except_mismatch_test() {
 
 fn test_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/schema.sql", content)])
 
   catalog
@@ -593,7 +594,7 @@ pub fn type_cast_infers_param_type_test() {
 
 fn typecast_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/typecast_schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/typecast_schema.sql", content)])
 
   catalog
@@ -859,7 +860,7 @@ pub fn sqlite_repeated_at_placeholder_single_param_test() {
 
 fn join_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/join_schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/join_schema.sql", content)])
 
   catalog

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -12,7 +12,7 @@ pub fn main() {
 
 pub fn parse_create_table_columns_test() {
   let assert Ok(content) = simplifile.read("test/fixtures/schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("test/fixtures/schema.sql", content)])
 
   list.length(catalog.tables) |> should.equal(1)
@@ -31,7 +31,7 @@ pub fn parse_create_table_columns_test() {
 
 pub fn parse_extended_types_test() {
   let assert Ok(content) = simplifile.read("test/fixtures/extended_schema.sql")
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([
       #("test/fixtures/extended_schema.sql", content),
     ])
@@ -66,19 +66,19 @@ pub fn parse_extended_types_test() {
 // Error and boundary tests
 
 pub fn empty_schema_content_test() {
-  let assert Ok(catalog) = schema_parser.parse_files([#("empty.sql", "")])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("empty.sql", "")])
   catalog.tables |> should.equal([])
 }
 
 pub fn schema_with_only_whitespace_test() {
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("blank.sql", "   \n  \n  ")])
   catalog.tables |> should.equal([])
 }
 
 pub fn schema_with_comments_only_test() {
   let content = "-- This is a comment\n-- Another comment\n"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("comments.sql", content)])
   catalog.tables |> should.equal([])
 }
@@ -97,7 +97,8 @@ pub fn schema_if_not_exists_test() {
     <> "  id BIGSERIAL PRIMARY KEY,\n"
     <> "  name TEXT NOT NULL\n"
     <> ");"
-  let assert Ok(catalog) = schema_parser.parse_files([#("ifne.sql", content)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("ifne.sql", content)])
   let assert [table] = catalog.tables
   table.name |> should.equal("users")
   list.length(table.columns) |> should.equal(2)
@@ -109,7 +110,8 @@ pub fn schema_quoted_table_name_test() {
     <> "  id BIGSERIAL PRIMARY KEY,\n"
     <> "  name TEXT NOT NULL\n"
     <> ");"
-  let assert Ok(catalog) = schema_parser.parse_files([#("quoted.sql", content)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("quoted.sql", content)])
   let assert [table] = catalog.tables
   table.name |> should.equal("mytable")
 }
@@ -117,7 +119,7 @@ pub fn schema_quoted_table_name_test() {
 pub fn schema_multiple_files_test() {
   let file1 = "CREATE TABLE a (id BIGSERIAL PRIMARY KEY);"
   let file2 = "CREATE TABLE b (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("a.sql", file1), #("b.sql", file2)])
   list.length(catalog.tables) |> should.equal(2)
 }
@@ -130,7 +132,8 @@ pub fn schema_table_with_constraints_test() {
     <> "  total NUMERIC(10,2) NOT NULL,\n"
     <> "  FOREIGN KEY (user_id) REFERENCES users(id)\n"
     <> ");"
-  let assert Ok(catalog) = schema_parser.parse_files([#("fk.sql", content)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("fk.sql", content)])
   let assert [table] = catalog.tables
   table.name |> should.equal("orders")
   // FOREIGN KEY constraint should not be parsed as a column
@@ -144,7 +147,8 @@ pub fn schema_enum_type_test() {
     <> "  id BIGSERIAL PRIMARY KEY,\n"
     <> "  current_mood mood NOT NULL\n"
     <> ");"
-  let assert Ok(catalog) = schema_parser.parse_files([#("enum.sql", content)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("enum.sql", content)])
   let assert [enum] = catalog.enums
   enum.name |> should.equal("mood")
   enum.values |> should.equal(["happy", "sad", "neutral"])
@@ -159,7 +163,7 @@ pub fn view_with_cast_expression_test() {
   let content =
     "CREATE TABLE t (x TEXT NOT NULL, y TEXT NOT NULL);\n"
     <> "CREATE VIEW v AS SELECT CAST(x AS TEXT) AS col_a, y AS col_b FROM t;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("cast_view.sql", content)])
 
   let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
@@ -177,7 +181,8 @@ pub fn view_basic_select_test() {
   let content =
     "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT);\n"
     <> "CREATE VIEW active_users AS SELECT id, name FROM users;"
-  let assert Ok(catalog) = schema_parser.parse_files([#("view.sql", content)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("view.sql", content)])
 
   let assert Ok(view) =
     list.find(catalog.tables, fn(tbl) { tbl.name == "active_users" })
@@ -190,7 +195,7 @@ pub fn view_with_alias_test() {
   let content =
     "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
     <> "CREATE VIEW user_names AS SELECT id, name AS display_name FROM users;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("view_alias.sql", content)])
 
   let assert Ok(view) =
@@ -208,7 +213,7 @@ pub fn view_star_test() {
   let content =
     "CREATE TABLE items (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
     <> "CREATE VIEW all_items AS SELECT * FROM items;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("view_star.sql", content)])
 
   let assert Ok(view) =
@@ -220,7 +225,7 @@ pub fn view_or_replace_test() {
   let content =
     "CREATE TABLE t (id BIGSERIAL PRIMARY KEY, val TEXT NOT NULL);\n"
     <> "CREATE OR REPLACE VIEW v AS SELECT id FROM t;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("or_replace.sql", content)])
 
   let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
@@ -229,7 +234,7 @@ pub fn view_or_replace_test() {
 
 pub fn view_nonexistent_table_test() {
   let content = "CREATE VIEW v AS SELECT id FROM nonexistent;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("noexist.sql", content)])
 
   // View referencing nonexistent table: all columns are unresolvable and
@@ -267,7 +272,7 @@ pub fn alter_table_add_column_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
 ALTER TABLE users ADD COLUMN email TEXT;"
-  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   table.name |> should.equal("users")
   list.length(table.columns) |> should.equal(3)
@@ -281,7 +286,7 @@ pub fn alter_table_add_column_with_keyword_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY);
 ALTER TABLE users ADD COLUMN status TEXT NOT NULL;"
-  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   list.length(table.columns) |> should.equal(2)
   let assert [_, status] = table.columns
@@ -293,7 +298,7 @@ pub fn alter_table_add_without_column_keyword_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY);
 ALTER TABLE users ADD bio TEXT;"
-  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   list.length(table.columns) |> should.equal(2)
   let assert [_, bio] = table.columns
@@ -304,7 +309,7 @@ pub fn alter_table_add_column_nonexistent_table_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY);
 ALTER TABLE posts ADD COLUMN title TEXT;"
-  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   // posts table does not exist, so ALTER TABLE is silently ignored
   let assert [table] = catalog.tables
   table.name |> should.equal("users")
@@ -315,7 +320,7 @@ pub fn alter_table_add_constraint_ignored_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
 ALTER TABLE users ADD CONSTRAINT unique_email UNIQUE (email);"
-  let assert Ok(catalog) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   // ADD CONSTRAINT should not add a column
   list.length(table.columns) |> should.equal(2)
@@ -325,7 +330,7 @@ pub fn view_with_count_expression_test() {
   let content =
     "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
     <> "CREATE VIEW author_counts AS SELECT COUNT(*) AS total FROM authors;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("count_view.sql", content)])
 
   let assert Ok(view) =
@@ -339,7 +344,7 @@ pub fn view_with_sum_expression_test() {
   let content =
     "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, amount INTEGER NOT NULL);\n"
     <> "CREATE VIEW order_totals AS SELECT SUM(amount) AS total_amount FROM orders;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("sum_view.sql", content)])
 
   let assert Ok(view) =
@@ -354,7 +359,7 @@ pub fn view_with_avg_expression_test() {
   let content =
     "CREATE TABLE products (id BIGSERIAL PRIMARY KEY, price REAL NOT NULL);\n"
     <> "CREATE VIEW avg_prices AS SELECT AVG(price) AS avg_price FROM products;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("avg_view.sql", content)])
 
   let assert Ok(view) =
@@ -368,7 +373,7 @@ pub fn view_with_coalesce_expression_test() {
   let content =
     "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT);\n"
     <> "CREATE VIEW user_display AS SELECT id, COALESCE(bio, 'N/A') AS bio_text FROM users;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("coalesce_view.sql", content)])
 
   let assert Ok(view) =
@@ -382,7 +387,7 @@ pub fn view_with_literal_expression_test() {
   let content =
     "CREATE TABLE t (id BIGSERIAL PRIMARY KEY);\n"
     <> "CREATE VIEW v AS SELECT 42 AS magic, 'hello' AS greeting FROM t;"
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("literal_view.sql", content)])
 
   let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })
@@ -403,7 +408,8 @@ pub fn serial_types_are_implicitly_not_null_test() {
     <> "  d INTEGER\n"
     <> ");\n"
 
-  let assert Ok(catalog) = schema_parser.parse_files([#("serial.sql", content)])
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("serial.sql", content)])
 
   let assert [table] = catalog.tables
   let assert [a, b, c, d] = table.columns
@@ -422,7 +428,7 @@ pub fn view_with_join_extracts_all_source_tables_test() {
     <> "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, amount INTEGER NOT NULL);\n"
     <> "CREATE VIEW user_orders AS SELECT u.name, o.amount FROM users u JOIN orders o ON u.id = o.user_id;\n"
 
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("join_view.sql", content)])
 
   let assert Ok(view) =
@@ -444,7 +450,7 @@ pub fn view_with_left_join_test() {
     <> "CREATE TABLE profiles (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, bio TEXT);\n"
     <> "CREATE VIEW user_profiles AS SELECT u.name, p.bio FROM users u LEFT JOIN profiles p ON u.id = p.user_id;\n"
 
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("left_join.sql", content)])
 
   let assert Ok(view) =
@@ -459,7 +465,7 @@ pub fn view_star_with_join_test() {
     <> "CREATE TABLE t2 (c INTEGER NOT NULL, d TEXT NOT NULL);\n"
     <> "CREATE VIEW v AS SELECT * FROM t1 JOIN t2 ON t1.a = t2.c;\n"
 
-  let assert Ok(catalog) =
+  let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("star_join.sql", content)])
 
   let assert Ok(view) = list.find(catalog.tables, fn(tbl) { tbl.name == "v" })

--- a/test/sqlc_compat_test.gleam
+++ b/test/sqlc_compat_test.gleam
@@ -679,7 +679,7 @@ pub fn distinct_top_scores_test() {
 
 fn load_catalog(path: String) -> model.Catalog {
   let assert Ok(content) = simplifile.read(path)
-  let assert Ok(catalog) = schema_parser.parse_files([#(path, content)])
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#(path, content)])
   catalog
 }
 


### PR DESCRIPTION
## Summary

- Replace side-effectful `io.println_error()` in `schema_parser.gleam` with a structured `SchemaWarning` type that flows through the return value
- The schema parser is now a pure function; the caller (`generate.gleam`) decides how to present warnings

## Changes

- **`src/sqlode/schema_parser.gleam`**: Add `SchemaWarning` type with `UnresolvableViewColumn(column: String)` variant; change `parse_files`/`parse_files_with_engine` return type to `Result(#(model.Catalog, List(SchemaWarning)), ParseError)`; thread warnings through `parse_content`, `parse_create_view_from_tokens`, `resolve_view_columns`, `resolve_single_view_column`; add `warning_to_string` function; remove `import gleam/io`; remove old CPS helper functions replaced by direct `Option`-returning equivalents
- **`src/sqlode/generate.gleam`**: Destructure the new tuple return, print warnings via `io.println_error` in `load_catalog`
- **`test/` (5 files)**: Update all `let assert Ok(catalog)` patterns to `let assert Ok(#(catalog, _))` to match the new return type

## Design Decisions

- Warning is emitted at the caller (`generate.gleam`) rather than inside the parser, keeping parsing pure and testable
- `SchemaWarning` is a public type so tests can assert on specific warning variants if needed

Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a schema warning collection system that gathers and reports non-fatal parsing issues, providing enhanced visibility into potential schema problems during processing.

* **Bug Fixes**
  * Improved view column resolution handling; unresolvable view columns are now explicitly reported as warnings for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->