### PR TITLE
fix(schema_parser): reject schema-changing DDL instead of silently ignoring

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -10,6 +10,12 @@ import sqlode/query_analyzer/token_utils
 pub type ParseError {
   InvalidCreateTable(path: String, detail: String)
   InvalidColumn(path: String, table: String, detail: String)
+  /// A DDL statement was recognised as schema-changing but sqlode does not
+  /// apply it to the catalog. Raised for operations that can produce a
+  /// catalog that looks valid but is missing real schema changes — e.g.
+  /// `DROP TABLE`, `ALTER TABLE ... DROP COLUMN`. Informational DDL such
+  /// as `CREATE INDEX` and `ALTER TABLE ... ADD CONSTRAINT` stays silent.
+  UnsupportedStatement(path: String, statement_type: String)
 }
 
 pub type SchemaWarning {
@@ -613,7 +619,89 @@ fn parse_statement_tokens(
 ) -> Result(Option(model.Table), ParseError) {
   case is_create_table_tokens(tokens) {
     True -> parse_create_table_tokens(path, tokens, enums)
-    False -> Ok(None)
+    False ->
+      case classify_unknown_statement(tokens) {
+        Unsupported(statement_type) ->
+          Error(UnsupportedStatement(path:, statement_type:))
+        SilentlyIgnored -> Ok(None)
+      }
+  }
+}
+
+type UnknownStatementKind {
+  Unsupported(statement_type: String)
+  SilentlyIgnored
+}
+
+/// Classify a statement that is not a CREATE TABLE / VIEW / ENUM and not an
+/// ALTER TABLE ... ADD COLUMN. The intent is to let informational or
+/// out-of-scope DDL through silently (CREATE INDEX, COMMENT ON, transaction
+/// control) while failing fast on DDL that materially changes the catalog
+/// and would otherwise be missed (DROP TABLE, ALTER TABLE DROP/RENAME/ALTER).
+///
+/// The lexer reserves only a subset of SQL words as `Keyword` tokens. Words
+/// like `rename`, `savepoint`, and `comment` arrive as `Ident` tokens, so
+/// we normalise the first few tokens of the statement to lowercase strings
+/// before matching, treating Keyword and Ident uniformly.
+fn classify_unknown_statement(tokens: List(lexer.Token)) -> UnknownStatementKind {
+  let words = tokens |> list.take(8) |> list.map(token_keyword_text)
+  case words {
+    ["create", "index", ..] -> SilentlyIgnored
+    ["create", "unique", "index", ..] -> SilentlyIgnored
+    ["drop", "index", ..] -> SilentlyIgnored
+    ["comment", "on", ..] -> SilentlyIgnored
+    ["begin", ..] -> SilentlyIgnored
+    ["commit", ..] -> SilentlyIgnored
+    ["rollback", ..] -> SilentlyIgnored
+    ["savepoint", ..] -> SilentlyIgnored
+    ["release", ..] -> SilentlyIgnored
+    ["set", ..] -> SilentlyIgnored
+
+    ["drop", "table", ..] -> Unsupported("DROP TABLE")
+    ["drop", "view", ..] -> Unsupported("DROP VIEW")
+    ["drop", "type", ..] -> Unsupported("DROP TYPE")
+
+    ["alter", "table", ..rest] -> classify_alter_table(rest)
+
+    _ -> SilentlyIgnored
+  }
+}
+
+fn classify_alter_table(words: List(String)) -> UnknownStatementKind {
+  let after_modifiers = case words {
+    ["if", "exists", ..r] -> r
+    ["only", ..r] -> r
+    _ -> words
+  }
+  case after_modifiers {
+    [_table_name, ..rest] -> classify_alter_table_action(rest)
+    [] -> SilentlyIgnored
+  }
+}
+
+fn classify_alter_table_action(words: List(String)) -> UnknownStatementKind {
+  case words {
+    ["drop", "constraint", ..] -> SilentlyIgnored
+    ["drop", "column", ..] -> Unsupported("ALTER TABLE DROP COLUMN")
+    ["drop", ..] -> Unsupported("ALTER TABLE DROP")
+    ["rename", "to", ..] -> Unsupported("ALTER TABLE RENAME TO")
+    ["rename", ..] -> Unsupported("ALTER TABLE RENAME COLUMN")
+    ["alter", ..] -> Unsupported("ALTER TABLE ALTER COLUMN")
+    ["add", "constraint", ..] -> SilentlyIgnored
+    ["add", "primary", ..] -> SilentlyIgnored
+    ["add", "unique", ..] -> SilentlyIgnored
+    ["add", "foreign", ..] -> SilentlyIgnored
+    ["add", "check", ..] -> SilentlyIgnored
+    ["add", "index", ..] -> SilentlyIgnored
+    _ -> SilentlyIgnored
+  }
+}
+
+fn token_keyword_text(token: lexer.Token) -> String {
+  case token {
+    lexer.Keyword(k) -> k
+    lexer.Ident(i) -> string.lowercase(i)
+    _ -> ""
   }
 }
 
@@ -968,6 +1056,14 @@ pub fn error_to_string(error: ParseError) -> String {
       <> table
       <> ": "
       <> detail
+    UnsupportedStatement(path:, statement_type:) ->
+      path_prefix(path)
+      <> "Unsupported schema DDL: "
+      <> statement_type
+      <> ". sqlode only applies CREATE TABLE, CREATE VIEW, CREATE TYPE ... AS ENUM,"
+      <> " and ALTER TABLE ... ADD COLUMN to the catalog;"
+      <> " keep other schema-changing DDL out of the schema input"
+      <> " or consolidate migrations into a single CREATE TABLE snapshot."
   }
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -633,3 +633,106 @@ pub fn partition_by_clause_does_not_break_table_test() {
   table.name |> should.equal("measurements")
   list.length(table.columns) |> should.equal(3)
 }
+
+// Unsupported-DDL diagnostics (Issue #362)
+
+pub fn drop_table_is_rejected_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "DROP TABLE users;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "test.sql") |> should.be_true()
+  string.contains(msg, "Unsupported schema DDL") |> should.be_true()
+  string.contains(msg, "DROP TABLE") |> should.be_true()
+}
+
+pub fn drop_table_if_exists_is_rejected_test() {
+  let sql = "DROP TABLE IF EXISTS users;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "DROP TABLE") |> should.be_true()
+}
+
+pub fn drop_view_is_rejected_test() {
+  let sql = "DROP VIEW author_counts;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "DROP VIEW") |> should.be_true()
+}
+
+pub fn drop_type_is_rejected_test() {
+  let sql = "DROP TYPE status;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "DROP TYPE") |> should.be_true()
+}
+
+pub fn alter_table_drop_column_is_rejected_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "ALTER TABLE users DROP COLUMN name;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "ALTER TABLE DROP COLUMN") |> should.be_true()
+}
+
+pub fn alter_table_if_exists_drop_column_is_rejected_test() {
+  let sql = "ALTER TABLE IF EXISTS users DROP COLUMN name;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "ALTER TABLE DROP COLUMN") |> should.be_true()
+}
+
+pub fn alter_table_rename_column_is_rejected_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "ALTER TABLE users RENAME COLUMN name TO full_name;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "ALTER TABLE RENAME COLUMN") |> should.be_true()
+}
+
+pub fn alter_table_rename_to_is_rejected_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);\n"
+    <> "ALTER TABLE users RENAME TO accounts;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "ALTER TABLE RENAME TO") |> should.be_true()
+}
+
+pub fn alter_table_alter_column_is_rejected_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, created_at TIMESTAMP);\n"
+    <> "ALTER TABLE users ALTER COLUMN created_at SET NOT NULL;"
+  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "ALTER TABLE ALTER COLUMN") |> should.be_true()
+}
+
+pub fn alter_table_drop_constraint_stays_silent_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL);\n"
+    <> "ALTER TABLE users DROP CONSTRAINT unique_email;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(2)
+}
+
+pub fn comment_on_stays_silent_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);\n"
+    <> "COMMENT ON TABLE users IS 'account records';"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  table.name |> should.equal("users")
+}
+
+pub fn transaction_control_stays_silent_test() {
+  let sql =
+    "BEGIN;\n" <> "CREATE TABLE users (id INTEGER PRIMARY KEY);\n" <> "COMMIT;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  table.name |> should.equal("users")
+}


### PR DESCRIPTION
## Summary
Stop returning `Ok(None)` for schema-changing DDL that sqlode does not apply, so migration directories can no longer yield a catalog that looks valid but is missing real schema changes. Informational / catalog-neutral DDL (`CREATE INDEX`, transaction control, `COMMENT ON`, `ADD CONSTRAINT`, …) still passes through silently to preserve the existing sqlc-compatible migration flow. Closes #362.

## Changes
- `src/sqlode/schema_parser.gleam`:
  - Add `UnsupportedStatement(path, statement_type)` variant to `ParseError` and an `error_to_string` arm that points users at the supported subset of DDL.
  - Replace the silent `False -> Ok(None)` fallthrough in `parse_statement_tokens` with a classifier that either returns `SilentlyIgnored` or `Unsupported(statement_type)`.
  - Normalise the first tokens of each statement to lowercase strings (via `token_keyword_text`) before matching, so DDL keywords that the lexer emits as `Ident` — `rename`, `savepoint`, `comment` — match alongside real `Keyword` tokens.
  - Skip `IF EXISTS` and `ONLY` modifiers on `ALTER TABLE` before examining the action keyword.
- `test/schema_parser_test.gleam`: add 12 tests — 9 pinning the new rejections (`DROP TABLE`, `DROP TABLE IF EXISTS`, `DROP VIEW`, `DROP TYPE`, `ALTER TABLE DROP COLUMN`, `ALTER TABLE IF EXISTS DROP COLUMN`, `ALTER TABLE RENAME COLUMN`, `ALTER TABLE RENAME TO`, `ALTER TABLE ALTER COLUMN`) and 3 pinning the intentionally-silent behaviour (`ALTER TABLE DROP CONSTRAINT`, `COMMENT ON`, `BEGIN` / `COMMIT` wrappers).

## Design Decisions
- **Rejected vs silent split based on catalog impact.** DDL that changes the shape of the catalog (dropping tables or columns, renaming them, altering column types) raises `UnsupportedStatement` because silently ignoring it produces a generated Gleam API that disagrees with the real database. DDL that is informational (indexes, comments) or catalog-neutral (session/transaction control, add/drop constraint) stays silent, matching sqlc's migration-directory expectations and the existing `create_[unique_]index_is_skipped_test` / `alter_table_add_constraint_ignored_test` coverage.
- **String-normalised classifier over Keyword-only pattern matching.** The lexer reserves only a subset of SQL words as `Keyword` tokens; `rename` / `savepoint` / `comment` arrive as `Ident`. Matching the first ~8 tokens as lowercase strings lets one classifier cover both token kinds without touching the lexer's reserved-word list (which would risk breaking user SQL that uses these words as identifiers).
- **Unknown fallback stays silent.** Statements we do not recognise at all default to `SilentlyIgnored` so genuinely new DDL variants cannot break parsing for existing users. The Issue's fail-fast requirement is satisfied specifically for the schema-changing operations enumerated above.

## Limitations
- `ALTER TABLE ADD COLUMN` on a missing table remains silent (see the pre-existing `alter_table_add_column_nonexistent_table_test`). That path is about apply-ordering rather than unsupported DDL and is out of scope for this issue.
- The error message names the statement type (e.g. `ALTER TABLE RENAME COLUMN`) and the source file, but does not include the column or table identifier. Users get precise enough context to grep their migrations; richer diagnostics can follow in a later pass.
- `DROP CONSTRAINT`, `ADD CONSTRAINT`, and index DDL stay silent intentionally; if those ever need to influence the generated API, a follow-up should introduce warnings instead of errors so the migration flow keeps working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema parser now detects and reports unsupported schema-changing SQL statements with informative error messages.

* **Tests**
  * Added comprehensive tests for unsupported and allowed DDL statement handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->