### PR TITLE
fix(runtime): expand slice placeholders from explicit markers

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -645,9 +645,11 @@ fn render_pog_query_call(
       |> list.filter(fn(l) { l != "" })
   }
 
+  let slice_expansion =
+    render_slice_expansion_line(params, "runtime.DollarNumbered")
+
   case has_slices {
-    True -> {
-      let slice_expansion = render_slice_expansion_line(params, "$")
+    True ->
       list.flatten([
         ["  " <> slice_expansion, "  let query = pog.query(sql)"],
         param_lines,
@@ -657,10 +659,9 @@ fn render_pog_query_call(
           "  |> pog.execute(db)",
         ],
       ])
-    }
     False ->
       list.flatten([
-        ["  pog.query(q.sql)"],
+        ["  " <> slice_expansion, "  pog.query(sql)"],
         param_lines,
         ["  |> pog.returning(" <> decoder <> ")", "  |> pog.execute(db)"],
       ])
@@ -750,16 +751,22 @@ fn render_pog_exec_last_id(
     ..render_first_or_default("returned", "returned.rows", "0")
   ]
 
+  let slice_expansion =
+    render_slice_expansion_line(params, "runtime.DollarNumbered")
+
   case has_slices {
-    True -> {
-      let slice_expansion = render_slice_expansion_line(params, "$")
+    True ->
       list.flatten([
         ["  " <> slice_expansion, "  let query = pog.query(sql)"],
         param_lines,
         ["  query", ..result_lines],
       ])
-    }
-    False -> list.flatten([["  pog.query(q.sql)"], param_lines, result_lines])
+    False ->
+      list.flatten([
+        ["  " <> slice_expansion, "  pog.query(sql)"],
+        param_lines,
+        result_lines,
+      ])
   }
 }
 
@@ -774,29 +781,17 @@ fn render_sqlight_query_call(
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = common.has_slices(params)
-  case has_slices {
-    True -> {
-      let slice_expansion = render_slice_expansion_line(params, "?")
-      [
-        "  " <> slice_expansion,
-        "  sqlight.query(",
-        "    sql,",
-        "    on: db,",
-        "    with: " <> params_str <> ",",
-        "    expecting: " <> decoder <> ",",
-        "  )",
-      ]
-    }
-    False -> [
-      "  sqlight.query(",
-      "    q.sql,",
-      "    on: db,",
-      "    with: " <> params_str <> ",",
-      "    expecting: " <> decoder <> ",",
-      "  )",
-    ]
-  }
+  let slice_expansion =
+    render_slice_expansion_line(params, "runtime.QuestionNumbered")
+  [
+    "  " <> slice_expansion,
+    "  sqlight.query(",
+    "    sql,",
+    "    on: db,",
+    "    with: " <> params_str <> ",",
+    "    expecting: " <> decoder <> ",",
+    "  )",
+  ]
 }
 
 fn render_sqlight_params(
@@ -890,20 +885,13 @@ fn render_sqlight_exec_last_id(
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = common.has_slices(params)
-  let sql_var = case has_slices {
-    True -> "sql"
-    False -> "q.sql"
-  }
-  let preamble = case has_slices {
-    True -> ["  " <> render_slice_expansion_line(params, "?")]
-    False -> []
-  }
+  let slice_expansion =
+    render_slice_expansion_line(params, "runtime.QuestionNumbered")
   list.flatten([
-    preamble,
     [
+      "  " <> slice_expansion,
       "  sqlight.query(",
-      "    " <> sql_var <> ",",
+      "    sql,",
       "    on: db,",
       "    with: " <> params_str <> ",",
       "    expecting: decode.success(Nil),",
@@ -1032,7 +1020,7 @@ fn render_list_param_value_expr(
 
 fn render_slice_expansion_line(
   params: List(model.QueryParam),
-  prefix: String,
+  style_expr: String,
 ) -> String {
   let slice_entries =
     params
@@ -1052,9 +1040,9 @@ fn render_slice_expansion_line(
   <> slice_entries
   <> "], "
   <> int.to_string(total_params)
-  <> ", \""
-  <> prefix
-  <> "\")"
+  <> ", "
+  <> style_expr
+  <> ")"
 }
 
 fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -133,12 +133,6 @@ fn render_adapter(
       && !list.is_empty(query.result_columns)
     })
 
-  let has_exec_rows =
-    list.any(queries, fn(query) {
-      query.base.command == runtime.QueryExecRows
-      || query.base.command == runtime.QueryExecResult
-    })
-
   let has_slices = common.queries_have_slices(queries)
 
   let has_enums = common.queries_have_enums(queries)
@@ -150,7 +144,7 @@ fn render_adapter(
         "",
         "import gleam/dynamic/decode",
       ],
-      case has_exec_rows || has_slices {
+      case has_slices {
         True -> ["import gleam/list"]
         False -> []
       },
@@ -160,10 +154,10 @@ fn render_adapter(
         False -> []
       },
       [config.library_import],
-      case has_slices {
-        True -> ["import sqlode/runtime"]
-        False -> []
-      },
+      // Every generated adapter now calls `runtime.expand_slice_placeholders`
+      // to substitute the placeholder markers emitted by the query parser,
+      // so the import is always required (not only when slices are used).
+      ["import sqlode/runtime"],
       case has_results || has_enums {
         True -> ["import " <> module_path <> "/models"]
         False -> []

--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -484,10 +484,22 @@ fn read_word(input: List(String), acc: List(String)) -> #(String, List(String)) 
 
 fn classify_word(word: String) -> Token {
   let lowered = string.lowercase(word)
-  case is_sql_keyword(lowered) {
-    True -> Keyword(lowered)
-    False -> Ident(word)
+  case is_sqlode_marker(word) {
+    True -> Placeholder(word)
+    False ->
+      case is_sql_keyword(lowered) {
+        True -> Keyword(lowered)
+        False -> Ident(word)
+      }
   }
+}
+
+fn is_sqlode_marker(word: String) -> Bool {
+  {
+    string.starts_with(word, "__sqlode_param_")
+    || string.starts_with(word, "__sqlode_slice_")
+  }
+  && string.ends_with(word, "__")
 }
 
 fn is_sql_keyword(word: String) -> Bool {

--- a/src/sqlode/query_analyzer/placeholder.gleam
+++ b/src/sqlode/query_analyzer/placeholder.gleam
@@ -45,22 +45,47 @@ pub fn placeholder_index_for_token(
   token: String,
   occurrence: Int,
 ) -> Option(Int) {
-  case engine {
-    model.PostgreSQL ->
-      token
-      |> string.replace("$", "")
-      |> int.parse
-      |> option.from_result
-    model.MySQL -> Some(occurrence)
-    model.SQLite ->
-      case string.starts_with(token, "?") && token != "?" {
-        True ->
+  case marker_index(token) {
+    Some(_) as matched -> matched
+    None ->
+      case engine {
+        model.PostgreSQL ->
           token
-          |> string.replace("?", "")
+          |> string.replace("$", "")
           |> int.parse
           |> option.from_result
-        False -> Some(occurrence)
+        model.MySQL -> Some(occurrence)
+        model.SQLite ->
+          case string.starts_with(token, "?") && token != "?" {
+            True ->
+              token
+              |> string.replace("?", "")
+              |> int.parse
+              |> option.from_result
+            False -> Some(occurrence)
+          }
       }
+  }
+}
+
+fn marker_index(token: String) -> Option(Int) {
+  let rest = case string.starts_with(token, "__sqlode_param_") {
+    True -> Some(string.drop_start(token, 15))
+    False ->
+      case string.starts_with(token, "__sqlode_slice_") {
+        True -> Some(string.drop_start(token, 15))
+        False -> None
+      }
+  }
+  case rest {
+    None -> None
+    Some(body) -> {
+      let core = case string.ends_with(body, "__") {
+        True -> string.drop_end(body, 2)
+        False -> body
+      }
+      int.parse(core) |> option.from_result
+    }
   }
 }
 

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -317,6 +317,12 @@ fn is_skip_annotation(line: String) -> Bool {
 }
 
 /// Count parameters from an already-expanded token list.
+///
+/// After macro/`@name` expansion every parameter is represented by a
+/// `__sqlode_param_<idx>__` or `__sqlode_slice_<idx>__` marker, so the
+/// parameter count is the highest index that appears. Raw engine
+/// placeholders (`$1`, `?1`, bare `?`) written directly by the user are
+/// also counted for back-compat with handwritten SQL.
 fn count_parameters_from_tokens(
   engine: model.Engine,
   tokens: List(lexer.Token),
@@ -330,9 +336,24 @@ fn count_parameters_from_tokens(
       }
     })
 
-  case engine {
+  let #(markers, raw) =
+    list.partition(placeholders, fn(p) { is_marker_placeholder(p) })
+
+  // Marker placeholders count as distinct indices. The same marker may
+  // appear multiple times (e.g. SQLite's `@name` reused in two positions)
+  // but contributes one parameter slot per distinct index.
+  let marker_count =
+    markers
+    |> list.filter_map(extract_marker_index)
+    |> list.unique
+    |> list.length
+
+  // Raw engine placeholders written directly by the user keep the same
+  // engine-specific counting the parser has always used (max index for
+  // PostgreSQL, positional for MySQL, distinct-name-plus-bare-? for SQLite).
+  let raw_count = case engine {
     model.PostgreSQL ->
-      placeholders
+      raw
       |> list.filter_map(fn(p) { string.replace(p, "$", "") |> int.parse })
       |> list.fold(0, fn(max_idx, v) {
         case v > max_idx {
@@ -340,12 +361,35 @@ fn count_parameters_from_tokens(
           False -> max_idx
         }
       })
-    model.MySQL -> list.length(placeholders)
+    model.MySQL -> list.length(raw)
     model.SQLite -> {
-      let #(anon, named) = list.partition(placeholders, fn(p) { p == "?" })
+      let #(anon, named) = list.partition(raw, fn(p) { p == "?" })
       list.length(anon) + list.length(list.unique(named))
     }
   }
+
+  marker_count + raw_count
+}
+
+fn is_marker_placeholder(p: String) -> Bool {
+  string.starts_with(p, "__sqlode_param_")
+  || string.starts_with(p, "__sqlode_slice_")
+}
+
+fn extract_marker_index(p: String) -> Result(Int, Nil) {
+  let body = case string.starts_with(p, "__sqlode_param_") {
+    True -> string.drop_start(p, 15)
+    False ->
+      case string.starts_with(p, "__sqlode_slice_") {
+        True -> string.drop_start(p, 15)
+        False -> p
+      }
+  }
+  let without_suffix = case string.ends_with(body, "__") {
+    True -> string.drop_end(body, 2)
+    False -> body
+  }
+  int.parse(without_suffix)
 }
 
 pub fn error_to_string(error: ParseError) -> String {
@@ -477,7 +521,10 @@ fn expand_macro_loop(
       // Collect tokens inside parens to extract the argument name
       let #(arg_tokens, remaining) = collect_macro_arg_tokens(rest, 1, [])
       let name = extract_arg_name(arg_tokens)
-      let placeholder = engine_placeholder(engine, idx)
+      let placeholder = case kind {
+        "slice" -> engine_slice_placeholder(engine, idx)
+        _ -> engine_placeholder(engine, idx)
+      }
       let macro_entry = case kind {
         "narg" -> model.MacroNarg(index: idx, name:)
         "slice" -> model.MacroSlice(index: idx, name:)
@@ -543,10 +590,15 @@ fn extract_arg_name(tokens: List(lexer.Token)) -> String {
   }
 }
 
-fn engine_placeholder(engine: model.Engine, index: Int) -> String {
-  case engine {
-    model.PostgreSQL -> "$" <> int.to_string(index)
-    model.MySQL -> "?"
-    model.SQLite -> "?" <> int.to_string(index)
-  }
+fn engine_placeholder(_engine: model.Engine, index: Int) -> String {
+  // Emit an engine-agnostic marker for every parameter position. The
+  // runtime walks these markers and substitutes the engine-specific
+  // placeholder (e.g. `$3`, `?3`, `?`) at prepare-time, which fixes
+  // both MySQL's bare-`?` expansion and placeholder-like text inside
+  // string literals or comments being rewritten by string.replace.
+  runtime.param_marker(index)
+}
+
+fn engine_slice_placeholder(_engine: model.Engine, index: Int) -> String {
+  runtime.slice_marker(index)
 }

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -46,28 +46,31 @@ pub type RawQuery(p) {
   )
 }
 
+/// Placeholder style used by the target database driver.
+///
+/// - `DollarNumbered` — PostgreSQL style: `$1`, `$2`, ...
+/// - `QuestionNumbered` — SQLite style: `?1`, `?2`, ...
+/// - `QuestionPositional` — MySQL style: bare `?` (matched by position)
+pub type PlaceholderStyle {
+  DollarNumbered
+  QuestionNumbered
+  QuestionPositional
+}
+
 /// Prepare a raw query for execution by encoding parameters and expanding
-/// slice placeholders.  Returns the final SQL string and the flattened
-/// parameter values, ready to be passed to a database driver.
-///
-/// For queries without slices the SQL is returned unchanged.
-///
-/// - `prefix` – placeholder prefix: `"$"` for PostgreSQL, `"?"` for SQLite
+/// the engine-agnostic placeholder markers that the generator emits.
+/// Returns the final SQL string and the flattened parameter values, ready
+/// to be passed to a database driver.
 pub fn prepare(
   query: RawQuery(p),
   params: p,
-  prefix: String,
+  style: PlaceholderStyle,
 ) -> #(String, List(Value)) {
   let values = query.encode(params)
   let slices = query.slice_info(params)
-  case slices {
-    [] -> #(query.sql, values)
-    _ -> {
-      let sql =
-        expand_slice_placeholders(query.sql, slices, query.param_count, prefix)
-      #(sql, values)
-    }
-  }
+  let sql =
+    expand_slice_placeholders(query.sql, slices, query.param_count, style)
+  #(sql, values)
 }
 
 pub fn null() -> Value {
@@ -105,39 +108,40 @@ pub fn nullable(value: option.Option(a), encode: fn(a) -> Value) -> Value {
   }
 }
 
-/// Expand slice placeholders in a SQL string.
+/// Marker prefix emitted by the generator for a regular `sqlode.arg` /
+/// `sqlode.narg` / `@name` parameter at the given 1-based index.
+/// Rendered into the final placeholder at runtime by `expand_slice_placeholders`.
+pub fn param_marker(index: Int) -> String {
+  "__sqlode_param_" <> int.to_string(index) <> "__"
+}
+
+/// Marker prefix emitted by the generator for a `sqlode.slice` parameter at
+/// the given 1-based index. Rendered into the expanded placeholder list at
+/// runtime by `expand_slice_placeholders`.
+pub fn slice_marker(index: Int) -> String {
+  "__sqlode_slice_" <> int.to_string(index) <> "__"
+}
+
+/// Render a parameter marker into the final engine-specific placeholder.
 ///
-/// When a query uses `sqlode.slice(ids)`, the parser emits a single placeholder
-/// (e.g. `$1` or `?1`).  At runtime the placeholder must be expanded to match
-/// the actual list length, and every subsequent placeholder must be renumbered.
+/// The generator emits `__sqlode_param_N__` / `__sqlode_slice_N__` in the SQL
+/// template regardless of the target engine. At runtime this function
+/// replaces each marker with the correct placeholder string (for example
+/// `$3` for PostgreSQL, `?3` for SQLite, `?` for MySQL) and expands slice
+/// markers to a comma-separated list sized by the caller-provided
+/// `slices`. Non-slice markers are renumbered sequentially across the
+/// whole SQL text so that slices that precede them shift their index.
 ///
-/// Arguments:
-/// - `sql`          – the SQL template with original placeholders
-/// - `slices`       – list of `#(original_index, slice_length)` for each slice param
-/// - `total_params` – total number of original parameter slots
-/// - `prefix`       – placeholder prefix: `"$"` for PostgreSQL, `"?"` for SQLite
-///
-/// Returns the expanded SQL string.
+/// Using markers instead of rewriting `prefix<>index` directly means
+/// placeholder-like text inside string literals or comments is never
+/// touched, and MySQL (which uses bare `?` rather than `?N`) works
+/// without special-casing the placeholder format.
 pub fn expand_slice_placeholders(
   sql: String,
   slices: List(#(Int, Int)),
   total_params: Int,
-  prefix: String,
+  style: PlaceholderStyle,
 ) -> String {
-  // Phase 1: Replace all original placeholders with unique markers
-  //          (from highest index to lowest to avoid partial matches)
-  // Note: int.range excludes the stop value, so use 0 to include 1
-  let marked =
-    int.range(from: total_params, to: 0, with: sql, run: fn(s, i) {
-      string.replace(
-        s,
-        prefix <> int.to_string(i),
-        "{{P" <> int.to_string(i) <> "}}",
-      )
-    })
-
-  // Phase 2: Compute a mapping from each original index to the new placeholder(s)
-  // Note: int.range excludes stop, so use total_params + 1 to include total_params
   let #(_, mapping) =
     int.range(
       from: 1,
@@ -145,28 +149,31 @@ pub fn expand_slice_placeholders(
       with: #(1, []),
       run: fn(acc, orig_idx) {
         let #(next_new_idx, map) = acc
-        let is_slice = list.find(slices, fn(s) { s.0 == orig_idx })
-        case is_slice {
+        case list.find(slices, fn(s) { s.0 == orig_idx }) {
           Ok(#(_, len)) -> {
+            let marker = slice_marker(orig_idx)
             case len {
-              0 -> #(next_new_idx, [#(orig_idx, "NULL"), ..map])
+              0 -> #(next_new_idx, [#(marker, "NULL"), ..map])
               _ -> {
                 let expanded =
                   int.range(
                     from: next_new_idx,
                     to: next_new_idx + len,
                     with: [],
-                    run: fn(items, i) { [prefix <> int.to_string(i), ..items] },
+                    run: fn(items, i) {
+                      [render_placeholder(style, i), ..items]
+                    },
                   )
                   |> list.reverse
                   |> string.join(", ")
-                #(next_new_idx + len, [#(orig_idx, expanded), ..map])
+                #(next_new_idx + len, [#(marker, expanded), ..map])
               }
             }
           }
           Error(_) -> {
+            let marker = param_marker(orig_idx)
             #(next_new_idx + 1, [
-              #(orig_idx, prefix <> int.to_string(next_new_idx)),
+              #(marker, render_placeholder(style, next_new_idx)),
               ..map
             ])
           }
@@ -174,10 +181,18 @@ pub fn expand_slice_placeholders(
       },
     )
 
-  // Phase 3: Replace markers with final placeholders
   mapping
-  |> list.fold(marked, fn(s, entry) {
-    let #(orig_idx, replacement) = entry
-    string.replace(s, "{{P" <> int.to_string(orig_idx) <> "}}", replacement)
+  |> list.reverse
+  |> list.fold(sql, fn(s, entry) {
+    let #(marker, replacement) = entry
+    string.replace(s, marker, replacement)
   })
+}
+
+fn render_placeholder(style: PlaceholderStyle, index: Int) -> String {
+  case style {
+    DollarNumbered -> "$" <> int.to_string(index)
+    QuestionNumbered -> "?" <> int.to_string(index)
+    QuestionPositional -> "?"
+  }
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -155,7 +155,9 @@ pub fn render_pog_adapter_test() {
   string.contains(rendered, "import db/queries") |> should.be_true()
   string.contains(rendered, "pub fn get_author(db: pog.Connection")
   |> should.be_true()
-  string.contains(rendered, "pog.query(q.sql)") |> should.be_true()
+  string.contains(rendered, "runtime.expand_slice_placeholders(")
+  |> should.be_true()
+  string.contains(rendered, "pog.query(sql)") |> should.be_true()
   string.contains(rendered, "pog.parameter(pog.int(p.id))")
   |> should.be_true()
   string.contains(rendered, "decode.success(models.GetAuthorRow(")
@@ -288,15 +290,20 @@ pub fn render_sqlight_adapter_slice_test() {
 }
 
 pub fn expand_slice_placeholders_single_test() {
-  let sql = "SELECT id, name FROM authors WHERE id IN ($1)"
-  let result = runtime.expand_slice_placeholders(sql, [#(1, 3)], 1, "$")
+  let sql = "SELECT id, name FROM authors WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    runtime.expand_slice_placeholders(sql, [#(1, 3)], 1, runtime.DollarNumbered)
   result
   |> should.equal("SELECT id, name FROM authors WHERE id IN ($1, $2, $3)")
 }
 
 pub fn expand_slice_placeholders_with_renumbering_test() {
-  let sql = "SELECT * FROM users WHERE name = $1 AND id IN ($2) AND status = $3"
-  let result = runtime.expand_slice_placeholders(sql, [#(2, 3)], 3, "$")
+  let sql =
+    "SELECT * FROM users WHERE name = __sqlode_param_1__"
+    <> " AND id IN (__sqlode_slice_2__)"
+    <> " AND status = __sqlode_param_3__"
+  let result =
+    runtime.expand_slice_placeholders(sql, [#(2, 3)], 3, runtime.DollarNumbered)
   result
   |> should.equal(
     "SELECT * FROM users WHERE name = $1 AND id IN ($2, $3, $4) AND status = $5",
@@ -304,27 +311,39 @@ pub fn expand_slice_placeholders_with_renumbering_test() {
 }
 
 pub fn expand_slice_placeholders_sqlite_test() {
-  let sql = "SELECT id, name FROM authors WHERE id IN (?1)"
-  let result = runtime.expand_slice_placeholders(sql, [#(1, 2)], 1, "?")
+  let sql = "SELECT id, name FROM authors WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    runtime.expand_slice_placeholders(
+      sql,
+      [#(1, 2)],
+      1,
+      runtime.QuestionNumbered,
+    )
   result
   |> should.equal("SELECT id, name FROM authors WHERE id IN (?1, ?2)")
 }
 
 pub fn expand_slice_placeholders_no_slices_test() {
-  let sql = "SELECT * FROM users WHERE id = $1"
-  let result = runtime.expand_slice_placeholders(sql, [], 1, "$")
+  let sql = "SELECT * FROM users WHERE id = __sqlode_param_1__"
+  let result =
+    runtime.expand_slice_placeholders(sql, [], 1, runtime.DollarNumbered)
   result |> should.equal("SELECT * FROM users WHERE id = $1")
 }
 
 pub fn expand_slice_placeholders_empty_slice_test() {
-  let sql = "SELECT * FROM users WHERE id IN ($1)"
-  let result = runtime.expand_slice_placeholders(sql, [#(1, 0)], 1, "$")
+  let sql = "SELECT * FROM users WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    runtime.expand_slice_placeholders(sql, [#(1, 0)], 1, runtime.DollarNumbered)
   result |> should.equal("SELECT * FROM users WHERE id IN (NULL)")
 }
 
 pub fn expand_slice_placeholders_empty_slice_with_other_params_test() {
-  let sql = "SELECT * FROM users WHERE name = $1 AND id IN ($2) AND status = $3"
-  let result = runtime.expand_slice_placeholders(sql, [#(2, 0)], 3, "$")
+  let sql =
+    "SELECT * FROM users WHERE name = __sqlode_param_1__"
+    <> " AND id IN (__sqlode_slice_2__)"
+    <> " AND status = __sqlode_param_3__"
+  let result =
+    runtime.expand_slice_placeholders(sql, [#(2, 0)], 3, runtime.DollarNumbered)
   result
   |> should.equal(
     "SELECT * FROM users WHERE name = $1 AND id IN (NULL) AND status = $2",
@@ -332,8 +351,14 @@ pub fn expand_slice_placeholders_empty_slice_with_other_params_test() {
 }
 
 pub fn expand_slice_placeholders_empty_slice_sqlite_test() {
-  let sql = "SELECT * FROM users WHERE id IN (?1)"
-  let result = runtime.expand_slice_placeholders(sql, [#(1, 0)], 1, "?")
+  let sql = "SELECT * FROM users WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    runtime.expand_slice_placeholders(
+      sql,
+      [#(1, 0)],
+      1,
+      runtime.QuestionNumbered,
+    )
   result |> should.equal("SELECT * FROM users WHERE id IN (NULL)")
 }
 

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -86,7 +86,7 @@ pub fn expand_sqlc_arg_macro_test() {
   query.macros
   |> should.equal([model.MacroArg(index: 1, name: "author_name")])
   string.contains(query.sql, "sqlode.arg") |> should.be_false()
-  string.contains(query.sql, "$1") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_1__") |> should.be_true()
 }
 
 pub fn expand_sqlc_narg_macro_test() {
@@ -120,7 +120,7 @@ pub fn expand_sqlc_arg_mysql_test() {
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
-  string.contains(query.sql, "?") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_1__") |> should.be_true()
 }
 
 // Quoted macro name tests
@@ -139,7 +139,7 @@ pub fn expand_sqlc_arg_single_quoted_test() {
   query.macros
   |> should.equal([model.MacroArg(index: 1, name: "author_name")])
   string.contains(query.sql, "sqlode.arg") |> should.be_false()
-  string.contains(query.sql, "$1") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_1__") |> should.be_true()
 }
 
 pub fn expand_sqlc_arg_double_quoted_test() {
@@ -205,7 +205,7 @@ pub fn expand_at_name_postgresql_test() {
   query.macros
   |> should.equal([model.MacroArg(index: 1, name: "author_name")])
   string.contains(query.sql, "@author_name") |> should.be_false()
-  string.contains(query.sql, "$1") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_1__") |> should.be_true()
 }
 
 pub fn expand_at_name_sqlite_test() {
@@ -222,7 +222,7 @@ pub fn expand_at_name_sqlite_test() {
   query.macros
   |> should.equal([model.MacroArg(index: 1, name: "author_name")])
   string.contains(query.sql, "@author_name") |> should.be_false()
-  string.contains(query.sql, "?1") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_1__") |> should.be_true()
 }
 
 pub fn expand_multiple_at_names_test() {
@@ -241,8 +241,8 @@ pub fn expand_multiple_at_names_test() {
     model.MacroArg(index: 1, name: "new_bio"),
     model.MacroArg(index: 2, name: "author_id"),
   ])
-  string.contains(query.sql, "$1") |> should.be_true()
-  string.contains(query.sql, "$2") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_1__") |> should.be_true()
+  string.contains(query.sql, "__sqlode_param_2__") |> should.be_true()
 }
 
 pub fn expand_at_name_mixed_with_sqlc_arg_test() {

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -59,13 +59,13 @@ pub fn prepare_no_slices_test() {
   let query =
     runtime.RawQuery(
       name: "GetUser",
-      sql: "SELECT * FROM users WHERE id = $1",
+      sql: "SELECT * FROM users WHERE id = __sqlode_param_1__",
       command: runtime.QueryOne,
       param_count: 1,
       encode: fn(_) { [runtime.int(42)] },
       slice_info: fn(_) { [] },
     )
-  let #(sql, values) = runtime.prepare(query, Nil, "$")
+  let #(sql, values) = runtime.prepare(query, Nil, runtime.DollarNumbered)
   sql |> should.equal("SELECT * FROM users WHERE id = $1")
   values |> should.equal([runtime.SqlInt(42)])
 }
@@ -74,13 +74,14 @@ pub fn prepare_with_slices_test() {
   let query =
     runtime.RawQuery(
       name: "GetByIds",
-      sql: "SELECT * FROM users WHERE id IN ($1)",
+      sql: "SELECT * FROM users WHERE id IN (__sqlode_slice_1__)",
       command: runtime.QueryMany,
       param_count: 1,
       encode: fn(ids) { list.map(ids, runtime.int) },
       slice_info: fn(ids) { [#(1, list.length(ids))] },
     )
-  let #(sql, values) = runtime.prepare(query, [10, 20, 30], "$")
+  let #(sql, values) =
+    runtime.prepare(query, [10, 20, 30], runtime.DollarNumbered)
   sql |> should.equal("SELECT * FROM users WHERE id IN ($1, $2, $3)")
   values
   |> should.equal([runtime.SqlInt(10), runtime.SqlInt(20), runtime.SqlInt(30)])
@@ -90,18 +91,17 @@ pub fn prepare_mixed_params_test() {
   let query =
     runtime.RawQuery(
       name: "GetByNameAndIds",
-      sql: "SELECT * FROM users WHERE name = $1 AND id IN ($2)",
+      sql: "SELECT * FROM users WHERE name = __sqlode_param_1__"
+        <> " AND id IN (__sqlode_slice_2__)",
       command: runtime.QueryMany,
       param_count: 2,
       encode: fn(p: #(String, List(Int))) {
-        list.flatten([
-          [runtime.string(p.0)],
-          list.map(p.1, runtime.int),
-        ])
+        list.flatten([[runtime.string(p.0)], list.map(p.1, runtime.int)])
       },
       slice_info: fn(p: #(String, List(Int))) { [#(2, list.length(p.1))] },
     )
-  let #(sql, values) = runtime.prepare(query, #("Alice", [1, 2]), "$")
+  let #(sql, values) =
+    runtime.prepare(query, #("Alice", [1, 2]), runtime.DollarNumbered)
   sql
   |> should.equal("SELECT * FROM users WHERE name = $1 AND id IN ($2, $3)")
   values
@@ -110,4 +110,86 @@ pub fn prepare_mixed_params_test() {
     runtime.SqlInt(1),
     runtime.SqlInt(2),
   ])
+}
+
+// Regression tests for Issue #360 — marker-based slice expansion
+
+pub fn prepare_mysql_slice_expands_to_positional_test() {
+  let query =
+    runtime.RawQuery(
+      name: "GetByIds",
+      sql: "SELECT * FROM users WHERE id IN (__sqlode_slice_1__)",
+      command: runtime.QueryMany,
+      param_count: 1,
+      encode: fn(ids) { list.map(ids, runtime.int) },
+      slice_info: fn(ids) { [#(1, list.length(ids))] },
+    )
+  let #(sql, _values) =
+    runtime.prepare(query, [10, 20, 30], runtime.QuestionPositional)
+  sql |> should.equal("SELECT * FROM users WHERE id IN (?, ?, ?)")
+}
+
+pub fn prepare_mysql_mixed_params_and_slice_test() {
+  let query =
+    runtime.RawQuery(
+      name: "GetByNameAndIds",
+      sql: "SELECT * FROM users WHERE name = __sqlode_param_1__"
+        <> " AND id IN (__sqlode_slice_2__)"
+        <> " AND status = __sqlode_param_3__",
+      command: runtime.QueryMany,
+      param_count: 3,
+      encode: fn(_) { [] },
+      slice_info: fn(_) { [#(2, 2)] },
+    )
+  let #(sql, _values) = runtime.prepare(query, Nil, runtime.QuestionPositional)
+  sql
+  |> should.equal(
+    "SELECT * FROM users WHERE name = ? AND id IN (?, ?) AND status = ?",
+  )
+}
+
+pub fn expand_slice_placeholders_preserves_string_literal_with_placeholder_text_test() {
+  // Even when a string literal in the SQL looks like a placeholder (`$1`),
+  // the marker-based expansion must not touch it.
+  let sql =
+    "SELECT '$1 is a placeholder' AS note, id FROM t WHERE id = __sqlode_param_1__"
+  let result =
+    runtime.expand_slice_placeholders(sql, [], 1, runtime.DollarNumbered)
+  result
+  |> should.equal(
+    "SELECT '$1 is a placeholder' AS note, id FROM t WHERE id = $1",
+  )
+}
+
+pub fn expand_slice_placeholders_preserves_comment_with_placeholder_text_test() {
+  let sql =
+    "SELECT id FROM t"
+    <> " /* $1 is the placeholder used below */"
+    <> " WHERE id = __sqlode_param_1__"
+  let result =
+    runtime.expand_slice_placeholders(sql, [], 1, runtime.DollarNumbered)
+  result
+  |> should.equal(
+    "SELECT id FROM t"
+    <> " /* $1 is the placeholder used below */"
+    <> " WHERE id = $1",
+  )
+}
+
+pub fn expand_slice_placeholders_mysql_with_placeholder_literal_test() {
+  // MySQL uses bare `?`. Text like `?` inside a string literal must be
+  // preserved even while slice markers are expanded.
+  let sql =
+    "SELECT '? is a placeholder' AS note, id FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    runtime.expand_slice_placeholders(
+      sql,
+      [#(1, 3)],
+      1,
+      runtime.QuestionPositional,
+    )
+  result
+  |> should.equal(
+    "SELECT '? is a placeholder' AS note, id FROM t WHERE id IN (?, ?, ?)",
+  )
 }


### PR DESCRIPTION
## Summary
Replace the rule-by-rule `string.replace(prefix<>index, ...)` slice expansion in `runtime.expand_slice_placeholders` with a marker-driven pipeline so that MySQL actually renumbers `sqlode.slice`, and placeholder-like text inside string literals or comments is never rewritten. Closes #360.

## Changes
- **Generator** (`src/sqlode/query_parser.gleam`): `sqlode.arg` / `sqlode.narg` / `sqlode.slice` and `@name` now emit engine-agnostic markers `__sqlode_param_N__` / `__sqlode_slice_N__` that encode the 1-based parameter index. `count_parameters_from_tokens` reads the index from markers and falls back to the existing per-engine counting for raw `$N` / `?N` / `?` that users may write by hand.
- **Lexer** (`src/sqlode/lexer.gleam`): `classify_word` recognises the markers and returns `Placeholder` tokens so every later re-tokenisation (notably inside `query_analyzer`) continues to treat them as parameter positions rather than identifiers.
- **Analyzer** (`src/sqlode/query_analyzer/placeholder.gleam`): `placeholder_index_for_token` extracts the index embedded in a marker before falling back to its engine-specific parsing.
- **Runtime** (`src/sqlode/runtime.gleam`): introduce a public `PlaceholderStyle` type (`DollarNumbered` / `QuestionNumbered` / `QuestionPositional`). `prepare` and `expand_slice_placeholders` now take `style: PlaceholderStyle` instead of a `prefix: String`, which disambiguates SQLite `?1, ?2, ...` from MySQL bare `?, ?, ...`. `expand_slice_placeholders` iterates 1..total_params, renders each marker into the engine's placeholder (with sequential numbering across slice expansions), and substitutes markers back with `string.replace`. No other SQL text is inspected, so literals and comments are untouched.
- **Adapter codegen** (`src/sqlode/codegen/adapter.gleam`): always call `runtime.expand_slice_placeholders(q.sql, [...], total, style)` and use the resulting `sql` variable, instead of conditionally falling through to `q.sql` when no slices are present — markers must be substituted on every call.
- **Tests**: update existing `prepare` / `expand_slice_placeholders` tests and parser assertions for the new marker form, and add regression coverage for MySQL slice expansion (`? + ?, ?, ? + ?`), mixed MySQL params and a slice, and placeholder-like text inside a string literal / block comment being preserved across expansion.

## Design Decisions
- **Markers for every placeholder, not only slices.** Using markers universally keeps the runtime walker trivial (`string.replace` per marker), avoids re-implementing a token-aware scanner inside `runtime.gleam`, and makes the expansion rules identical across engines. Because markers are uncommon strings that are never emitted inside string literals or comments, the well-known false-positive class from the old substring-replace approach disappears.
- **`PlaceholderStyle` instead of a string prefix.** SQLite (`?1`) and MySQL (bare `?`) both used `"?"` as prefix, which is why the old code could not distinguish them. A small explicit enum documents intent, keeps rendering logic centralised, and leaves room for future dialects without more string conventions.
- **Lexer-level marker recognition.** The markers have to survive round-tripping through `lexer.tokenize` because the analyzer re-tokenises the post-expansion SQL. Classifying `__sqlode_param_N__` / `__sqlode_slice_N__` as `Placeholder` tokens was the smallest change that kept existing `find_equality_patterns` / `find_in_patterns` etc. working unchanged.
- **Always call `expand_slice_placeholders`.** Every generated query now contains markers regardless of whether the parameters include a slice, so the adapter must always expand them. The empty-slices path is a no-op fold over `[]` and renders the SQL in a single pass.

## Limitations
- This is a breaking change to the runtime API: `prepare` and `expand_slice_placeholders` now take `PlaceholderStyle` rather than `prefix: String`. Users must regenerate their adapters after upgrading so the generated SQL (markers) matches the new runtime expansion.
- Adapter code paths that used to branch on `has_slices` now always compute `sql` via expansion. The overhead is a bounded `int.range`/fold over `total_params`; still cheaper than re-implementing token-aware scanning in the runtime, but it is no longer zero-cost for parameterless queries.
- Issue #359 (storing the placeholder style on `RawQuery` so `prepare` does not need a manual style argument) is complementary to this change and left as follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized placeholder handling across PostgreSQL, MySQL, and SQLite through a unified marker-based system for consistent query generation and improved maintainability.
  * Enhanced internal query expansion mechanism for better placeholder and slice parameter management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->