### PR TITLE
feat(query_analyzer): infer derived tables in FROM / JOIN subqueries

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -33,25 +33,25 @@ fn analyze_query(
   catalog: model.Catalog,
   query: model.ParsedQuery,
 ) -> Result(model.AnalyzedQuery, AnalysisError) {
-  // Build virtual tables from any leading WITH (CTE) clause and from
-  // `FROM (VALUES ...) AS alias(cols)` constructs so the main query can
-  // reference both like real tables.
+  // Surface virtual tables the outer query references — CTEs, VALUES
+  // in FROM, and derived-table subqueries — so both result-column and
+  // parameter inference see them. Nested subqueries rediscover their
+  // own VALUES / derived tables inside infer_columns_from_tokens_scoped.
   let tokens = lexer.tokenize(query.sql, engine)
   use cte_tables <- result.try(column_inferencer.extract_cte_tables(
     query.name,
     tokens,
     catalog,
   ))
+  let with_ctes = merge_virtual_tables(catalog, cte_tables)
   let values_tables = column_inferencer.extract_values_tables(tokens)
-  let virtual_tables = list.append(cte_tables, values_tables)
-  let augmented = case virtual_tables {
-    [] -> catalog
-    _ ->
-      model.Catalog(
-        tables: list.append(catalog.tables, virtual_tables),
-        enums: catalog.enums,
-      )
-  }
+  let with_values = merge_virtual_tables(with_ctes, values_tables)
+  use derived_tables <- result.try(column_inferencer.extract_derived_tables(
+    query.name,
+    tokens,
+    with_values,
+  ))
+  let augmented = merge_virtual_tables(with_values, derived_tables)
 
   let occurrences = placeholder.extract(ctx, engine, query.sql)
   use params <- result.try(build_params(
@@ -69,6 +69,20 @@ fn analyze_query(
   ))
 
   Ok(model.AnalyzedQuery(base: query, params:, result_columns:))
+}
+
+fn merge_virtual_tables(
+  catalog: model.Catalog,
+  vtables: List(model.Table),
+) -> model.Catalog {
+  case vtables {
+    [] -> catalog
+    _ ->
+      model.Catalog(
+        tables: list.append(catalog.tables, vtables),
+        enums: catalog.enums,
+      )
+  }
 }
 
 fn build_params(

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -58,12 +58,22 @@ pub fn infer_columns_from_tokens(
 /// FROM clause of its own, fall back to `outer_tables` so correlated
 /// references like `SELECT (SELECT books.id)` can still be resolved
 /// against the enclosing query's FROM list.
+///
+/// Every entry point also runs VALUES and derived-table discovery over
+/// its own token scope and augments the catalog before resolution, so
+/// nested subqueries pick up sibling virtual tables without extra work
+/// from the caller.
 pub fn infer_columns_from_tokens_scoped(
   query_name: String,
   tokens: List(lexer.Token),
   catalog: model.Catalog,
   outer_tables: List(String),
 ) -> Result(List(model.ResultItem), AnalysisError) {
+  use augmented <- result.try(augment_with_subquery_tables(
+    query_name,
+    tokens,
+    catalog,
+  ))
   case tok_extract_returning_columns(tokens) {
     Some(returning_cols) -> {
       let table_names = token_utils.extract_table_names(tokens)
@@ -74,7 +84,7 @@ pub fn infer_columns_from_tokens_scoped(
           resolve_select_columns(
             query_name,
             returning_cols,
-            catalog,
+            augmented,
             primary,
             tables,
             nullable_tables,
@@ -99,7 +109,7 @@ pub fn infer_columns_from_tokens_scoped(
           resolve_select_columns(
             query_name,
             select_columns,
-            catalog,
+            augmented,
             primary,
             tables,
             nullable_tables,
@@ -108,6 +118,21 @@ pub fn infer_columns_from_tokens_scoped(
       }
     }
   }
+}
+
+fn augment_with_subquery_tables(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(model.Catalog, AnalysisError) {
+  let values = extract_values_tables(tokens)
+  let with_values = augment_catalog_with(catalog, values)
+  use derived <- result.try(extract_derived_tables(
+    query_name,
+    tokens,
+    with_values,
+  ))
+  Ok(augment_catalog_with(with_values, derived))
 }
 
 /// Pick the scope the resolver should use: the inner FROM tables if any,
@@ -375,6 +400,114 @@ fn build_values_columns(
       model.Column(name: name, scalar_type: st, nullable: nullable),
       ..build_values_columns(rest_names, rest_types)
     ]
+  }
+}
+
+/// Find every derived table in the token stream — `FROM (SELECT ...)`,
+/// `JOIN (SELECT ...)`, `JOIN LATERAL (SELECT ...)`, and comma-LATERAL
+/// `, LATERAL (SELECT ...)` — and build a virtual Table for each. Each
+/// body is resolved against `catalog` via `infer_columns_from_tokens`,
+/// so nested CTEs / VALUES / derived tables compose naturally. An
+/// explicit `AS alias(c1, c2)` column list overrides the body's names.
+pub fn extract_derived_tables(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(List(model.Table), AnalysisError) {
+  find_derived_tables(query_name, tokens, catalog, [])
+}
+
+fn find_derived_tables(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+  acc: List(model.Table),
+) -> Result(List(model.Table), AnalysisError) {
+  case tokens {
+    [] -> Ok(list.reverse(acc))
+    [lexer.Keyword("from"), lexer.LParen, lexer.Keyword("select"), ..rest] ->
+      handle_derived(query_name, rest, catalog, acc)
+    [
+      lexer.Keyword("join"),
+      lexer.Keyword("lateral"),
+      lexer.LParen,
+      lexer.Keyword("select"),
+      ..rest
+    ] -> handle_derived(query_name, rest, catalog, acc)
+    [lexer.Keyword("join"), lexer.LParen, lexer.Keyword("select"), ..rest] ->
+      handle_derived(query_name, rest, catalog, acc)
+    [lexer.Keyword("lateral"), lexer.LParen, lexer.Keyword("select"), ..rest] ->
+      handle_derived(query_name, rest, catalog, acc)
+    [_, ..rest] -> find_derived_tables(query_name, rest, catalog, acc)
+  }
+}
+
+fn handle_derived(
+  query_name: String,
+  tokens_after_select_kw: List(lexer.Token),
+  catalog: model.Catalog,
+  acc: List(model.Table),
+) -> Result(List(model.Table), AnalysisError) {
+  let #(body, after_rp) =
+    token_utils.collect_paren_contents([
+      lexer.Keyword("select"),
+      ..tokens_after_select_kw
+    ])
+  case parse_derived_alias(after_rp) {
+    Some(#(alias, explicit_names, remaining)) -> {
+      use cols <- result.try(infer_columns_from_tokens(
+        query_name,
+        body,
+        catalog,
+      ))
+      let body_columns =
+        list.filter_map(cols, fn(item) {
+          case item {
+            model.ScalarResult(rc) ->
+              Ok(model.Column(
+                name: rc.name,
+                scalar_type: rc.scalar_type,
+                nullable: rc.nullable,
+              ))
+            _ -> Error(Nil)
+          }
+        })
+      let columns = apply_explicit_column_names(body_columns, explicit_names)
+      let table = model.Table(name: alias, columns: columns)
+      find_derived_tables(query_name, remaining, catalog, [table, ..acc])
+    }
+    None -> find_derived_tables(query_name, after_rp, catalog, acc)
+  }
+}
+
+/// Parse `AS alias(c1, c2, ...)` after a derived-table subquery. The
+/// column list is optional: `AS alias` alone is valid (column names
+/// then come from the body). Returns the alias, any explicit names,
+/// and the tokens following both.
+fn parse_derived_alias(
+  tokens: List(lexer.Token),
+) -> Option(#(String, List(String), List(lexer.Token))) {
+  let after_as = case tokens {
+    [lexer.Keyword("as"), ..rest] -> rest
+    _ -> tokens
+  }
+  case after_as {
+    [lexer.Ident(alias), lexer.LParen, ..rest_after_lp] -> {
+      let #(col_tokens, after_cols) =
+        token_utils.collect_paren_contents(rest_after_lp)
+      let names = parse_cte_column_list(col_tokens)
+      Some(#(string.lowercase(alias), names, after_cols))
+    }
+    [lexer.QuotedIdent(alias), lexer.LParen, ..rest_after_lp] -> {
+      let #(col_tokens, after_cols) =
+        token_utils.collect_paren_contents(rest_after_lp)
+      let names = parse_cte_column_list(col_tokens)
+      Some(#(string.lowercase(alias), names, after_cols))
+    }
+    [lexer.Ident(alias), ..rest] -> Some(#(string.lowercase(alias), [], rest))
+    [lexer.QuotedIdent(alias), ..rest] ->
+      Some(#(string.lowercase(alias), [], rest))
+    _ -> None
   }
 }
 

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -17,20 +17,16 @@ fn table_names_loop(
 ) -> List(String) {
   case tokens {
     [] -> list.reverse(acc)
-    // FROM (VALUES ...) AS alias(...) — the alias names the virtual
-    // table populated by extract_values_tables. Emit the alias so the
-    // resolver can look it up. Non-VALUES subqueries are left alone
-    // (derived tables are not inferred yet).
-    [lexer.Keyword("from"), lexer.LParen, lexer.Keyword("values"), ..rest] -> {
+    // FROM (subquery) AS alias(...) — covers VALUES, derived tables,
+    // and LATERAL subqueries. The alias names a virtual table that
+    // extract_values_tables or extract_derived_tables is responsible
+    // for registering in the catalog.
+    [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
       let remaining = skip_parens(rest, 1)
       case read_subquery_alias(remaining) {
         #(Some(n), after_alias) -> table_names_loop(after_alias, [n, ..acc])
         #(None, _) -> table_names_loop(remaining, acc)
       }
-    }
-    [lexer.Keyword("from"), lexer.LParen, ..rest] -> {
-      let remaining = skip_parens(rest, 1)
-      table_names_loop(remaining, acc)
     }
     [lexer.Keyword(kw), ..rest]
       if kw == "from" || kw == "into" || kw == "update"
@@ -41,7 +37,24 @@ fn table_names_loop(
         None -> table_names_loop(rest, acc)
       }
     }
-    [lexer.Keyword("join"), lexer.LParen, lexer.Keyword("values"), ..rest] -> {
+    // JOIN LATERAL (subquery) AS alias(...) — consume LATERAL before
+    // the paren so the alias is picked up.
+    [lexer.Keyword("join"), lexer.Keyword("lateral"), lexer.LParen, ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      case read_subquery_alias(remaining) {
+        #(Some(n), after_alias) -> table_names_loop(after_alias, [n, ..acc])
+        #(None, _) -> table_names_loop(remaining, acc)
+      }
+    }
+    [lexer.Keyword("join"), lexer.LParen, ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      case read_subquery_alias(remaining) {
+        #(Some(n), after_alias) -> table_names_loop(after_alias, [n, ..acc])
+        #(None, _) -> table_names_loop(remaining, acc)
+      }
+    }
+    // PostgreSQL comma-LATERAL: FROM t1, LATERAL (subquery) AS alias
+    [lexer.Keyword("lateral"), lexer.LParen, ..rest] -> {
       let remaining = skip_parens(rest, 1)
       case read_subquery_alias(remaining) {
         #(Some(n), after_alias) -> table_names_loop(after_alias, [n, ..acc])

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -1963,6 +1963,85 @@ pub fn correlated_subquery_outer_only_column_test() {
   echoed.nullable |> should.equal(True)
 }
 
+// --- #324: derived tables in FROM / JOIN ---
+
+pub fn derived_table_in_from_body_names_test() {
+  // `FROM (SELECT id, name FROM authors) AS sub` — no explicit column
+  // list, so the derived table's columns come from the inner SELECT
+  // and are reachable via the alias.
+  let sql =
+    "-- name: FromDerived :many\nSELECT sub.id, sub.name FROM (SELECT id, name FROM authors) AS sub;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(id_col), model.ScalarResult(name_col)] =
+    query.result_columns
+  id_col.name |> should.equal("id")
+  id_col.scalar_type |> should.equal(model.IntType)
+  name_col.name |> should.equal("name")
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn derived_table_with_explicit_column_list_test() {
+  // The alias column list `s(x, y)` renames the inferred columns; the
+  // outer SELECT must reference the new names.
+  let sql =
+    "-- name: FromDerivedAliased :many\nSELECT s.x, s.y FROM (SELECT id, name FROM authors) AS s(x, y);"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(x_col), model.ScalarResult(y_col)] =
+    query.result_columns
+  x_col.name |> should.equal("x")
+  x_col.scalar_type |> should.equal(model.IntType)
+  y_col.name |> should.equal("y")
+  y_col.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn derived_table_in_join_test() {
+  // Derived table joined onto a real table. The inner SELECT computes
+  // `author_id` and an aggregated column, and the outer SELECT pulls
+  // columns from both sides.
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: AuthorsWithPostCount :many\nSELECT authors.name, sub.total FROM authors JOIN (SELECT author_id, COUNT(*) AS total FROM books GROUP BY author_id) AS sub ON authors.id = sub.author_id;"
+  let assert Ok(queries) =
+    query_parser.parse_file("d.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [model.ScalarResult(name_col), model.ScalarResult(total_col)] =
+    query.result_columns
+  name_col.scalar_type |> should.equal(model.StringType)
+  total_col.name |> should.equal("total")
+  total_col.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn derived_table_nested_test() {
+  // `FROM (SELECT * FROM (SELECT ...) AS inner) AS outer` — the inner
+  // derived table must be discovered and augmented before the outer
+  // body's resolver runs.
+  let sql =
+    "-- name: Nested :many\nSELECT outer_alias.id FROM (SELECT inner_alias.id FROM (SELECT id, name FROM authors) AS inner_alias) AS outer_alias;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(id_col)] = query.result_columns
+  id_col.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn derived_table_referencing_cte_test() {
+  // A derived table's body can reference a CTE defined in the same
+  // query, because extract_derived_tables runs against the catalog
+  // already augmented with CTE virtual tables.
+  let sql =
+    "-- name: DerivedOverCte :many\nWITH c AS (SELECT id, name FROM authors) SELECT d.name FROM (SELECT name FROM c) AS d;"
+  let query = analyze_one(sql, test_catalog())
+  let assert [model.ScalarResult(name_col)] = query.result_columns
+  name_col.name |> should.equal("name")
+  name_col.scalar_type |> should.equal(model.StringType)
+}
+
 pub fn mysql_on_duplicate_key_update_test() {
   // MySQL: INSERT ... ON DUPLICATE KEY UPDATE col = VALUES(col)
   // Param count should be 2 (from the INSERT VALUES); VALUES(col) on


### PR DESCRIPTION
## Summary
Closes the FROM-clause half of #324: `FROM (SELECT ...) AS t(cols?)` and its `JOIN` / `LATERAL` / comma-`LATERAL` variants are now resolved into virtual tables, so the outer query can project and join against their columns like real tables. Scalar, `EXISTS`, and correlated subqueries were already handled in PR #354 and PR #355.

## Changes
- `src/sqlode/query_analyzer/column_inferencer.gleam`: New `extract_derived_tables` walks the token stream for `FROM/JOIN/JOIN LATERAL/LATERAL (SELECT ...)` patterns, resolves each body with `infer_columns_from_tokens`, and builds a `model.Table` whose columns come from the body (renamed via the explicit alias column list when present, reusing `apply_explicit_column_names`). `infer_columns_from_tokens_scoped` now runs `augment_with_subquery_tables` at the top of every call so nested subqueries pick up sibling VALUES / derived tables without the caller threading them in.
- `src/sqlode/query_analyzer/token_utils.gleam`: `table_names_loop` now recognises `FROM (subquery) AS alias`, `JOIN (subquery) AS alias`, `JOIN LATERAL (subquery) AS alias`, and comma-style `LATERAL (subquery) AS alias`, replacing the earlier VALUES-only special case. The alias is what the resolver looks up in the augmented catalog.
- `src/sqlode/query_analyzer.gleam`: `analyze_query` now surfaces CTE, VALUES, and derived virtual tables in that order, so both result-column and parameter inference see them. A new `merge_virtual_tables` helper keeps the cascading augmentation readable.
- `test/query_analyzer_test.gleam`: Five new tests — `derived_table_in_from_body_names_test`, `derived_table_with_explicit_column_list_test`, `derived_table_in_join_test` (with an aggregated `COUNT(*)` column), `derived_table_nested_test`, and `derived_table_referencing_cte_test`.

## Design Decisions
- **Derived tables share the CTE / VALUES virtual-table pipeline**: they all end up as `model.Table`s the resolver looks up by alias, so the downstream code path (including `SELECT *` expansion, LEFT-JOIN nullability propagation) just works without a new kind of result item.
- **Augmentation lives inside the scoped entry point**: putting VALUES / derived discovery inside `infer_columns_from_tokens_scoped` means nested derived tables and scalar subqueries pick them up for free. The outer `analyze_query` still does the same discovery once so parameter inference can resolve references into VALUES / derived columns too. Double scanning is unavoidable for the outer scope but cheap relative to the rest of analysis.
- **Alias column list is optional**: unlike VALUES (where the alias column list is required because literals have no inherent names), a derived table can rely on the inner SELECT's names. `parse_derived_alias` handles both forms.
- **LATERAL is recognised but outer-scope access is not tracked per-subquery**: the scalar-subquery outer-scope fallback from PR #355 already covers column references into the enclosing FROM, so LATERAL bodies that reference outer tables work transitively.

## Limitations
- Name collisions between a derived table alias and a real / CTE table resolve to whichever `list.find` hits first; the catalog list is not scoped. Rare but possible.
- A derived table whose body cannot be resolved (e.g. references an unknown column) currently fails the whole query with the inner error. That is stricter than the pre-PR behaviour, which left `result_columns` empty. The stricter error is more honest than silently producing wrong Gleam types, but may surface analysis errors on previously-silently-ignored queries.
- Param inference does not currently re-discover derived tables that live only inside another derived table's body, so placeholders nested two levels deep may not get their types inferred. That is a follow-up.

Closes #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Query analyzer now properly handles derived tables in `FROM` and `JOIN` clauses
  - Column names and types from nested subqueries are correctly inferred
  - Derived tables support explicit column aliases and can reference CTEs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->