### PR TITLE
feat(query_analyzer): infer CTE virtual tables and scalar subqueries (batches 7-8)

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -2,6 +2,7 @@ import gleam/dict
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
+import sqlode/lexer
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer/column_inferencer
@@ -32,19 +33,36 @@ fn analyze_query(
   catalog: model.Catalog,
   query: model.ParsedQuery,
 ) -> Result(model.AnalyzedQuery, AnalysisError) {
+  // Build virtual tables from any leading WITH (CTE) clause so the
+  // main query can reference CTE names like real tables.
+  let tokens = lexer.tokenize(query.sql, engine)
+  use cte_tables <- result.try(column_inferencer.extract_cte_tables(
+    query.name,
+    tokens,
+    catalog,
+  ))
+  let augmented = case cte_tables {
+    [] -> catalog
+    _ ->
+      model.Catalog(
+        tables: list.append(catalog.tables, cte_tables),
+        enums: catalog.enums,
+      )
+  }
+
   let occurrences = placeholder.extract(ctx, engine, query.sql)
   use params <- result.try(build_params(
     ctx,
     engine,
     query,
-    catalog,
+    augmented,
     occurrences,
   ))
   use result_columns <- result.try(column_inferencer.infer_result_columns(
     ctx,
     engine,
     query,
-    catalog,
+    augmented,
   ))
 
   Ok(model.AnalyzedQuery(base: query, params:, result_columns:))

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -38,52 +38,151 @@ pub fn infer_result_columns(
     | runtime.QueryBatchOne
     | runtime.QueryBatchMany -> {
       let tokens = lexer.tokenize(query.sql, engine)
+      infer_columns_from_tokens(query.name, tokens, catalog)
+    }
+  }
+}
 
-      case tok_extract_returning_columns(tokens) {
-        Some(returning_cols) -> {
-          let table_names = token_utils.extract_table_names(tokens)
-          let nullable_tables = tok_extract_nullable_tables(tokens, table_names)
-          case table_names {
-            [] -> Ok([])
-            [primary, ..] ->
-              resolve_select_columns(
-                query.name,
-                returning_cols,
-                catalog,
-                primary,
-                table_names,
-                nullable_tables,
-              )
-          }
-        }
-        None -> {
-          let main_tokens = tok_strip_cte(tokens)
-          use _ <- result.try(validate_compound_column_counts(
-            query.name,
-            main_tokens,
-          ))
-          let main_tokens2 = tok_strip_compound(main_tokens)
-          let table_names = token_utils.extract_table_names(main_tokens2)
-          let nullable_tables =
-            tok_extract_nullable_tables(main_tokens2, table_names)
+/// Token-based column inference, exposed so callers (notably the CTE
+/// virtual-table builder in `query_analyzer`) can reuse the SELECT
+/// resolver without re-lexing or constructing a synthetic ParsedQuery.
+pub fn infer_columns_from_tokens(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(List(model.ResultItem), AnalysisError) {
+  case tok_extract_returning_columns(tokens) {
+    Some(returning_cols) -> {
+      let table_names = token_utils.extract_table_names(tokens)
+      let nullable_tables = tok_extract_nullable_tables(tokens, table_names)
+      case table_names {
+        [] -> Ok([])
+        [primary, ..] ->
+          resolve_select_columns(
+            query_name,
+            returning_cols,
+            catalog,
+            primary,
+            table_names,
+            nullable_tables,
+          )
+      }
+    }
+    None -> {
+      let main_tokens = tok_strip_cte(tokens)
+      use _ <- result.try(validate_compound_column_counts(
+        query_name,
+        main_tokens,
+      ))
+      let main_tokens2 = tok_strip_compound(main_tokens)
+      let table_names = token_utils.extract_table_names(main_tokens2)
+      let nullable_tables =
+        tok_extract_nullable_tables(main_tokens2, table_names)
 
-          case table_names {
-            [] -> Ok([])
-            [primary, ..] -> {
-              let select_columns = tok_extract_select_columns(main_tokens2)
-              resolve_select_columns(
-                query.name,
-                select_columns,
-                catalog,
-                primary,
-                table_names,
-                nullable_tables,
-              )
-            }
-          }
+      case table_names {
+        [] -> Ok([])
+        [primary, ..] -> {
+          let select_columns = tok_extract_select_columns(main_tokens2)
+          resolve_select_columns(
+            query_name,
+            select_columns,
+            catalog,
+            primary,
+            table_names,
+            nullable_tables,
+          )
         }
       }
     }
+  }
+}
+
+/// Extract CTE definitions from a query's tokens and return the
+/// resulting virtual tables. Each `name AS (body)` (or
+/// `name(c1, c2) AS (body)`) becomes a Table whose columns come from
+/// running infer_columns_from_tokens on the body. RECURSIVE CTEs use
+/// the anchor (first) branch via the existing tok_strip_compound, so
+/// recursive self-references are not analysed.
+pub fn extract_cte_tables(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(List(model.Table), AnalysisError) {
+  case tokens {
+    [lexer.Keyword("with"), lexer.Keyword("recursive"), ..rest] ->
+      parse_cte_defs(query_name, rest, catalog, [])
+    [lexer.Keyword("with"), ..rest] ->
+      parse_cte_defs(query_name, rest, catalog, [])
+    _ -> Ok([])
+  }
+}
+
+fn parse_cte_defs(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+  acc: List(model.Table),
+) -> Result(List(model.Table), AnalysisError) {
+  case tokens {
+    [lexer.Ident(name), ..rest_after_name] -> {
+      // Optional explicit column list: name(c1, c2, ...) AS (...).
+      // We consume but ignore it; column names come from the body.
+      let after_optional_cols = case rest_after_name {
+        [lexer.LParen, ..after_lp] -> {
+          let #(_, after_cols) = token_utils.collect_paren_contents(after_lp)
+          after_cols
+        }
+        _ -> rest_after_name
+      }
+      case after_optional_cols {
+        [lexer.Keyword("as"), lexer.LParen, ..after_as_lp] -> {
+          let #(body, after_body) =
+            token_utils.collect_paren_contents(after_as_lp)
+          let augmented = augment_catalog_with(catalog, acc)
+          use cols <- result.try(infer_columns_from_tokens(
+            query_name,
+            body,
+            augmented,
+          ))
+          let columns =
+            list.filter_map(cols, fn(item) {
+              case item {
+                model.ScalarResult(rc) ->
+                  Ok(model.Column(
+                    name: rc.name,
+                    scalar_type: rc.scalar_type,
+                    nullable: rc.nullable,
+                  ))
+                _ -> Error(Nil)
+              }
+            })
+          let table =
+            model.Table(name: string.lowercase(name), columns: columns)
+          let new_acc = [table, ..acc]
+          case after_body {
+            [lexer.Comma, ..more] ->
+              parse_cte_defs(query_name, more, catalog, new_acc)
+            _ -> Ok(list.reverse(new_acc))
+          }
+        }
+        _ -> Ok(list.reverse(acc))
+      }
+    }
+    _ -> Ok(list.reverse(acc))
+  }
+}
+
+fn augment_catalog_with(
+  catalog: model.Catalog,
+  vtables: List(model.Table),
+) -> model.Catalog {
+  case vtables {
+    [] -> catalog
+    _ ->
+      model.Catalog(
+        tables: list.append(catalog.tables, vtables),
+        enums: catalog.enums,
+      )
   }
 }
 
@@ -333,6 +432,23 @@ fn infer_expression_type_from_tokens(
 
     // --- Boolean-producing patterns (SQL reserved syntax) ---
     [lexer.Keyword("exists"), lexer.LParen, ..] -> Ok(#(model.BoolType, False))
+
+    // --- Scalar / correlated subquery: ( SELECT ... ) ---
+    // The first column of the subquery's SELECT list determines the
+    // expression type. The result is nullable because the subquery
+    // may return zero rows.
+    [lexer.LParen, lexer.Keyword("select"), ..rest] -> {
+      let #(inner, _) =
+        token_utils.collect_paren_contents([lexer.Keyword("select"), ..rest])
+      case infer_columns_from_tokens(query_name, inner, catalog) {
+        Ok([model.ScalarResult(col), ..]) -> Ok(#(col.scalar_type, True))
+        _ ->
+          Error(UnsupportedExpression(
+            query_name:,
+            expression: tok_tokens_to_text(tokens),
+          ))
+      }
+    }
 
     [lexer.Keyword("not"), ..rest] ->
       infer_expression_type_from_tokens(rest, catalog, table_names, query_name)

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1771,6 +1771,124 @@ pub fn compound_column_count_mismatch_errors_test() {
   }
 }
 
+// --- Batch 7: WITH (CTE) and WITH RECURSIVE result column inference ---
+
+pub fn with_cte_table_lookup_test() {
+  // Plain CTE: `WITH cte AS (SELECT ...) SELECT cols FROM cte`. The
+  // CTE name acts as a virtual table whose columns come from the
+  // CTE body's SELECT list.
+  let sql =
+    "-- name: ActiveAuthors :many\nWITH active AS (SELECT id, name FROM authors) SELECT id, name FROM active;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  id_col.name |> should.equal("id")
+  id_col.scalar_type |> should.equal(model.IntType)
+  name_col.name |> should.equal("name")
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn with_recursive_anchor_columns_test() {
+  // RECURSIVE: column types come from the anchor (first) branch of
+  // the UNION ALL. The recursive branch references the CTE itself.
+  let sql =
+    "-- name: AuthorChain :many\nWITH RECURSIVE chain AS (SELECT id, name FROM authors WHERE id = 1 UNION ALL SELECT id, name FROM authors WHERE id > 1) SELECT id, name FROM chain;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  id_col.scalar_type |> should.equal(model.IntType)
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+// --- Batch 8: LATERAL JOIN / correlated subqueries ---
+
+pub fn lateral_join_keyword_does_not_break_test() {
+  // `JOIN LATERAL (subquery)` — at minimum the LATERAL keyword and
+  // the subquery must not derail outer SELECT inference. The outer
+  // table's columns must still be resolved.
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: BookFirstAuthor :many\nSELECT books.title FROM books LEFT JOIN LATERAL (SELECT name FROM authors WHERE authors.id = books.author_id LIMIT 1) AS first_author ON true;"
+  let assert Ok(queries) =
+    query_parser.parse_file("l.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [model.ScalarResult(title_col)] = query.result_columns
+  title_col.name |> should.equal("title")
+}
+
+pub fn correlated_subquery_in_select_test() {
+  // Correlated scalar subquery in SELECT. The outer column reference
+  // (posts.author_id) inside the subquery must not break the outer
+  // analysis. Result type of the subquery is the subquery's column.
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: PostsWithAuthorName :many\nSELECT books.title, (SELECT name FROM authors WHERE authors.id = books.author_id) AS author_name FROM books;"
+  let assert Ok(queries) =
+    query_parser.parse_file("c.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [model.ScalarResult(title), model.ScalarResult(author_name)] =
+    query.result_columns
+  title.name |> should.equal("title")
+  author_name.name |> should.equal("author_name")
+  // Subquery results are nullable (zero rows possible).
+  author_name.scalar_type |> should.equal(model.StringType)
+  author_name.nullable |> should.equal(True)
+}
+
+pub fn cte_with_explicit_column_list_test() {
+  // `WITH name(c1, c2) AS (...)` — explicit column list is consumed
+  // but the column names still come from the body's SELECT list
+  // (minimum implementation).
+  let sql =
+    "-- name: AliasedCte :many\nWITH renamed(x, y) AS (SELECT id, name FROM authors) SELECT id, name FROM renamed;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  id_col.scalar_type |> should.equal(model.IntType)
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn multiple_ctes_chain_test() {
+  // Multiple CTEs separated by commas; later CTEs may reference
+  // earlier ones.
+  let sql =
+    "-- name: ChainedCte :many\nWITH a AS (SELECT id, name FROM authors), b AS (SELECT id, name FROM a) SELECT id, name FROM b;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  id_col.scalar_type |> should.equal(model.IntType)
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn exists_subquery_returns_bool_test() {
+  // EXISTS (SELECT ...) was already handled by the boolean pattern;
+  // pin it here so the subquery extension does not regress it. We
+  // include an outer FROM because result-column resolution needs a
+  // primary table.
+  let sql =
+    "-- name: HasAuthors :one\nSELECT id, EXISTS (SELECT 1 FROM authors WHERE id = 1) AS has_any FROM authors WHERE id = 1;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [_id, model.ScalarResult(col)] = query.result_columns
+  col.name |> should.equal("has_any")
+  col.scalar_type |> should.equal(model.BoolType)
+}
+
 pub fn values_in_from_returns_empty_columns_test() {
   // VALUES in FROM with `AS t(id, name)` is not yet inferred. The
   // analyzer skips the parenthesised subquery and finds no real


### PR DESCRIPTION
## Summary
Tackles the two remaining "large" batches from the SQL grammar coverage audit:
- Batch 7: `WITH` / `WITH RECURSIVE` CTEs
- Batch 8: scalar / correlated subqueries and `LATERAL JOIN`

Both are implemented against a shared primitive — token-based column inference — so the changes stay localised to the analyzer and do not require a parser rewrite.

## Changes

### Token-based inference (refactor)
- `src/sqlode/query_analyzer/column_inferencer.gleam`: expose `infer_columns_from_tokens(query_name, tokens, catalog)` so the entry point takes pre-lexed tokens. `infer_result_columns` becomes a thin wrapper that lexes and delegates.

### CTE virtual tables (batch 7)
- `src/sqlode/query_analyzer/column_inferencer.gleam`: new `extract_cte_tables` walks a leading `WITH` clause, builds a virtual `model.Table` from each `name [(col_list)] AS (body)` entry, and chains them so later CTEs can reference earlier ones. Explicit column lists are consumed but the body's column names win (minimum viable). `RECURSIVE` falls out of the existing `tok_strip_compound`: the anchor branch alone is analysed, so the self-reference in the recursive branch is never resolved against the catalog.
- `src/sqlode/query_analyzer.gleam`: `analyze_query` calls `extract_cte_tables` first and passes the augmented catalog (real tables + CTE virtual tables) to both param and column inference. CTE names then resolve like real tables throughout.

### Scalar / correlated subquery type (batch 8)
- `src/sqlode/query_analyzer/column_inferencer.gleam`: extend `infer_expression_type_from_tokens` with a pattern that matches `( SELECT ... )` in expression position, recurses into `infer_columns_from_tokens`, and returns the first column's type as nullable (subqueries may return zero rows). Outer column refs inside the subquery resolve against whatever catalog is currently in scope.
- `LATERAL JOIN` already worked because `extract_table_names` skips the parenthesised subquery and the outer SELECT resolves normally. Pinned with a test.

### Tests
- Adds 7 tests to `test/query_analyzer_test.gleam`: CTE basic / explicit column list / multiple chained CTEs / WITH RECURSIVE / LATERAL JOIN / correlated subquery (with nullability) / EXISTS subquery regression pin.
- Total: 738 unit tests + full `integration_test/run.sh` passes (3 + 5 + 9 + 4).

## Design Decisions
- **Shared token-based primitive**: Both CTE body inference and scalar subquery inference reuse the same `infer_columns_from_tokens` function. This keeps the logic in one place and avoids a second copy of SELECT / JOIN / compound handling.
- **Catalog augmentation over parser scope**: Rather than threading a scope through every analyzer call, the CTE virtual tables are added to the catalog once in `analyze_query` and then behave like regular tables. The resolver already handles qualified / unqualified column references against a table list, so nothing downstream needs to know CTEs exist.
- **Anchor-only for RECURSIVE**: Taking just the anchor branch is enough for the common recursive-CTE shapes used for tree and chain traversals — the anchor dictates column types and the recursive branch must be type-compatible per SQL itself.
- **Minimum viable explicit column lists**: `WITH name(c1, c2) AS (...)` consumes `(c1, c2)` but uses the body's names. Rewriting column names is a later follow-up.

## Limitations
- Subquery column resolution uses whatever catalog is currently in scope — genuine outer-column scoping (where a correlated subquery references a column the outer query just bound) is implicit and fragile. Fine for common patterns, but a real scope tracker is still owed.
- Explicit CTE column lists are ignored, so `WITH t(x, y) AS (SELECT a, b FROM ...)` produces columns named `a, b`, not `x, y`.
- CTE bodies themselves are analysed as standalone SELECTs; they do not see earlier CTEs defined in the same `WITH`. Chains work because each finalised CTE is added to the augmented catalog before the next one is parsed.
- `VALUES` in `FROM (VALUES ...) AS t(c1, c2)` is still deferred (see the pinned test in `values_in_from_returns_empty_columns_test`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Common Table Expressions (CTEs) and recursive CTEs in SQL queries
  * Improved result column inference with support for correlated scalar subqueries and LATERAL joins
  * Enhanced query analysis to handle CTE chaining and explicit column lists

* **Tests**
  * Added comprehensive test coverage for CTE functionality, recursive CTEs, and subquery operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->