### PR TITLE
feat(query_analyzer): close CTE aliases, VALUES FROM, outer-scope limits

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -33,19 +33,22 @@ fn analyze_query(
   catalog: model.Catalog,
   query: model.ParsedQuery,
 ) -> Result(model.AnalyzedQuery, AnalysisError) {
-  // Build virtual tables from any leading WITH (CTE) clause so the
-  // main query can reference CTE names like real tables.
+  // Build virtual tables from any leading WITH (CTE) clause and from
+  // `FROM (VALUES ...) AS alias(cols)` constructs so the main query can
+  // reference both like real tables.
   let tokens = lexer.tokenize(query.sql, engine)
   use cte_tables <- result.try(column_inferencer.extract_cte_tables(
     query.name,
     tokens,
     catalog,
   ))
-  let augmented = case cte_tables {
+  let values_tables = column_inferencer.extract_values_tables(tokens)
+  let virtual_tables = list.append(cte_tables, values_tables)
+  let augmented = case virtual_tables {
     [] -> catalog
     _ ->
       model.Catalog(
-        tables: list.append(catalog.tables, cte_tables),
+        tables: list.append(catalog.tables, virtual_tables),
         enums: catalog.enums,
       )
   }

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -51,19 +51,32 @@ pub fn infer_columns_from_tokens(
   tokens: List(lexer.Token),
   catalog: model.Catalog,
 ) -> Result(List(model.ResultItem), AnalysisError) {
+  infer_columns_from_tokens_scoped(query_name, tokens, catalog, [])
+}
+
+/// Same as `infer_columns_from_tokens`, but when the inner query has no
+/// FROM clause of its own, fall back to `outer_tables` so correlated
+/// references like `SELECT (SELECT books.id)` can still be resolved
+/// against the enclosing query's FROM list.
+pub fn infer_columns_from_tokens_scoped(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+  outer_tables: List(String),
+) -> Result(List(model.ResultItem), AnalysisError) {
   case tok_extract_returning_columns(tokens) {
     Some(returning_cols) -> {
       let table_names = token_utils.extract_table_names(tokens)
       let nullable_tables = tok_extract_nullable_tables(tokens, table_names)
-      case table_names {
+      case effective_tables(table_names, outer_tables) {
         [] -> Ok([])
-        [primary, ..] ->
+        [primary, ..] as tables ->
           resolve_select_columns(
             query_name,
             returning_cols,
             catalog,
             primary,
-            table_names,
+            tables,
             nullable_tables,
           )
       }
@@ -79,21 +92,35 @@ pub fn infer_columns_from_tokens(
       let nullable_tables =
         tok_extract_nullable_tables(main_tokens2, table_names)
 
-      case table_names {
+      case effective_tables(table_names, outer_tables) {
         [] -> Ok([])
-        [primary, ..] -> {
+        [primary, ..] as tables -> {
           let select_columns = tok_extract_select_columns(main_tokens2)
           resolve_select_columns(
             query_name,
             select_columns,
             catalog,
             primary,
-            table_names,
+            tables,
             nullable_tables,
           )
         }
       }
     }
+  }
+}
+
+/// Pick the scope the resolver should use: the inner FROM tables if any,
+/// else the outer FROM tables (for correlated subqueries without their
+/// own FROM). Returning [] preserves the pre-scope "empty -> Ok([])"
+/// behaviour so callers can still detect "no columns produced".
+fn effective_tables(
+  inner_tables: List(String),
+  outer_tables: List(String),
+) -> List(String) {
+  case inner_tables {
+    [] -> outer_tables
+    _ -> inner_tables
   }
 }
 
@@ -126,13 +153,15 @@ fn parse_cte_defs(
   case tokens {
     [lexer.Ident(name), ..rest_after_name] -> {
       // Optional explicit column list: name(c1, c2, ...) AS (...).
-      // We consume but ignore it; column names come from the body.
-      let after_optional_cols = case rest_after_name {
+      // When present, these names override the body's SELECT-list names.
+      let #(explicit_names, after_optional_cols) = case rest_after_name {
         [lexer.LParen, ..after_lp] -> {
-          let #(_, after_cols) = token_utils.collect_paren_contents(after_lp)
-          after_cols
+          let #(col_tokens, after_cols) =
+            token_utils.collect_paren_contents(after_lp)
+          let names = parse_cte_column_list(col_tokens)
+          #(names, after_cols)
         }
-        _ -> rest_after_name
+        _ -> #([], rest_after_name)
       }
       case after_optional_cols {
         [lexer.Keyword("as"), lexer.LParen, ..after_as_lp] -> {
@@ -144,7 +173,7 @@ fn parse_cte_defs(
             body,
             augmented,
           ))
-          let columns =
+          let body_columns =
             list.filter_map(cols, fn(item) {
               case item {
                 model.ScalarResult(rc) ->
@@ -156,6 +185,8 @@ fn parse_cte_defs(
                 _ -> Error(Nil)
               }
             })
+          let columns =
+            apply_explicit_column_names(body_columns, explicit_names)
           let table =
             model.Table(name: string.lowercase(name), columns: columns)
           let new_acc = [table, ..acc]
@@ -172,6 +203,49 @@ fn parse_cte_defs(
   }
 }
 
+/// Parse the explicit column list from `WITH name(c1, c2, ...) AS (...)`.
+/// Non-ident items are skipped; empty list means no rename.
+fn parse_cte_column_list(tokens: List(lexer.Token)) -> List(String) {
+  token_utils.split_on_commas(tokens)
+  |> list.filter_map(fn(group) {
+    case group {
+      [lexer.Ident(n)] -> Ok(string.lowercase(n))
+      [lexer.QuotedIdent(n)] -> Ok(string.lowercase(n))
+      _ -> Error(Nil)
+    }
+  })
+}
+
+/// Rename columns using the explicit column list, in order. Extra body
+/// columns keep their original names; extra explicit names are ignored.
+fn apply_explicit_column_names(
+  columns: List(model.Column),
+  names: List(String),
+) -> List(model.Column) {
+  case names {
+    [] -> columns
+    _ -> rename_columns(columns, names)
+  }
+}
+
+fn rename_columns(
+  columns: List(model.Column),
+  names: List(String),
+) -> List(model.Column) {
+  case columns, names {
+    [], _ -> []
+    cols, [] -> cols
+    [col, ..rest_cols], [name, ..rest_names] -> [
+      model.Column(
+        name: name,
+        scalar_type: col.scalar_type,
+        nullable: col.nullable,
+      ),
+      ..rename_columns(rest_cols, rest_names)
+    ]
+  }
+}
+
 fn augment_catalog_with(
   catalog: model.Catalog,
   vtables: List(model.Table),
@@ -183,6 +257,124 @@ fn augment_catalog_with(
         tables: list.append(catalog.tables, vtables),
         enums: catalog.enums,
       )
+  }
+}
+
+/// Find every `(VALUES ...) AS alias(c1, c2, ...)` in the token stream
+/// and build a virtual Table for each. Column types come from the first
+/// row's literals; rows with unsupported expressions are skipped silently
+/// (the resolver will surface any downstream issue).
+pub fn extract_values_tables(tokens: List(lexer.Token)) -> List(model.Table) {
+  find_values_tables(tokens, [])
+}
+
+fn find_values_tables(
+  tokens: List(lexer.Token),
+  acc: List(model.Table),
+) -> List(model.Table) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [lexer.LParen, lexer.Keyword("values"), ..rest] -> {
+      let #(values_body, after_rp) =
+        token_utils.collect_paren_contents([lexer.Keyword("values"), ..rest])
+      case parse_values_alias(after_rp) {
+        Some(#(alias, col_names, remaining)) ->
+          case infer_values_first_row_types(values_body) {
+            Ok(types) -> {
+              let columns = build_values_columns(col_names, types)
+              let table = model.Table(name: alias, columns: columns)
+              find_values_tables(remaining, [table, ..acc])
+            }
+            Error(_) -> find_values_tables(remaining, acc)
+          }
+        None -> find_values_tables(after_rp, acc)
+      }
+    }
+    [_, ..rest] -> find_values_tables(rest, acc)
+  }
+}
+
+fn parse_values_alias(
+  tokens: List(lexer.Token),
+) -> Option(#(String, List(String), List(lexer.Token))) {
+  let after_as = case tokens {
+    [lexer.Keyword("as"), ..rest] -> rest
+    _ -> tokens
+  }
+  case after_as {
+    [lexer.Ident(alias), lexer.LParen, ..rest_after_lp] -> {
+      let #(col_tokens, after_cols) =
+        token_utils.collect_paren_contents(rest_after_lp)
+      case parse_cte_column_list(col_tokens) {
+        [] -> None
+        names -> Some(#(string.lowercase(alias), names, after_cols))
+      }
+    }
+    [lexer.QuotedIdent(alias), lexer.LParen, ..rest_after_lp] -> {
+      let #(col_tokens, after_cols) =
+        token_utils.collect_paren_contents(rest_after_lp)
+      case parse_cte_column_list(col_tokens) {
+        [] -> None
+        names -> Some(#(string.lowercase(alias), names, after_cols))
+      }
+    }
+    _ -> None
+  }
+}
+
+fn infer_values_first_row_types(
+  values_body: List(lexer.Token),
+) -> Result(List(#(model.ScalarType, Bool)), Nil) {
+  // The body starts with `Keyword("values") LParen <row1> RParen, ...`
+  case values_body {
+    [lexer.Keyword("values"), lexer.LParen, ..rest_after_lp] -> {
+      let #(first_row, _) = token_utils.collect_paren_contents(rest_after_lp)
+      let items = token_utils.split_on_commas(first_row)
+      list.try_map(items, infer_literal_type_with_nullability)
+    }
+    _ -> Error(Nil)
+  }
+}
+
+fn infer_literal_type_with_nullability(
+  tokens: List(lexer.Token),
+) -> Result(#(model.ScalarType, Bool), Nil) {
+  case tokens {
+    [lexer.NumberLit(n)] -> Ok(#(number_scalar_type(n), False))
+    [lexer.Operator("-"), lexer.NumberLit(n)] ->
+      Ok(#(number_scalar_type(n), False))
+    [lexer.Operator("+"), lexer.NumberLit(n)] ->
+      Ok(#(number_scalar_type(n), False))
+    [lexer.StringLit(_)] -> Ok(#(model.StringType, False))
+    [lexer.Keyword("true")] | [lexer.Keyword("false")] ->
+      Ok(#(model.BoolType, False))
+    [lexer.Keyword("null")] -> Ok(#(model.StringType, True))
+    _ -> Error(Nil)
+  }
+}
+
+fn number_scalar_type(n: String) -> model.ScalarType {
+  case
+    string.contains(n, ".")
+    || string.contains(n, "e")
+    || string.contains(n, "E")
+  {
+    True -> model.FloatType
+    False -> model.IntType
+  }
+}
+
+fn build_values_columns(
+  names: List(String),
+  types: List(#(model.ScalarType, Bool)),
+) -> List(model.Column) {
+  case names, types {
+    [], _ -> []
+    _, [] -> []
+    [name, ..rest_names], [#(st, nullable), ..rest_types] -> [
+      model.Column(name: name, scalar_type: st, nullable: nullable),
+      ..build_values_columns(rest_names, rest_types)
+    ]
   }
 }
 
@@ -436,11 +628,20 @@ fn infer_expression_type_from_tokens(
     // --- Scalar / correlated subquery: ( SELECT ... ) ---
     // The first column of the subquery's SELECT list determines the
     // expression type. The result is nullable because the subquery
-    // may return zero rows.
+    // may return zero rows. `table_names` is passed as the outer scope
+    // so a subquery without its own FROM can still resolve columns of
+    // the enclosing query (e.g. `SELECT (SELECT books.id)` from books).
     [lexer.LParen, lexer.Keyword("select"), ..rest] -> {
       let #(inner, _) =
         token_utils.collect_paren_contents([lexer.Keyword("select"), ..rest])
-      case infer_columns_from_tokens(query_name, inner, catalog) {
+      case
+        infer_columns_from_tokens_scoped(
+          query_name,
+          inner,
+          catalog,
+          table_names,
+        )
+      {
         Ok([model.ScalarResult(col), ..]) -> Ok(#(col.scalar_type, True))
         _ ->
           Error(UnsupportedExpression(

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -17,6 +17,17 @@ fn table_names_loop(
 ) -> List(String) {
   case tokens {
     [] -> list.reverse(acc)
+    // FROM (VALUES ...) AS alias(...) — the alias names the virtual
+    // table populated by extract_values_tables. Emit the alias so the
+    // resolver can look it up. Non-VALUES subqueries are left alone
+    // (derived tables are not inferred yet).
+    [lexer.Keyword("from"), lexer.LParen, lexer.Keyword("values"), ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      case read_subquery_alias(remaining) {
+        #(Some(n), after_alias) -> table_names_loop(after_alias, [n, ..acc])
+        #(None, _) -> table_names_loop(remaining, acc)
+      }
+    }
     [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
       let remaining = skip_parens(rest, 1)
       table_names_loop(remaining, acc)
@@ -30,6 +41,13 @@ fn table_names_loop(
         None -> table_names_loop(rest, acc)
       }
     }
+    [lexer.Keyword("join"), lexer.LParen, lexer.Keyword("values"), ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      case read_subquery_alias(remaining) {
+        #(Some(n), after_alias) -> table_names_loop(after_alias, [n, ..acc])
+        #(None, _) -> table_names_loop(remaining, acc)
+      }
+    }
     [lexer.Keyword("join"), ..rest] -> {
       let #(name, remaining) = read_table_name(rest)
       case name {
@@ -38,6 +56,31 @@ fn table_names_loop(
       }
     }
     [_, ..rest] -> table_names_loop(rest, acc)
+  }
+}
+
+/// Read an optional AS followed by an identifier alias, optionally
+/// followed by a parenthesised column list. Returns the alias and the
+/// token stream positioned after the alias (and column list, if any).
+pub fn read_subquery_alias(
+  tokens: List(lexer.Token),
+) -> #(Option(String), List(lexer.Token)) {
+  let after_as = case tokens {
+    [lexer.Keyword("as"), ..rest] -> rest
+    _ -> tokens
+  }
+  case after_as {
+    [lexer.Ident(name), lexer.LParen, ..rest_after_lp] -> {
+      let #(_, after_cols) = collect_paren_contents(rest_after_lp)
+      #(Some(string.lowercase(name)), after_cols)
+    }
+    [lexer.QuotedIdent(name), lexer.LParen, ..rest_after_lp] -> {
+      let #(_, after_cols) = collect_paren_contents(rest_after_lp)
+      #(Some(string.lowercase(name)), after_cols)
+    }
+    [lexer.Ident(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    [lexer.QuotedIdent(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    _ -> #(None, after_as)
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1852,16 +1852,18 @@ pub fn correlated_subquery_in_select_test() {
 }
 
 pub fn cte_with_explicit_column_list_test() {
-  // `WITH name(c1, c2) AS (...)` — explicit column list is consumed
-  // but the column names still come from the body's SELECT list
-  // (minimum implementation).
+  // `WITH name(c1, c2) AS (...)` — the explicit column list renames
+  // the CTE's columns. Types and nullability come from the body, but
+  // the outer query must reference the new names.
   let sql =
-    "-- name: AliasedCte :many\nWITH renamed(x, y) AS (SELECT id, name FROM authors) SELECT id, name FROM renamed;"
+    "-- name: AliasedCte :many\nWITH renamed(x, y) AS (SELECT id, name FROM authors) SELECT x, y FROM renamed;"
   let query = analyze_one(sql, test_catalog())
-  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+  let assert [model.ScalarResult(x_col), model.ScalarResult(y_col)] =
     query.result_columns
-  id_col.scalar_type |> should.equal(model.IntType)
-  name_col.scalar_type |> should.equal(model.StringType)
+  x_col.name |> should.equal("x")
+  x_col.scalar_type |> should.equal(model.IntType)
+  y_col.name |> should.equal("y")
+  y_col.scalar_type |> should.equal(model.StringType)
 }
 
 pub fn multiple_ctes_chain_test() {
@@ -1889,16 +1891,76 @@ pub fn exists_subquery_returns_bool_test() {
   col.scalar_type |> should.equal(model.BoolType)
 }
 
-pub fn values_in_from_returns_empty_columns_test() {
-  // VALUES in FROM with `AS t(id, name)` is not yet inferred. The
-  // analyzer skips the parenthesised subquery and finds no real
-  // table, so result_columns ends up empty. This pin documents the
-  // current behavior; replace with proper inference (alias + column
-  // list + literal type inference from the first row) when added.
+pub fn values_in_from_infers_columns_test() {
+  // `FROM (VALUES ...) AS t(id, name)` becomes a virtual table whose
+  // column types come from the first row's literal types and whose
+  // names come from the alias column list.
   let sql =
     "-- name: FromValues :many\nSELECT t.id, t.name FROM (VALUES (1, 'alice'), (2, 'bob')) AS t(id, name);"
   let query = analyze_one(sql, test_catalog())
-  query.result_columns |> should.equal([])
+  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  id_col.name |> should.equal("id")
+  id_col.scalar_type |> should.equal(model.IntType)
+  name_col.name |> should.equal("name")
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn values_in_from_infers_float_and_bool_test() {
+  // Mix of numeric (with decimal), boolean, and string literals —
+  // verifies the literal-to-ScalarType table handles the common cases.
+  let sql =
+    "-- name: FromMixedValues :many\nSELECT t.ratio, t.active, t.label FROM (VALUES (1.5, true, 'x')) AS t(ratio, active, label);"
+  let query = analyze_one(sql, test_catalog())
+  let assert [
+    model.ScalarResult(ratio_col),
+    model.ScalarResult(active_col),
+    model.ScalarResult(label_col),
+  ] = query.result_columns
+  ratio_col.scalar_type |> should.equal(model.FloatType)
+  active_col.scalar_type |> should.equal(model.BoolType)
+  label_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn cte_explicit_column_list_renames_partially_test() {
+  // Fewer explicit names than body columns: only the first N get
+  // renamed; the rest keep their original names. This mirrors how the
+  // query would behave if the user under-specified on purpose.
+  let sql =
+    "-- name: PartialRename :many\nWITH t(alias_id) AS (SELECT id, name FROM authors) SELECT alias_id, name FROM t;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(alias_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  alias_col.name |> should.equal("alias_id")
+  alias_col.scalar_type |> should.equal(model.IntType)
+  name_col.name |> should.equal("name")
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn correlated_subquery_outer_only_column_test() {
+  // The inner SELECT has no FROM of its own, so its column reference
+  // (`books.title`) must be resolved from the enclosing query's FROM
+  // list. This exercises the outer-scope fallback in
+  // infer_columns_from_tokens_scoped.
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: EchoTitle :many\nSELECT books.title, (SELECT books.title) AS echoed FROM books;"
+  let assert Ok(queries) =
+    query_parser.parse_file("e.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [model.ScalarResult(title), model.ScalarResult(echoed)] =
+    query.result_columns
+  title.scalar_type |> should.equal(model.StringType)
+  echoed.scalar_type |> should.equal(model.StringType)
+  echoed.nullable |> should.equal(True)
 }
 
 pub fn mysql_on_duplicate_key_update_test() {


### PR DESCRIPTION
## Summary
Retires the three known limitations that were deferred out of PR #354 (batches 9, 10, 11), bringing CTE column renaming, `VALUES` in `FROM`, and correlated-subquery outer scope under proper inference.

## Changes
- `src/sqlode/query_analyzer/column_inferencer.gleam`: `parse_cte_defs` now keeps the explicit `WITH t(x, y)` column list and rewrites body column names via `apply_explicit_column_names`. Adds `extract_values_tables` plus literal type inference (`Int`/`Float`/`Bool`/`String`/`NULL`) to build a virtual table from `(VALUES ...) AS alias(cols)`. Introduces `infer_columns_from_tokens_scoped` so a FROMless inner SELECT can fall back to the enclosing query's FROM list, and the scalar-subquery handler passes outer `table_names` into it.
- `src/sqlode/query_analyzer/token_utils.gleam`: `table_names_loop` recognises `FROM (VALUES ...) AS t(...)` and `JOIN (VALUES ...) AS t(...)` via a new `read_subquery_alias` helper so the alias is surfaced to the resolver.
- `src/sqlode/query_analyzer.gleam`: `analyze_query` augments the catalog with both CTE and VALUES virtual tables before building params and resolving result columns.
- `test/query_analyzer_test.gleam`: updates the pinned limitation tests (`cte_with_explicit_column_list_test`, renames `values_in_from_returns_empty_columns_test` → `values_in_from_infers_columns_test`) and adds `values_in_from_infers_float_and_bool_test`, `cte_explicit_column_list_renames_partially_test`, `correlated_subquery_outer_only_column_test`.

## Design Decisions
- **CTE virtual tables vs. real parser work**: The renaming is applied as a post-pass on the inferred body columns, mirroring how `extract_cte_tables` already produces virtual tables. This avoids introducing a dedicated CTE AST node just for aliasing.
- **VALUES types from the first row only**: SQL semantics forbid type conflicts across rows, so checking the first row is sufficient for common cases and keeps the inference cheap. `NULL` in the first row marks the column nullable and defaults to `StringType` (least assumptive). Rows with non-literal expressions are skipped; the resolver will surface any downstream mismatch.
- **Scoped entry point over threading state**: `infer_columns_from_tokens_scoped` takes `outer_tables` as a parameter rather than mutating a context, keeping the existing `infer_columns_from_tokens` call sites untouched (they pass `[]`). `effective_tables` falls back to outer only when inner is empty, so genuine subqueries with their own FROM keep prior behaviour.
- **VALUES detection scoped to `FROM`/`JOIN` + `VALUES`**: Derived-table aliases (`FROM (SELECT ...) AS t`) are intentionally not emitted as table names because we do not yet infer their columns; surfacing them would turn a silent empty result into a `TableNotFound`.

## Limitations
- Derived tables `FROM (SELECT ...) AS t(cols)` still return empty result columns; inferring the inner SELECT's shape is separate work.
- VALUES literal inference only understands scalar literals and signed numerics. Expressions like `CAST(1 AS bigint)` inside a VALUES row will cause that column to be skipped, leaving the virtual table short.
- Outer scope is a single level: a triply-nested subquery references only its immediate parent's FROM, not the whole chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VALUES clauses in FROM expressions now properly infer column names and data types from the column list and literal values
  * Common Table Expressions (WITH clauses) with explicit column lists now correctly rename output columns

* **Bug Fixes**
  * Correlated scalar subqueries now correctly resolve column references from outer query scopes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->