### PR TITLE
feat(query_parser): accept sqlc-style block-comment annotations

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -223,14 +223,9 @@ fn parse_annotation(
   path: String,
   line_number: Int,
 ) -> Result(Option(PendingQuery), ParseError) {
-  case string.starts_with(line, "-- name:") {
-    False -> Ok(None)
-    True -> {
-      let rest =
-        line
-        |> string.replace("-- name:", "")
-        |> string.trim
-
+  case extract_annotation_payload(line) {
+    None -> Ok(None)
+    Some(rest) -> {
       let parts =
         string.split(rest, " ")
         |> list.map(string.trim)
@@ -261,8 +256,57 @@ fn parse_annotation(
           Error(InvalidAnnotation(
             path:,
             line: line_number,
-            detail: "expected '-- name: <Name> <command>' where command is one of: :one, :many, :exec, :execresult, :execrows, :execlastid",
+            detail: "expected '-- name: <Name> <command>' or '/* name: <Name> <command> */' where command is one of: :one, :many, :exec, :execresult, :execrows, :execlastid, :batchone, :batchmany, :batchexec, :copyfrom",
           ))
+      }
+    }
+  }
+}
+
+/// Extracts the annotation payload (the text after `name:` and before any
+/// terminator) from a trimmed line. Supports both `-- name: ...` and
+/// `/* name: ... */` forms. Returns None for non-annotation lines so callers
+/// can treat them as SQL body.
+fn extract_annotation_payload(line: String) -> Option(String) {
+  case extract_line_annotation(line) {
+    Some(payload) -> Some(payload)
+    None -> extract_block_annotation(line)
+  }
+}
+
+fn extract_line_annotation(line: String) -> Option(String) {
+  case string.starts_with(line, "-- name:") {
+    False -> None
+    True ->
+      line
+      |> string.replace("-- name:", "")
+      |> string.trim
+      |> Some
+  }
+}
+
+fn extract_block_annotation(line: String) -> Option(String) {
+  case string.starts_with(line, "/*") && string.ends_with(line, "*/") {
+    False -> None
+    True -> {
+      let inner =
+        line
+        |> string.drop_start(2)
+        |> string.drop_end(2)
+
+      case string.contains(inner, "*/") {
+        True -> None
+        False -> {
+          let inner_trimmed = string.trim(inner)
+          case string.starts_with(inner_trimmed, "name:") {
+            False -> None
+            True ->
+              inner_trimmed
+              |> string.replace("name:", "")
+              |> string.trim
+              |> Some
+          }
+        }
       }
     }
   }

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -724,3 +724,222 @@ pub fn skip_annotation_middle_query_test() {
   let names = list.map(queries, fn(q) { q.name })
   names |> should.equal(["First", "Third"])
 }
+
+// Block-comment annotation tests (sqlc-style `/* name: ... */`)
+
+pub fn parse_block_annotation_one_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "/* name: GetAuthor :one */\nSELECT id FROM authors WHERE id = $1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("GetAuthor")
+  query.function_name |> should.equal("get_author")
+  query.command |> should.equal(runtime.QueryOne)
+  query.param_count |> should.equal(1)
+}
+
+pub fn parse_block_annotation_many_test() {
+  let naming_ctx = naming.new()
+  let content = "/* name: ListAll :many */\nSELECT * FROM authors;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("ListAll")
+  query.command |> should.equal(runtime.QueryMany)
+}
+
+pub fn parse_block_annotation_exec_test() {
+  let naming_ctx = naming.new()
+  let content = "/* name: InsertRow :exec */\nINSERT INTO t (v) VALUES ($1);"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("InsertRow")
+  query.command |> should.equal(runtime.QueryExec)
+}
+
+pub fn parse_block_annotation_whitespace_tolerance_test() {
+  let naming_ctx = naming.new()
+  let content = "/*    name:   Spaced   :one    */\nSELECT 1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("Spaced")
+  query.command |> should.equal(runtime.QueryOne)
+}
+
+pub fn parse_block_annotation_no_inner_space_test() {
+  let naming_ctx = naming.new()
+  let content = "/*name: Tight :one*/\nSELECT 1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("Tight")
+  query.command |> should.equal(runtime.QueryOne)
+}
+
+pub fn parse_mixed_line_and_block_annotations_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: First :one\n"
+    <> "SELECT 1;\n"
+    <> "\n"
+    <> "/* name: Second :many */\n"
+    <> "SELECT 2;\n"
+    <> "\n"
+    <> "-- name: Third :exec\n"
+    <> "INSERT INTO t VALUES (1);\n"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("mixed.sql", model.PostgreSQL, naming_ctx, content)
+  list.length(queries) |> should.equal(3)
+
+  let assert [q1, q2, q3] = queries
+  q1.name |> should.equal("First")
+  q1.command |> should.equal(runtime.QueryOne)
+  q2.name |> should.equal("Second")
+  q2.command |> should.equal(runtime.QueryMany)
+  q3.name |> should.equal("Third")
+  q3.command |> should.equal(runtime.QueryExec)
+}
+
+pub fn parse_block_annotation_multiline_body_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "/* name: BigQuery :many */\n"
+    <> "SELECT id,\n"
+    <> "       name,\n"
+    <> "       bio\n"
+    <> "FROM authors\n"
+    <> "WHERE id = $1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("BigQuery")
+  query.param_count |> should.equal(1)
+}
+
+pub fn parse_block_annotation_with_macro_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "/* name: Search :many */\n"
+    <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(1)
+  list.length(query.macros) |> should.equal(1)
+}
+
+pub fn parse_block_annotation_body_with_regular_block_comment_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "/* name: WithComment :one */\n"
+    <> "SELECT id\n"
+    <> "/* just a regular comment */\n"
+    <> "FROM authors WHERE id = $1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("WithComment")
+  query.param_count |> should.equal(1)
+}
+
+pub fn parse_block_comment_other_directive_ignored_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: Real :one\n" <> "/* other: bogus :many */\n" <> "SELECT 1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("Real")
+  query.command |> should.equal(runtime.QueryOne)
+}
+
+pub fn parse_block_annotation_inline_sql_not_annotation_test() {
+  let naming_ctx = naming.new()
+  // Line does not end with */, so it's not a valid annotation line.
+  let content = "/* name: X :one */ SELECT 1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  queries |> should.equal([])
+}
+
+pub fn parse_block_annotation_unclosed_ignored_test() {
+  let naming_ctx = naming.new()
+  let content = "/* name: NotReally :one\nSELECT 1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  queries |> should.equal([])
+}
+
+pub fn parse_block_annotation_multiline_not_annotation_test() {
+  let naming_ctx = naming.new()
+  // Annotation text split across lines is not supported.
+  let content = "/* name: Split\n" <> " :one */\n" <> "SELECT 1;"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  queries |> should.equal([])
+}
+
+pub fn parse_block_annotation_invalid_command_test() {
+  let naming_ctx = naming.new()
+  let content = "/* name: Q :bogus */\nSELECT 1;"
+
+  let assert Error(error) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let msg = query_parser.error_to_string(error)
+  string.contains(msg, "must be one of") |> should.be_true()
+}
+
+pub fn parse_block_annotation_missing_command_test() {
+  let naming_ctx = naming.new()
+  let content = "/* name: OnlyName */\nSELECT 1;"
+
+  let assert Error(error) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let msg = query_parser.error_to_string(error)
+  string.contains(msg, "/* name:") |> should.be_true()
+}
+
+pub fn parse_block_annotation_missing_sql_body_test() {
+  let naming_ctx = naming.new()
+  let content = "/* name: NoBody :one */\n"
+
+  let assert Error(error) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal("block.sql:1: query NoBody is missing SQL body")
+}
+
+pub fn skip_annotation_applies_to_block_annotation_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- sqlode:skip\n"
+    <> "/* name: Skipped :one */\n"
+    <> "SELECT 1;\n"
+    <> "\n"
+    <> "-- name: Kept :many\n"
+    <> "SELECT 2;\n"
+
+  let assert Ok(queries) =
+    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("Kept")
+  query.command |> should.equal(runtime.QueryMany)
+}


### PR DESCRIPTION
## Summary
Recognise `/* name: Query :cmd */` alongside the existing `-- name:` line-comment annotation form, so query files copied from sqlc projects parse without needing to be rewritten. Closes #358.

## Changes
- `src/sqlode/query_parser.gleam`: route `parse_annotation` through a new `extract_annotation_payload` helper that understands both line and block comment forms; update the malformed-annotation error message to list both syntaxes and all current commands (including batch variants and `:copyfrom`).
- `test/query_parser_test.gleam`: add 17 tests covering basic acceptance of the block form, mixed line/block usage, multi-line bodies, macros inside a block-annotated query, regular block comments in the body, invalid or missing commands, missing body, inline SQL on the annotation line, unclosed blocks, multi-line annotation text, and skip-annotation interaction.

## Design Decisions
- **Single-line only.** A block annotation must both start with `/*` and end with `*/` on the same trimmed line. Unclosed or multi-line forms are treated as SQL body and stripped by the lexer, mirroring how unclosed line comments behave today.
- **`*/` must not appear inside the inner payload.** Guards against `/* a */ b */` being misparsed after the outer `starts_with` / `ends_with` check succeeds.
- **Payload extractor over duplicated branches.** A helper that returns the post-`name:` payload keeps the downstream `parts` split, `parse_query_command` call, and `PendingQuery` construction in one place — both forms share the same error surface.
- **Non-annotation block comments are untouched.** `/* other: ... */` or `/* just a comment */` yields `None` from the extractor and is appended to the body, where the lexer already removes block comments. Existing `ignore_placeholder_in_block_comment_test` continues to pass.

## Limitations
- Multi-line block annotation text (e.g. `/* name: Q\n:one */`) is intentionally not supported.
- `/* sqlode:skip */` as a block form is out of scope; the skip directive remains line-comment only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended annotation syntax to support block-comment style (`/* name: ... */`) for SQL queries, complementing existing line-comment style (`-- name:`).

* **Tests**
  * Added comprehensive test coverage for block-comment annotations, whitespace handling, mixed annotation styles, and boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->