### PR TITLE
feat(generate): add omit_unused_models option for slimmer model output

### DIFF
--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -119,7 +119,7 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
     gleam_node,
     [
       "out", "runtime", "type_mapping", "emit_sql_as_comment",
-      "emit_exact_table_names",
+      "emit_exact_table_names", "omit_unused_models",
     ],
     "sql.gen.gleam.",
   ))
@@ -160,6 +160,9 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
   let emit_exact_table_names =
     optional_bool(gleam_node, "emit_exact_table_names")
     |> option.unwrap(False)
+  let omit_unused_models =
+    optional_bool(gleam_node, "omit_unused_models")
+    |> option.unwrap(False)
 
   use overrides <- result.try(parse_overrides(node))
 
@@ -174,6 +177,7 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
       type_mapping:,
       emit_sql_as_comment:,
       emit_exact_table_names:,
+      omit_unused_models:,
     ),
     overrides:,
   ))

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -223,14 +223,18 @@ fn base_output_files(
   ]
 
   case has_models {
-    True ->
+    True -> {
+      let effective_catalog = case gleam.omit_unused_models {
+        True -> prune_catalog_to_used(catalog, analyzed)
+        False -> catalog
+      }
       list.append(files, [
         writer.GeneratedFile(
           directory: out,
           path: "models.gleam",
           content: models.render(
             naming_ctx,
-            catalog,
+            effective_catalog,
             analyzed,
             table_matches,
             gleam.type_mapping,
@@ -238,7 +242,93 @@ fn base_output_files(
           ),
         ),
       ])
+    }
     False -> files
+  }
+}
+
+/// Drop tables and enums from the catalog that no generated query
+/// actually references. A table is "used" when at least one analysed
+/// query names it as a `source_table` on a scalar result column, lists
+/// it via `EmbeddedResult`, or is carried by a `table_matches` alias
+/// (SELECT * on an exact table). An enum is "used" when one of the
+/// retained tables owns a column of that enum type, or when a query
+/// result column / parameter has that enum type.
+fn prune_catalog_to_used(
+  catalog: model.Catalog,
+  queries: List(model.AnalyzedQuery),
+) -> model.Catalog {
+  let referenced_tables = collect_referenced_tables(queries)
+
+  let retained_tables =
+    list.filter(catalog.tables, fn(t) {
+      list.contains(referenced_tables, t.name)
+    })
+
+  let referenced_enums = collect_referenced_enums(retained_tables, queries)
+  let retained_enums =
+    list.filter(catalog.enums, fn(e) { list.contains(referenced_enums, e.name) })
+
+  model.Catalog(tables: retained_tables, enums: retained_enums)
+}
+
+fn collect_referenced_tables(queries: List(model.AnalyzedQuery)) -> List(String) {
+  queries
+  |> list.flat_map(fn(query) {
+    list.flat_map(query.result_columns, fn(item) {
+      case item {
+        model.ScalarResult(col) ->
+          case col.source_table {
+            option.Some(name) -> [name]
+            option.None -> []
+          }
+        model.EmbeddedResult(embed) -> [embed.table_name]
+      }
+    })
+  })
+  |> list.unique
+}
+
+fn collect_referenced_enums(
+  retained_tables: List(model.Table),
+  queries: List(model.AnalyzedQuery),
+) -> List(String) {
+  let from_tables =
+    retained_tables
+    |> list.flat_map(fn(t) { t.columns })
+    |> list.filter_map(fn(c) { enum_name(c.scalar_type) })
+
+  let from_query_columns =
+    queries
+    |> list.flat_map(fn(q) {
+      list.flat_map(q.result_columns, fn(item) {
+        case item {
+          model.ScalarResult(col) ->
+            case enum_name(col.scalar_type) {
+              Ok(name) -> [name]
+              Error(Nil) -> []
+            }
+          model.EmbeddedResult(embed) ->
+            list.filter_map(embed.columns, fn(c) { enum_name(c.scalar_type) })
+        }
+      })
+    })
+
+  let from_query_params =
+    queries
+    |> list.flat_map(fn(q) {
+      list.filter_map(q.params, fn(p) { enum_name(p.scalar_type) })
+    })
+
+  list.append(from_tables, list.append(from_query_columns, from_query_params))
+  |> list.unique
+}
+
+fn enum_name(scalar_type: model.ScalarType) -> Result(String, Nil) {
+  case scalar_type {
+    model.EnumType(name) -> Ok(name)
+    model.ArrayType(inner) -> enum_name(inner)
+    _ -> Error(Nil)
   }
 }
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -98,6 +98,12 @@ pub type GleamOutput {
     type_mapping: TypeMapping,
     emit_sql_as_comment: Bool,
     emit_exact_table_names: Bool,
+    /// When True, the generated `models.gleam` includes only tables and
+    /// enums that are referenced by at least one generated query
+    /// (directly via `source_table`, `embed`, or via enum types on used
+    /// tables / query columns / query params). Defaults to False to
+    /// preserve the existing full-catalog output.
+    omit_unused_models: Bool,
   )
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -182,6 +182,7 @@ pub fn render_sqlight_adapter_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -241,6 +242,7 @@ pub fn render_pog_adapter_slice_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -275,6 +277,7 @@ pub fn render_sqlight_adapter_slice_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -431,6 +434,7 @@ pub fn render_adapter_uses_table_constructor_for_match_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -474,6 +478,7 @@ fn test_block() -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -491,6 +496,7 @@ fn test_block_native() -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -572,6 +578,7 @@ pub fn render_enum_decoder_uses_decode_then_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -642,6 +649,7 @@ pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -680,6 +688,7 @@ pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -827,6 +836,7 @@ fn readme_test_block() -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -930,6 +940,7 @@ pub fn render_pog_adapter_with_array_columns_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )

--- a/test/fixtures/multi_table_query.sql
+++ b/test/fixtures/multi_table_query.sql
@@ -1,0 +1,4 @@
+-- name: GetAuthor :one
+SELECT id, name
+FROM authors
+WHERE id = $1;

--- a/test/fixtures/multi_table_schema.sql
+++ b/test/fixtures/multi_table_schema.sql
@@ -1,0 +1,14 @@
+CREATE TYPE used_status AS ENUM ('active', 'inactive');
+CREATE TYPE unused_status AS ENUM ('draft', 'published');
+
+CREATE TABLE authors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  status used_status NOT NULL
+);
+
+CREATE TABLE unused_table (
+  id BIGSERIAL PRIMARY KEY,
+  label TEXT NOT NULL,
+  state unused_status NOT NULL
+);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -25,6 +25,7 @@ fn base_block(overrides: model.Overrides) -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: overrides,
   )
@@ -280,6 +281,7 @@ pub fn module_qualified_custom_type_in_params_generates_import_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.Overrides(
         type_overrides: [
@@ -359,6 +361,7 @@ pub fn rich_type_mapping_emits_semantic_aliases_test() {
         type_mapping: model.RichMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -396,6 +399,7 @@ pub fn strong_type_mapping_emits_wrapper_types_test() {
         type_mapping: model.StrongMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -476,6 +480,7 @@ pub fn exact_table_match_produces_alias_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -626,6 +631,7 @@ fn join_rename_block(renames: List(model.ColumnRename)) -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.Overrides(type_overrides: [], column_renames: renames),
   )
@@ -774,6 +780,7 @@ fn nullable_block(overrides: model.Overrides) -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: overrides,
   )
@@ -879,6 +886,7 @@ fn all_commands_block(
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1012,6 +1020,7 @@ pub fn run_with_missing_schema_file_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1036,6 +1045,7 @@ pub fn run_with_missing_query_file_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1061,6 +1071,7 @@ pub fn run_with_no_queries_in_file_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1086,6 +1097,7 @@ pub fn execresult_rejected_on_native_runtime_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1110,6 +1122,7 @@ pub fn execresult_allowed_on_raw_runtime_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1133,6 +1146,7 @@ fn unsupported_annotation_block(query_file: String) -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1194,6 +1208,7 @@ fn compound_block() -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1273,6 +1288,7 @@ fn view_block() -> model.SqlBlock {
       type_mapping: model.StringMapping,
       emit_sql_as_comment: False,
       emit_exact_table_names: False,
+      omit_unused_models: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1349,6 +1365,7 @@ pub fn invalid_out_path_rejected_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1380,6 +1397,7 @@ pub fn accept_directory_for_schema_and_queries_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1409,6 +1427,7 @@ pub fn mixed_file_and_directory_inputs_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1434,6 +1453,7 @@ pub fn reject_empty_schema_directory_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1459,6 +1479,7 @@ pub fn reject_empty_query_directory_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1486,6 +1507,7 @@ pub fn reject_duplicate_query_names_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1514,6 +1536,7 @@ pub fn emit_sql_as_comment_includes_sql_in_output_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: True,
         emit_exact_table_names: False,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1554,6 +1577,7 @@ pub fn emit_exact_table_names_skips_singularization_test() {
         type_mapping: model.StringMapping,
         emit_sql_as_comment: False,
         emit_exact_table_names: True,
+        omit_unused_models: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1578,6 +1602,56 @@ pub fn singularizes_table_names_by_default_test() {
   models
   |> string.contains("pub type Author {")
   |> should.be_true
+
+  cleanup()
+}
+
+// omit_unused_models tests (Issue #364)
+
+fn multi_table_block(omit_unused_models: Bool) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.PostgreSQL,
+    schema: ["test/fixtures/multi_table_schema.sql"],
+    queries: ["test/fixtures/multi_table_query.sql"],
+    gleam: model.GleamOutput(
+      out: test_out,
+      runtime: model.Raw,
+      type_mapping: model.StringMapping,
+      emit_sql_as_comment: False,
+      emit_exact_table_names: False,
+      omit_unused_models: omit_unused_models,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+pub fn omit_unused_models_default_keeps_all_tables_test() {
+  cleanup()
+  run_generate(multi_table_block(False))
+  let models = read_generated("models.gleam")
+
+  // Default behaviour: both tables and both enums remain in models.gleam.
+  string.contains(models, "pub type Author {") |> should.be_true
+  string.contains(models, "pub type UnusedTable {") |> should.be_true
+  string.contains(models, "pub type UsedStatus {") |> should.be_true
+  string.contains(models, "pub type UnusedStatus {") |> should.be_true
+
+  cleanup()
+}
+
+pub fn omit_unused_models_drops_unreferenced_tables_test() {
+  cleanup()
+  run_generate(multi_table_block(True))
+  let models = read_generated("models.gleam")
+
+  // The referenced table/enum stay.
+  string.contains(models, "pub type Author {") |> should.be_true
+  string.contains(models, "pub type UsedStatus {") |> should.be_true
+
+  // The unused table and its enum are dropped.
+  string.contains(models, "pub type UnusedTable {") |> should.be_false
+  string.contains(models, "pub type UnusedStatus {") |> should.be_false
 
   cleanup()
 }


### PR DESCRIPTION
## Summary
Teach `sqlode generate` to drop catalog tables and enums that no generated query actually references, gated behind a new `gen.gleam.omit_unused_models` config flag (default `false`). This reduces the public surface of `models.gleam` for large schemas where most tables never appear in query results, matching sqlc's `omit_unused_structs` behaviour for Gleam consumers. Closes #364.

## Changes
- `src/sqlode/model.gleam`: add `omit_unused_models: Bool` field to `GleamOutput`.
- `src/sqlode/config.gleam`: accept `omit_unused_models` in the `sql.gen.gleam` block's unknown-key guard and parse it as an optional bool (default `False`).
- `src/sqlode/generate.gleam`: when the flag is `True`, pass a pruned catalog to `models.render` via a new `prune_catalog_to_used` helper. The pruning keeps tables named on any `source_table` of a scalar result column or on an `EmbeddedResult`, and keeps enums used by those retained tables' columns, by any query result column, or by any query parameter (traversing `ArrayType` wrappers). Adapter generation and row-type inference keep seeing the full analysed queries.
- Test fixtures `test/fixtures/multi_table_schema.sql` and `multi_table_query.sql`: two tables and two enums where only one table is referenced, used by the new tests.
- `test/generate_test.gleam`: pin the default behaviour (all tables and enums kept) and the flagged behaviour (unused table + its enum dropped, referenced table + enum kept).
- `test/codegen_test.gleam` / `test/generate_test.gleam`: fill in `omit_unused_models: False` on existing `GleamOutput(...)` literal sites.

## Design Decisions
- **Off by default.** Existing projects keep the same output until they opt in. The option mirrors the intent of sqlc's `omit_unused_structs` without silently shrinking generated code for users who rely on the current models module.
- **Prune at the `base_output_files` boundary, not inside `models.render`.** The pruned catalog is a local value that feeds only the `models.render` call; adapter generation, row-type matching, and query analysis keep seeing the full schema. This isolates the behaviour change to the emitted `models.gleam` and leaves every existing code path untouched for `omit_unused_models: false`.
- **Keep enums used by retained tables too.** A retained table's columns can reference an enum; dropping that enum would produce a `models.gleam` that does not compile. The same is true for enum types carried on query parameters (via cast or inference), so both sources are included in the referenced-enum set.
- **Traverse `ArrayType` when collecting enum names.** `text[]` array columns over an enum element type still need the enum alias emitted. Extracting the inner scalar type catches that case without special-casing elsewhere.

## Limitations
- A query's result column without a `source_table` (e.g. pure expressions like `SELECT 1 AS n`) does not contribute to the retained-table set. This is correct — the query does not reference any table — but means `omit_unused_models: true` never retains a table on the basis of an expression-only query.
- Custom types declared via overrides are not inspected because they do not live in the catalog. Overrides that re-type a column to a Gleam-side custom type still keep the owning table (the override does not change `source_table`), and the custom-type imports are emitted from the query result columns as today.
- CTE virtual tables are not part of `catalog.tables`, so `omit_unused_models` does not affect them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `omit_unused_models` configuration option to selectively include only tables and enums referenced by generated queries. When enabled, unused models are excluded from generated code, reducing output size. Defaults to `False` to preserve all models and maintain backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->