### PR TITLE
feat(cli): auto-discover sqlc/sqlode config filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ sqlode follows sqlc conventions, so most SQL files work without changes. Key dif
 | | sqlc | sqlode |
 |---|---|---|
 | Install | Standalone binary (`brew install sqlc`) | Escript or `gleam add sqlode` |
-| Config | `sqlc.yaml` / `sqlc.json` | `sqlode.yaml` (v2 format only) |
+| Config | `sqlc.yaml` / `sqlc.json` | `sqlode.yaml` (v2 format only), also accepts `sqlc.yaml` / `sqlc.yml` / `sqlc.json` on autodiscovery |
 | Generate | `sqlc generate` | `sqlode generate` |
 | Init | `sqlc init` | `sqlode init` |
 | Vet/Verify | `sqlc vet`, `sqlc verify` | Not supported |
@@ -593,7 +593,7 @@ sqlode follows sqlc conventions, so most SQL files work without changes. Key dif
 ### Migration steps
 
 1. Install sqlode (see [Install](#install) above).
-2. Copy your `sqlc.yaml` to `sqlode.yaml`. Keep `version: "2"` and the `sql` blocks. Replace the `gen` section:
+2. Keep your existing `sqlc.yaml` / `sqlc.yml` / `sqlc.json` in place — `sqlode generate` auto-discovers them in the current directory when `--config` is not passed. (The search order is `sqlode.yaml`, `sqlode.yml`, `sqlc.yaml`, `sqlc.yml`, `sqlc.json`; if more than one exists, pass `--config=<path>` to pick explicitly.) If you prefer a dedicated file, copy the config to `sqlode.yaml`. Either way keep `version: "2"` and the `sql` blocks. Replace the `gen` section:
 
    ```yaml
    gen:

--- a/spec/generate_spec.sh
+++ b/spec/generate_spec.sh
@@ -10,6 +10,7 @@ Describe 'sqlode generate'
       The status should be success
       The output should include 'generate'
       The output should include 'config'
+      The output should include 'auto-discover'
     End
   End
 
@@ -38,6 +39,107 @@ Describe 'sqlode generate'
       The contents of file "$TEST_OUTPUT_DIR/db/queries.gleam" should include 'pub fn list_authors() -> runtime.RawQuery(Nil) {'
       The contents of file "$TEST_OUTPUT_DIR/db/models.gleam" should include 'pub type GetAuthorRow {'
       The contents of file "$TEST_OUTPUT_DIR/db/models.gleam" should include 'pub type ListAuthorsRow {'
+    End
+  End
+
+  Describe 'config autodiscovery'
+    AUTODISCOVER_DIR="$PROJECT_ROOT/test_output/autodiscover"
+
+    setup_autodiscover_dir() {
+      rm -rf "$AUTODISCOVER_DIR"
+      mkdir -p "$AUTODISCOVER_DIR"
+    }
+
+    write_config() {
+      name="$1"
+      cat > "$AUTODISCOVER_DIR/$name" <<YAML
+version: "2"
+sql:
+  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
+    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        out: "$AUTODISCOVER_DIR/src/db"
+        runtime: "raw"
+YAML
+    }
+
+    generate_in_dir() {
+      cd "$AUTODISCOVER_DIR" && gleam run --module=sqlode -- generate 2>&1
+    }
+
+    generate_from_autodiscover_dir() {
+      cd "$PROJECT_ROOT" && gleam export erlang-shipment >/dev/null 2>&1
+      cd "$AUTODISCOVER_DIR" && "$PROJECT_ROOT/build/erlang-shipment/entrypoint.sh" run generate 2>&1
+    }
+
+    cleanup_autodiscover_dir() {
+      rm -rf "$AUTODISCOVER_DIR"
+    }
+
+    It 'fails with a helpful message when no config file exists'
+      setup_autodiscover_dir
+      When call generate_from_autodiscover_dir
+      The status should be failure
+      The output should include 'No config file found'
+      The output should include 'sqlode.yaml'
+      The output should include 'sqlc.json'
+      cleanup_autodiscover_dir
+    End
+
+    It 'picks up sqlode.yaml without --config'
+      setup_autodiscover_dir
+      write_config sqlode.yaml
+      When call generate_from_autodiscover_dir
+      The status should be success
+      The output should include 'Loading config from: sqlode.yaml'
+      The output should include 'Successfully generated'
+      cleanup_autodiscover_dir
+    End
+
+    It 'falls back to sqlc.yaml when sqlode.yaml is absent'
+      setup_autodiscover_dir
+      write_config sqlc.yaml
+      When call generate_from_autodiscover_dir
+      The status should be success
+      The output should include 'Loading config from: sqlc.yaml'
+      The output should include 'Successfully generated'
+      cleanup_autodiscover_dir
+    End
+
+    It 'falls back to sqlc.json when only JSON is present'
+      setup_autodiscover_dir
+      cat > "$AUTODISCOVER_DIR/sqlc.json" <<JSON
+{
+  "version": "2",
+  "sql": [
+    {
+      "schema": "$PROJECT_ROOT/test/fixtures/schema.sql",
+      "queries": "$PROJECT_ROOT/test/fixtures/query.sql",
+      "engine": "postgresql",
+      "gen": {"gleam": {"out": "$AUTODISCOVER_DIR/src/db", "runtime": "raw"}}
+    }
+  ]
+}
+JSON
+      When call generate_from_autodiscover_dir
+      The status should be success
+      The output should include 'Loading config from: sqlc.json'
+      The output should include 'Successfully generated'
+      cleanup_autodiscover_dir
+    End
+
+    It 'refuses to pick when multiple candidates exist'
+      setup_autodiscover_dir
+      write_config sqlode.yaml
+      write_config sqlc.yaml
+      When call generate_from_autodiscover_dir
+      The status should be failure
+      The output should include 'Multiple config files found'
+      The output should include 'sqlode.yaml'
+      The output should include 'sqlc.yaml'
+      cleanup_autodiscover_dir
     End
   End
 End

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -3,6 +3,7 @@ import gleam/int
 import gleam/io
 import gleam/list
 import gleam/result
+import gleam/string
 import glint
 import simplifile
 import sqlode/generate
@@ -22,31 +23,47 @@ fn global_help_text() -> String {
   "Generate type-safe Gleam code from SQL files using sqlc-style config.
 
 Usage:
-  sqlode generate [--config=./sqlode.yaml]
+  sqlode generate [--config=<path>]
   sqlode init [--output=./sqlode.yaml] [--engine=postgresql|sqlite|mysql] [--runtime=raw|native]
   sqlode version
 
+Without --config, generate auto-discovers sqlode.yaml, sqlode.yml,
+sqlc.yaml, sqlc.yml, or sqlc.json in the current directory.
+
 Run `sqlode <command> --help` for details on each command."
 }
+
+/// Candidate config filenames searched, in order, when --config is not
+/// given. The first match wins; if two or more files exist the command
+/// fails with a message listing them so the user picks explicitly.
+const config_candidates = [
+  "sqlode.yaml", "sqlode.yml", "sqlc.yaml", "sqlc.yml", "sqlc.json",
+]
 
 fn generate_command() -> glint.Command(Nil) {
   {
     use config_path <- glint.flag(
       glint.string_flag("config")
-      |> glint.flag_default("./sqlode.yaml")
-      |> glint.flag_help("Path to config file (default: ./sqlode.yaml)"),
+      |> glint.flag_default("")
+      |> glint.flag_help(
+        "Path to config file. Default: auto-discover sqlode.yaml, sqlode.yml, sqlc.yaml, sqlc.yml, or sqlc.json in the current directory.",
+      ),
     )
 
     glint.command_help(
-      "Read sqlode.yaml, parse SQL schema and queries, emit Gleam code.
+      "Parse SQL schema and queries, emit Gleam code.
+
+Without --config, generate auto-discovers sqlode.yaml, sqlode.yml,
+sqlc.yaml, sqlc.yml, or sqlc.json in the current directory and fails
+if more than one candidate exists.
 
 Examples:
   sqlode generate
   sqlode generate --config=./custom.yaml",
       fn() {
         glint.command(fn(_named_args, _args, flags) {
-          let config_path = config_path(flags) |> result.unwrap("./sqlode.yaml")
-          run_generate(config_path)
+          let flag_value = config_path(flags) |> result.unwrap("")
+          run_generate(flag_value)
         })
       },
     )
@@ -103,23 +120,64 @@ fn version_command() -> glint.Command(Nil) {
   })
 }
 
-fn run_generate(config_path: String) -> Nil {
-  io.println("Loading config from: " <> config_path)
-
-  case generate.run(config_path) {
-    Ok(written) -> {
-      io.println("")
-      io.println(
-        "Successfully generated "
-        <> int.to_string(list.length(written))
-        <> " files",
-      )
-      list.each(written, fn(path) { io.println("  Generated: " <> path) })
-    }
-    Error(error) -> {
-      io.println_error("Error: " <> generate.error_to_string(error))
+fn run_generate(flag_value: String) -> Nil {
+  case resolve_config_path(flag_value) {
+    Error(message) -> {
+      io.println_error("Error: " <> message)
       halt(1)
     }
+    Ok(config_path) -> {
+      io.println("Loading config from: " <> config_path)
+
+      case generate.run(config_path) {
+        Ok(written) -> {
+          io.println("")
+          io.println(
+            "Successfully generated "
+            <> int.to_string(list.length(written))
+            <> " files",
+          )
+          list.each(written, fn(path) { io.println("  Generated: " <> path) })
+        }
+        Error(error) -> {
+          io.println_error("Error: " <> generate.error_to_string(error))
+          halt(1)
+        }
+      }
+    }
+  }
+}
+
+fn resolve_config_path(flag_value: String) -> Result(String, String) {
+  case flag_value {
+    "" -> autodiscover_config()
+    explicit -> Ok(explicit)
+  }
+}
+
+fn autodiscover_config() -> Result(String, String) {
+  let found =
+    list.filter(config_candidates, fn(path) {
+      case simplifile.is_file(path) {
+        Ok(True) -> True
+        _ -> False
+      }
+    })
+
+  case found {
+    [] ->
+      Error(
+        "No config file found. Looked for: "
+        <> string.join(config_candidates, ", ")
+        <> ". Create one with `sqlode init` or pass --config=<path>.",
+      )
+    [single] -> Ok(single)
+    multiple ->
+      Error(
+        "Multiple config files found: "
+        <> string.join(multiple, ", ")
+        <> ". Pick one explicitly with --config=<path>.",
+      )
   }
 }
 


### PR DESCRIPTION
## Summary
Drop the hardcoded `./sqlode.yaml` default on `sqlode generate --config`. When no `--config` is passed, search the current directory for `sqlode.yaml`, `sqlode.yml`, `sqlc.yaml`, `sqlc.yml`, or `sqlc.json` (in that order) and use the first match. This removes the rename-first step for sqlc users migrating to sqlode. Closes #357.

## Changes
- `src/sqlode/cli.gleam`: replace the `"./sqlode.yaml"` default on `--config` with an empty default that triggers autodiscovery. Add `resolve_config_path` / `autodiscover_config`, plus a `config_candidates` constant listing the search order. Refresh the global and per-command help text to describe the new behaviour.
- `src/sqlode/cli.gleam`: explicit `--config=<path>` is preserved as the authoritative override; passing it still bypasses the search entirely.
- `README.md`: update the sqlc migration steps to say the existing `sqlc.yaml` / `sqlc.yml` / `sqlc.json` is auto-discovered, with a pointer at `--config` when multiple candidates exist.
- `spec/generate_spec.sh`: add a `config autodiscovery` describe covering no-config, single `sqlode.yaml`, fallback to `sqlc.yaml`, `sqlc.json` acceptance, and the multiple-candidates error. Pin the presence of the `auto-discover` wording in `--help`.

## Design Decisions
- **Empty default instead of a magic string.** `glint.flag_default("")` + an `""` → autodiscover branch keeps the flag a plain string, avoids inventing a sentinel (`"auto"`, `"-"`) that could collide with a real path, and lets us fall through to the authoritative `--config` path untouched.
- **JSON support comes for free.** `yay.parse_string` accepts YAML 1.2 and JSON is a strict subset, so `sqlc.json` parses correctly with the existing loader. Adding a dedicated JSON branch would duplicate format handling without changing behaviour.
- **Fail fast on multiple candidates.** Silently picking one of several files is exactly the kind of surprise that made sqlc's migration path annoying in the first place. The error lists every candidate that exists so the fix is obvious (pass `--config=<path>` or delete the stale file).
- **Search only the current working directory.** Walking up directory trees would change what `sqlode generate` targets based on where the user happens to be, which is the same implicit-state problem sqlc contributors have complained about. Keeping the search flat matches the existing behaviour of `./sqlode.yaml`.

## Limitations
- The search is scoped to the current working directory. If a project wants to keep its config elsewhere (monorepo, nested package), `--config=<path>` remains the explicit answer.
- Only the filename is auto-discovered; the YAML / JSON schema is unchanged. Users still need to move the `gen.gleam` section into the shape sqlode expects, as documented in the Migration steps.
- Behaviour is only exercised via ShellSpec. The Gleam unit tests do not cover `cli.gleam` directly because the discovery logic depends on the working directory, which is better verified end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Config file autodiscovery now supports `sqlode.yaml`, `sqlode.yml`, `sqlc.yaml`, `sqlc.yml`, and `sqlc.json`. Explicit `--config` path required when multiple configs exist.

* **Tests**
  * Added autodiscovery test suite covering missing configs, successful loading, fallback precedence, and multiple config detection.

* **Documentation**
  * Updated migration guide with autodiscovery behavior and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->