### PR TITLE
feat(runtime): carry placeholder dialect on RawQuery

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -1014,7 +1014,7 @@ fn render_list_param_value_expr(
 
 fn render_slice_expansion_line(
   params: List(model.QueryParam),
-  style_expr: String,
+  _style_expr: String,
 ) -> String {
   let slice_entries =
     params
@@ -1034,9 +1034,7 @@ fn render_slice_expansion_line(
   <> slice_entries
   <> "], "
   <> int.to_string(total_params)
-  <> ", "
-  <> style_expr
-  <> ")"
+  <> ", q.placeholder_style)"
 }
 
 fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -17,10 +17,16 @@ pub fn render(
   let emit_sql_as_comment = gleam.emit_sql_as_comment
 
   let has_slices = common.queries_have_slices(queries)
+  let style_expr = engine_placeholder_style_expr(engine)
 
   let query_functions =
     queries
-    |> list.map(render_query_function(naming_ctx, _, emit_sql_as_comment))
+    |> list.map(render_query_function(
+      naming_ctx,
+      _,
+      emit_sql_as_comment,
+      style_expr,
+    ))
     |> string.join("\n\n")
 
   let all_items = case queries {
@@ -69,10 +75,19 @@ pub fn render(
   )
 }
 
+fn engine_placeholder_style_expr(engine: model.Engine) -> String {
+  case engine {
+    model.PostgreSQL -> "runtime.DollarNumbered"
+    model.MySQL -> "runtime.QuestionPositional"
+    model.SQLite -> "runtime.QuestionNumbered"
+  }
+}
+
 fn render_query_function(
   naming_ctx: naming.NamingContext,
   query: model.AnalyzedQuery,
   emit_sql_as_comment: Bool,
+  style_expr: String,
 ) -> String {
   let has_params = !list.is_empty(query.params)
 
@@ -128,6 +143,7 @@ fn render_query_function(
           <> model.query_command_to_string(query.base.command)
           <> ",",
         "    param_count: " <> int.to_string(query.base.param_count) <> ",",
+        "    placeholder_style: " <> style_expr <> ",",
         encode_line,
         slice_info_line,
         "  )",

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -32,20 +32,6 @@ pub type QueryInfo {
   QueryInfo(name: String, sql: String, command: QueryCommand, param_count: Int)
 }
 
-/// A typed raw query descriptor that bundles SQL metadata with its parameter
-/// encoder.  The type parameter `p` represents the parameter type for this
-/// query, which ties the query to its expected parameters at the type level.
-pub type RawQuery(p) {
-  RawQuery(
-    name: String,
-    sql: String,
-    command: QueryCommand,
-    param_count: Int,
-    encode: fn(p) -> List(Value),
-    slice_info: fn(p) -> List(#(Int, Int)),
-  )
-}
-
 /// Placeholder style used by the target database driver.
 ///
 /// - `DollarNumbered` — PostgreSQL style: `$1`, `$2`, ...
@@ -57,19 +43,42 @@ pub type PlaceholderStyle {
   QuestionPositional
 }
 
+/// A typed raw query descriptor that bundles SQL metadata with its parameter
+/// encoder.  The type parameter `p` represents the parameter type for this
+/// query, which ties the query to its expected parameters at the type level.
+///
+/// `placeholder_style` records the dialect the generator emitted the SQL
+/// for, so callers of `prepare` do not need to know or repeat the engine
+/// choice: they pass the query and parameters and get back a final SQL
+/// string already rendered for the target driver.
+pub type RawQuery(p) {
+  RawQuery(
+    name: String,
+    sql: String,
+    command: QueryCommand,
+    param_count: Int,
+    placeholder_style: PlaceholderStyle,
+    encode: fn(p) -> List(Value),
+    slice_info: fn(p) -> List(#(Int, Int)),
+  )
+}
+
 /// Prepare a raw query for execution by encoding parameters and expanding
-/// the engine-agnostic placeholder markers that the generator emits.
+/// the engine-agnostic placeholder markers that the generator emits. The
+/// target placeholder dialect is read from `query.placeholder_style`, so
+/// callers no longer need to pass a separate style argument.
 /// Returns the final SQL string and the flattened parameter values, ready
 /// to be passed to a database driver.
-pub fn prepare(
-  query: RawQuery(p),
-  params: p,
-  style: PlaceholderStyle,
-) -> #(String, List(Value)) {
+pub fn prepare(query: RawQuery(p), params: p) -> #(String, List(Value)) {
   let values = query.encode(params)
   let slices = query.slice_info(params)
   let sql =
-    expand_slice_placeholders(query.sql, slices, query.param_count, style)
+    expand_slice_placeholders(
+      query.sql,
+      slices,
+      query.param_count,
+      query.placeholder_style,
+    )
   #(sql, values)
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -38,6 +38,8 @@ pub fn render_queries_module_test() {
   |> should.be_true()
   string.contains(rendered, "command: runtime.QueryOne")
   |> should.be_true()
+  string.contains(rendered, "placeholder_style: runtime.DollarNumbered,")
+  |> should.be_true()
   string.contains(rendered, "encode: params.get_author_values,")
   |> should.be_true()
   string.contains(rendered, "slice_info: fn(_) { [] },")

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -62,10 +62,11 @@ pub fn prepare_no_slices_test() {
       sql: "SELECT * FROM users WHERE id = __sqlode_param_1__",
       command: runtime.QueryOne,
       param_count: 1,
+      placeholder_style: runtime.DollarNumbered,
       encode: fn(_) { [runtime.int(42)] },
       slice_info: fn(_) { [] },
     )
-  let #(sql, values) = runtime.prepare(query, Nil, runtime.DollarNumbered)
+  let #(sql, values) = runtime.prepare(query, Nil)
   sql |> should.equal("SELECT * FROM users WHERE id = $1")
   values |> should.equal([runtime.SqlInt(42)])
 }
@@ -77,11 +78,11 @@ pub fn prepare_with_slices_test() {
       sql: "SELECT * FROM users WHERE id IN (__sqlode_slice_1__)",
       command: runtime.QueryMany,
       param_count: 1,
+      placeholder_style: runtime.DollarNumbered,
       encode: fn(ids) { list.map(ids, runtime.int) },
       slice_info: fn(ids) { [#(1, list.length(ids))] },
     )
-  let #(sql, values) =
-    runtime.prepare(query, [10, 20, 30], runtime.DollarNumbered)
+  let #(sql, values) = runtime.prepare(query, [10, 20, 30])
   sql |> should.equal("SELECT * FROM users WHERE id IN ($1, $2, $3)")
   values
   |> should.equal([runtime.SqlInt(10), runtime.SqlInt(20), runtime.SqlInt(30)])
@@ -95,13 +96,13 @@ pub fn prepare_mixed_params_test() {
         <> " AND id IN (__sqlode_slice_2__)",
       command: runtime.QueryMany,
       param_count: 2,
+      placeholder_style: runtime.DollarNumbered,
       encode: fn(p: #(String, List(Int))) {
         list.flatten([[runtime.string(p.0)], list.map(p.1, runtime.int)])
       },
       slice_info: fn(p: #(String, List(Int))) { [#(2, list.length(p.1))] },
     )
-  let #(sql, values) =
-    runtime.prepare(query, #("Alice", [1, 2]), runtime.DollarNumbered)
+  let #(sql, values) = runtime.prepare(query, #("Alice", [1, 2]))
   sql
   |> should.equal("SELECT * FROM users WHERE name = $1 AND id IN ($2, $3)")
   values
@@ -121,11 +122,11 @@ pub fn prepare_mysql_slice_expands_to_positional_test() {
       sql: "SELECT * FROM users WHERE id IN (__sqlode_slice_1__)",
       command: runtime.QueryMany,
       param_count: 1,
+      placeholder_style: runtime.QuestionPositional,
       encode: fn(ids) { list.map(ids, runtime.int) },
       slice_info: fn(ids) { [#(1, list.length(ids))] },
     )
-  let #(sql, _values) =
-    runtime.prepare(query, [10, 20, 30], runtime.QuestionPositional)
+  let #(sql, _values) = runtime.prepare(query, [10, 20, 30])
   sql |> should.equal("SELECT * FROM users WHERE id IN (?, ?, ?)")
 }
 
@@ -138,14 +139,32 @@ pub fn prepare_mysql_mixed_params_and_slice_test() {
         <> " AND status = __sqlode_param_3__",
       command: runtime.QueryMany,
       param_count: 3,
+      placeholder_style: runtime.QuestionPositional,
       encode: fn(_) { [] },
       slice_info: fn(_) { [#(2, 2)] },
     )
-  let #(sql, _values) = runtime.prepare(query, Nil, runtime.QuestionPositional)
+  let #(sql, _values) = runtime.prepare(query, Nil)
   sql
   |> should.equal(
     "SELECT * FROM users WHERE name = ? AND id IN (?, ?) AND status = ?",
   )
+}
+
+// Issue #359 — placeholder style carried by RawQuery
+
+pub fn prepare_sqlite_reads_style_from_raw_query_test() {
+  let query =
+    runtime.RawQuery(
+      name: "GetById",
+      sql: "SELECT * FROM users WHERE id = __sqlode_param_1__",
+      command: runtime.QueryOne,
+      param_count: 1,
+      placeholder_style: runtime.QuestionNumbered,
+      encode: fn(_) { [runtime.int(1)] },
+      slice_info: fn(_) { [] },
+    )
+  let #(sql, _values) = runtime.prepare(query, Nil)
+  sql |> should.equal("SELECT * FROM users WHERE id = ?1")
 }
 
 pub fn expand_slice_placeholders_preserves_string_literal_with_placeholder_text_test() {


### PR DESCRIPTION
## Summary
Record the target placeholder dialect on `RawQuery` so `runtime.prepare(query, params)` no longer needs a manual `prefix` / style argument. Callers of the raw runtime stop having to remember whether the query was generated for `$N`, `?N`, or bare `?`, and the generated module is self-describing for the target driver. Closes #359.

## Changes
- `src/sqlode/runtime.gleam`:
  - Add `placeholder_style: PlaceholderStyle` to `RawQuery` so the dialect travels with the query descriptor.
  - Simplify `prepare(query, params)` to read the style from `query.placeholder_style`.
  - Keep the public low-level `expand_slice_placeholders(..., style)` unchanged as the Issue-permitted escape hatch for callers that do not hold a `RawQuery`.
- `src/sqlode/codegen/queries.gleam`: pick the style from the block's engine (`DollarNumbered` for PostgreSQL, `QuestionNumbered` for SQLite, `QuestionPositional` for MySQL) and emit it alongside the other `RawQuery` fields.
- `src/sqlode/codegen/adapter.gleam`: render `runtime.expand_slice_placeholders(q.sql, [...], N, q.placeholder_style)`. The adapter pipeline no longer threads a per-engine style expression through `render_slice_expansion_line`, so the style now has exactly one source of truth.
- `test/runtime_test.gleam`: update existing `prepare` tests to set `placeholder_style` on the `RawQuery` literal and invoke `prepare(query, params)`. Add a SQLite-specific test that confirms the style on the query alone drives the final placeholder form (`?1`).
- `test/codegen_test.gleam`: snapshot-assert that the emitted `RawQuery` literal now contains `placeholder_style: runtime.DollarNumbered,` for PostgreSQL generation.

## Design Decisions
- **Field on `RawQuery`, not a new helper.** The generator already knows the engine at generation time, so storing the dialect on the query itself is the obvious place. Any alternative that re-derives the dialect at call-time (e.g. threading an engine value through a helper) would just move the same footgun.
- **`prepare` drops the argument rather than defaulting it.** Leaving an optional argument would let callers override the style and silently re-introduce the bug the Issue is fixing. Making the signature `prepare(query, params)` makes the dialect choice authoritative.
- **`expand_slice_placeholders` keeps `style`.** The Issue explicitly allows a low-level escape hatch. The function is still useful for callers that manipulate SQL without a full `RawQuery` (tests, future custom runners), so it stays public and keeps taking a `PlaceholderStyle` argument.
- **Adapter reads from `q.placeholder_style`.** Native adapters still call `expand_slice_placeholders` directly (they do their own parameter encoding), so they need the style at the call site. Reading it from `q` instead of hard-coding the engine in codegen removes a source of drift between the `queries` and adapter modules.

## Limitations
- This is a breaking change to the runtime API: `RawQuery` now has a 7th field and `prepare` takes two arguments instead of three. Users must regenerate their adapters after upgrading.
- Issue #299 (native adapters consuming `RawQuery.encode` / `runtime.prepare` instead of re-encoding parameters per-driver) is a complementary next step that would remove the remaining direct `expand_slice_placeholders` call from generated adapters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified query preparation API—placeholder style is now automatically determined based on the target database engine and embedded in query objects, eliminating manual style specification during prepare operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->