### PR TITLE
refactor(integration_test): extract shared project scaffolding

### DIFF
--- a/integration_test/compile_test.sh
+++ b/integration_test/compile_test.sh
@@ -6,36 +6,16 @@
 set -eu
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PROJECT_ROOT
 INTEGRATION_DIR="$PROJECT_ROOT/test_integration_tmp"
 
+# shellcheck source=integration_test/lib.sh
+. "$PROJECT_ROOT/integration_test/lib.sh"
+
 cleanup() {
-  rm -rf "$INTEGRATION_DIR"
+  integration_clean "$INTEGRATION_DIR"
 }
 trap cleanup EXIT
-
-# Render the per-case gleam.toml and sqlode.yaml from tracked templates.
-# Templates live under integration_test/fixtures/ and use placeholders
-# {{PROJECT_ROOT}} / {{INTEGRATION_DIR}} / {{SCHEMA}} / {{QUERIES}} that
-# this function substitutes via sed.
-render_project() {
-  schema_path="$1"
-  queries_path="$2"
-
-  mkdir -p "$INTEGRATION_DIR/src/db"
-
-  sed \
-    -e "s|{{PROJECT_ROOT}}|$PROJECT_ROOT|g" \
-    "$PROJECT_ROOT/integration_test/fixtures/compile_test_gleam.toml.tmpl" \
-    > "$INTEGRATION_DIR/gleam.toml"
-
-  sed \
-    -e "s|{{PROJECT_ROOT}}|$PROJECT_ROOT|g" \
-    -e "s|{{INTEGRATION_DIR}}|$INTEGRATION_DIR|g" \
-    -e "s|{{SCHEMA}}|$schema_path|g" \
-    -e "s|{{QUERIES}}|$queries_path|g" \
-    "$PROJECT_ROOT/integration_test/fixtures/compile_test_sqlode.yaml.tmpl" \
-    > "$INTEGRATION_DIR/sqlode.yaml"
-}
 
 run_case() {
   label="$1"
@@ -46,15 +26,18 @@ run_case() {
   echo "--- $label ---"
 
   cleanup
-  render_project "$schema_path" "$queries_path"
+  integration_write_project \
+    --dir "$INTEGRATION_DIR" \
+    --engine postgresql \
+    --runtime raw \
+    --schema "$schema_path" \
+    --queries "$queries_path"
 
   echo "Generating code..."
-  cd "$PROJECT_ROOT"
-  gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+  integration_generate "$INTEGRATION_DIR"
 
   echo "Building generated project..."
-  cd "$INTEGRATION_DIR"
-  gleam build
+  integration_build "$INTEGRATION_DIR"
 
   echo "PASS: $label"
 }

--- a/integration_test/fixtures/compile_test_gleam.toml.tmpl
+++ b/integration_test/fixtures/compile_test_gleam.toml.tmpl
@@ -1,7 +1,0 @@
-name = "integration_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlode = { path = "{{PROJECT_ROOT}}" }

--- a/integration_test/fixtures/compile_test_sqlode.yaml.tmpl
+++ b/integration_test/fixtures/compile_test_sqlode.yaml.tmpl
@@ -1,9 +1,0 @@
-version: "2"
-sql:
-  - schema: "{{SCHEMA}}"
-    queries: "{{QUERIES}}"
-    engine: "postgresql"
-    gen:
-      gleam:
-        out: "{{INTEGRATION_DIR}}/src/db"
-        runtime: "raw"

--- a/integration_test/lib.sh
+++ b/integration_test/lib.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# Shared integration-project scaffolding used by both `spec/compile_spec.sh`
+# (ShellSpec) and the per-scenario scripts in `integration_test/`.
+#
+# Callers are expected to export $PROJECT_ROOT before sourcing this file.
+# Each helper is idempotent; they operate on the directory passed in and
+# never read or write the outer shell's pwd.
+#
+# Example:
+#   PROJECT_ROOT=/path/to/sqlode
+#   . "$PROJECT_ROOT/integration_test/lib.sh"
+#
+#   integration_clean "$INTEGRATION_DIR"
+#   integration_write_project \
+#     --dir "$INTEGRATION_DIR" \
+#     --name my_case \
+#     --engine sqlite \
+#     --runtime native \
+#     --schema "$PROJECT_ROOT/test/fixtures/sqlite_schema.sql" \
+#     --queries "$PROJECT_ROOT/test/fixtures/sqlite_crud_query.sql" \
+#     --dev-deps gleeunit
+#   integration_generate "$INTEGRATION_DIR"
+#   integration_build "$INTEGRATION_DIR"
+
+integration_clean() {
+  rm -rf "$1"
+}
+
+integration_write_project() {
+  dir=""
+  name="integration_test"
+  engine=""
+  runtime=""
+  schema=""
+  queries=""
+  dev_deps=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dir) dir="$2"; shift 2 ;;
+      --name) name="$2"; shift 2 ;;
+      --engine) engine="$2"; shift 2 ;;
+      --runtime) runtime="$2"; shift 2 ;;
+      --schema) schema="$2"; shift 2 ;;
+      --queries) queries="$2"; shift 2 ;;
+      --dev-deps) dev_deps="$2"; shift 2 ;;
+      *)
+        echo "integration_write_project: unknown arg: $1" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  if [ -z "$dir" ] || [ -z "$engine" ] || [ -z "$runtime" ] \
+     || [ -z "$schema" ] || [ -z "$queries" ]; then
+    echo "integration_write_project: --dir, --engine, --runtime, --schema, --queries are required" >&2
+    return 2
+  fi
+
+  mkdir -p "$dir/src/db"
+  _integration_write_gleam_toml "$dir" "$name" "$engine" "$runtime" "$dev_deps"
+  _integration_write_sqlode_yaml "$dir" "$schema" "$queries" "$engine" "$runtime"
+}
+
+_integration_driver_dep() {
+  # Args: runtime engine
+  case "$1:$2" in
+    native:postgresql) printf 'pog = ">= 4.0.0 and < 5.0.0"\n' ;;
+    native:sqlite) printf 'sqlight = ">= 1.0.0 and < 2.0.0"\n' ;;
+    *) printf '' ;;
+  esac
+}
+
+_integration_dev_deps_block() {
+  case "$1" in
+    "") return 0 ;;
+    gleeunit)
+      printf '\n[dev-dependencies]\ngleeunit = ">= 1.0.0 and < 2.0.0"\n'
+      ;;
+    *)
+      # Passed through verbatim as an entry list separated by newlines.
+      printf '\n[dev-dependencies]\n%s\n' "$1"
+      ;;
+  esac
+}
+
+_integration_write_gleam_toml() {
+  dir="$1"
+  name="$2"
+  engine="$3"
+  runtime="$4"
+  dev_deps="$5"
+
+  driver_line=$(_integration_driver_dep "$runtime" "$engine")
+  dev_section=$(_integration_dev_deps_block "$dev_deps")
+
+  {
+    printf 'name = "%s"\n' "$name"
+    printf 'version = "0.1.0"\n'
+    printf 'target = "erlang"\n'
+    printf '\n'
+    printf '[dependencies]\n'
+    printf 'gleam_stdlib = ">= 0.44.0 and < 2.0.0"\n'
+    if [ -n "$driver_line" ]; then
+      # driver_line already carries a trailing newline when emitted by
+      # _integration_driver_dep, but command substitution strips it, so
+      # print the value and re-add a newline to keep the next entry on
+      # a fresh line.
+      printf '%s\n' "$driver_line"
+    fi
+    printf 'sqlode = { path = "%s" }\n' "$PROJECT_ROOT"
+    if [ -n "$dev_section" ]; then
+      printf '%s\n' "$dev_section"
+    fi
+  } > "$dir/gleam.toml"
+}
+
+_integration_write_sqlode_yaml() {
+  dir="$1"
+  schema="$2"
+  queries="$3"
+  engine="$4"
+  runtime="$5"
+
+  cat > "$dir/sqlode.yaml" <<YAML
+version: "2"
+sql:
+  - schema: "$schema"
+    queries: "$queries"
+    engine: "$engine"
+    gen:
+      gleam:
+        out: "$dir/src/db"
+        runtime: "$runtime"
+YAML
+}
+
+integration_generate() {
+  (cd "$PROJECT_ROOT" && gleam run -- generate --config="$1/sqlode.yaml")
+}
+
+integration_build() {
+  (cd "$1" && gleam build)
+}
+
+integration_test() {
+  (cd "$1" && gleam test)
+}

--- a/integration_test/sqlite_advanced_test.sh
+++ b/integration_test/sqlite_advanced_test.sh
@@ -5,53 +5,34 @@
 set -eu
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PROJECT_ROOT
 INTEGRATION_DIR="$PROJECT_ROOT/test_integration_sqlite_advanced_tmp"
 
+# shellcheck source=integration_test/lib.sh
+. "$PROJECT_ROOT/integration_test/lib.sh"
+
 cleanup() {
-  rm -rf "$INTEGRATION_DIR"
+  integration_clean "$INTEGRATION_DIR"
 }
 trap cleanup EXIT
 
 echo "=== Integration test: SQLite advanced features ==="
 
-# --- Setup: create a temporary Gleam project ---
 cleanup
-mkdir -p "$INTEGRATION_DIR/src/db"
+integration_write_project \
+  --dir "$INTEGRATION_DIR" \
+  --name sqlite_advanced_test \
+  --engine sqlite \
+  --runtime native \
+  --schema "$PROJECT_ROOT/test/fixtures/sqlite_advanced_schema.sql" \
+  --queries "$PROJECT_ROOT/test/fixtures/sqlite_advanced_query.sql" \
+  --dev-deps gleeunit
 mkdir -p "$INTEGRATION_DIR/test"
 
-cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "sqlite_advanced_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-
-[dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"
-TOML
-
-cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/sqlite_advanced_schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/sqlite_advanced_query.sql"
-    engine: "sqlite"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "native"
-YAML
-
-# --- Generate adapter code ---
 echo ""
 echo "--- Generating SQLite adapter code ---"
-cd "$PROJECT_ROOT"
-gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+integration_generate "$INTEGRATION_DIR"
 
-# --- Verify generated files exist ---
 echo ""
 echo "--- Verifying generated files ---"
 for f in params.gleam queries.gleam models.gleam sqlight_adapter.gleam; do
@@ -62,23 +43,18 @@ for f in params.gleam queries.gleam models.gleam sqlight_adapter.gleam; do
 done
 echo "All expected files generated"
 
-# --- Copy the integration test module from tracked fixture ---
 cp "$PROJECT_ROOT/integration_test/fixtures/sqlite_advanced_test.gleam" \
    "$INTEGRATION_DIR/test/sqlite_advanced_test_test.gleam"
 
-# --- Build first to check compilation ---
 echo ""
 echo "--- Building project ---"
-cd "$INTEGRATION_DIR"
-gleam build
+integration_build "$INTEGRATION_DIR"
 
 echo "PASS: project builds successfully"
 
-# --- Run the tests ---
 echo ""
 echo "--- Running integration tests ---"
-cd "$INTEGRATION_DIR"
-gleam test
+integration_test "$INTEGRATION_DIR"
 
 echo ""
 echo "=== SQLite advanced integration test passed ==="

--- a/integration_test/sqlite_extended_test.sh
+++ b/integration_test/sqlite_extended_test.sh
@@ -5,53 +5,34 @@
 set -eu
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PROJECT_ROOT
 INTEGRATION_DIR="$PROJECT_ROOT/test_integration_sqlite_extended_tmp"
 
+# shellcheck source=integration_test/lib.sh
+. "$PROJECT_ROOT/integration_test/lib.sh"
+
 cleanup() {
-  rm -rf "$INTEGRATION_DIR"
+  integration_clean "$INTEGRATION_DIR"
 }
 trap cleanup EXIT
 
 echo "=== Integration test: SQLite extended features ==="
 
-# --- Setup: create a temporary Gleam project ---
 cleanup
-mkdir -p "$INTEGRATION_DIR/src/db"
+integration_write_project \
+  --dir "$INTEGRATION_DIR" \
+  --name sqlite_extended_test \
+  --engine sqlite \
+  --runtime native \
+  --schema "$PROJECT_ROOT/test/fixtures/sqlite_extended_schema.sql" \
+  --queries "$PROJECT_ROOT/test/fixtures/sqlite_extended_query.sql" \
+  --dev-deps gleeunit
 mkdir -p "$INTEGRATION_DIR/test"
 
-cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "sqlite_extended_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-
-[dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"
-TOML
-
-cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/sqlite_extended_schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/sqlite_extended_query.sql"
-    engine: "sqlite"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "native"
-YAML
-
-# --- Generate adapter code ---
 echo ""
 echo "--- Generating SQLite adapter code ---"
-cd "$PROJECT_ROOT"
-gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+integration_generate "$INTEGRATION_DIR"
 
-# --- Verify generated files exist ---
 echo ""
 echo "--- Verifying generated files ---"
 for f in params.gleam queries.gleam models.gleam sqlight_adapter.gleam; do
@@ -62,23 +43,18 @@ for f in params.gleam queries.gleam models.gleam sqlight_adapter.gleam; do
 done
 echo "All expected files generated"
 
-# --- Copy the integration test module from tracked fixture ---
 cp "$PROJECT_ROOT/integration_test/fixtures/sqlite_extended_test.gleam" \
    "$INTEGRATION_DIR/test/sqlite_extended_test_test.gleam"
 
-# --- Build first to check compilation ---
 echo ""
 echo "--- Building project ---"
-cd "$INTEGRATION_DIR"
-gleam build
+integration_build "$INTEGRATION_DIR"
 
 echo "PASS: project builds successfully"
 
-# --- Run the tests ---
 echo ""
 echo "--- Running integration tests ---"
-cd "$INTEGRATION_DIR"
-gleam test
+integration_test "$INTEGRATION_DIR"
 
 echo ""
 echo "=== SQLite extended integration test passed ==="

--- a/integration_test/sqlite_test.sh
+++ b/integration_test/sqlite_test.sh
@@ -6,53 +6,34 @@
 set -eu
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PROJECT_ROOT
 INTEGRATION_DIR="$PROJECT_ROOT/test_integration_sqlite_tmp"
 
+# shellcheck source=integration_test/lib.sh
+. "$PROJECT_ROOT/integration_test/lib.sh"
+
 cleanup() {
-  rm -rf "$INTEGRATION_DIR"
+  integration_clean "$INTEGRATION_DIR"
 }
 trap cleanup EXIT
 
 echo "=== Integration test: SQLite real database ==="
 
-# --- Setup: create a temporary Gleam project ---
 cleanup
-mkdir -p "$INTEGRATION_DIR/src/db"
+integration_write_project \
+  --dir "$INTEGRATION_DIR" \
+  --name sqlite_integration_test \
+  --engine sqlite \
+  --runtime native \
+  --schema "$PROJECT_ROOT/test/fixtures/sqlite_schema.sql" \
+  --queries "$PROJECT_ROOT/test/fixtures/sqlite_crud_query.sql" \
+  --dev-deps gleeunit
 mkdir -p "$INTEGRATION_DIR/test"
 
-cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "sqlite_integration_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-
-[dev-dependencies]
-gleeunit = ">= 1.0.0 and < 2.0.0"
-TOML
-
-cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/sqlite_schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/sqlite_crud_query.sql"
-    engine: "sqlite"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "native"
-YAML
-
-# --- Generate adapter code ---
 echo ""
 echo "--- Generating SQLite adapter code ---"
-cd "$PROJECT_ROOT"
-gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml"
+integration_generate "$INTEGRATION_DIR"
 
-# --- Verify generated files exist ---
 echo ""
 echo "--- Verifying generated files ---"
 for f in params.gleam queries.gleam models.gleam sqlight_adapter.gleam; do
@@ -63,23 +44,18 @@ for f in params.gleam queries.gleam models.gleam sqlight_adapter.gleam; do
 done
 echo "All expected files generated"
 
-# --- Copy the integration test module from tracked fixture ---
 cp "$PROJECT_ROOT/integration_test/fixtures/sqlite_basic_test.gleam" \
    "$INTEGRATION_DIR/test/sqlite_integration_test_test.gleam"
 
-# --- Build first to check compilation ---
 echo ""
 echo "--- Building project ---"
-cd "$INTEGRATION_DIR"
-gleam build
+integration_build "$INTEGRATION_DIR"
 
 echo "PASS: project builds successfully"
 
-# --- Run the tests ---
 echo ""
 echo "--- Running integration tests ---"
-cd "$INTEGRATION_DIR"
-gleam test
+integration_test "$INTEGRATION_DIR"
 
 echo ""
 echo "=== SQLite integration test passed ==="

--- a/spec/compile_spec.sh
+++ b/spec/compile_spec.sh
@@ -3,154 +3,70 @@
 
 Describe 'generated code compilation'
   Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+  # shellcheck source=integration_test/lib.sh
+  Include "$PROJECT_ROOT/integration_test/lib.sh"
 
   INTEGRATION_DIR="$PROJECT_ROOT/test_integration_tmp"
+  SCHEMA="$PROJECT_ROOT/test/fixtures/schema.sql"
+  QUERIES="$PROJECT_ROOT/test/fixtures/query.sql"
 
   setup_raw_project() {
-    rm -rf "$INTEGRATION_DIR"
-    mkdir -p "$INTEGRATION_DIR/src/db"
-
-    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "integration_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-TOML
-
-    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
-    engine: "postgresql"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "raw"
-YAML
+    integration_clean "$INTEGRATION_DIR"
+    integration_write_project \
+      --dir "$INTEGRATION_DIR" \
+      --engine postgresql \
+      --runtime raw \
+      --schema "$SCHEMA" \
+      --queries "$QUERIES"
   }
 
   setup_sqlight_project() {
-    rm -rf "$INTEGRATION_DIR"
-    mkdir -p "$INTEGRATION_DIR/src/db"
-
-    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "integration_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-TOML
-
-    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
-    engine: "sqlite"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "native"
-YAML
+    integration_clean "$INTEGRATION_DIR"
+    integration_write_project \
+      --dir "$INTEGRATION_DIR" \
+      --engine sqlite \
+      --runtime native \
+      --schema "$SCHEMA" \
+      --queries "$QUERIES"
   }
 
   setup_pog_project() {
-    rm -rf "$INTEGRATION_DIR"
-    mkdir -p "$INTEGRATION_DIR/src/db"
-
-    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "integration_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-pog = ">= 4.0.0 and < 5.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-TOML
-
-    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/query.sql"
-    engine: "postgresql"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "native"
-YAML
-  }
-
-  cleanup_project() {
-    rm -rf "$INTEGRATION_DIR"
-  }
-
-  generate_and_build() {
-    cd "$PROJECT_ROOT" && gleam run -- generate --config="$INTEGRATION_DIR/sqlode.yaml" 2>&1
-    cd "$INTEGRATION_DIR" && gleam build 2>&1
+    integration_clean "$INTEGRATION_DIR"
+    integration_write_project \
+      --dir "$INTEGRATION_DIR" \
+      --engine postgresql \
+      --runtime native \
+      --schema "$SCHEMA" \
+      --queries "$QUERIES"
   }
 
   setup_mysql_raw_project() {
-    rm -rf "$INTEGRATION_DIR"
-    mkdir -p "$INTEGRATION_DIR/src/db"
-
-    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "integration_test"
-version = "0.1.0"
-target = "erlang"
-
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-TOML
-
-    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/mysql_schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/mysql_query.sql"
-    engine: "mysql"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "raw"
-YAML
+    integration_clean "$INTEGRATION_DIR"
+    integration_write_project \
+      --dir "$INTEGRATION_DIR" \
+      --engine mysql \
+      --runtime raw \
+      --schema "$PROJECT_ROOT/test/fixtures/mysql_schema.sql" \
+      --queries "$PROJECT_ROOT/test/fixtures/mysql_query.sql"
   }
 
   setup_all_commands_sqlight_project() {
-    rm -rf "$INTEGRATION_DIR"
-    mkdir -p "$INTEGRATION_DIR/src/db"
+    integration_clean "$INTEGRATION_DIR"
+    integration_write_project \
+      --dir "$INTEGRATION_DIR" \
+      --engine sqlite \
+      --runtime native \
+      --schema "$PROJECT_ROOT/test/fixtures/all_commands_schema.sql" \
+      --queries "$PROJECT_ROOT/test/fixtures/all_commands_query.sql"
+  }
 
-    cat > "$INTEGRATION_DIR/gleam.toml" << TOML
-name = "integration_test"
-version = "0.1.0"
-target = "erlang"
+  cleanup_project() {
+    integration_clean "$INTEGRATION_DIR"
+  }
 
-[dependencies]
-gleam_stdlib = ">= 0.44.0 and < 2.0.0"
-sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = { path = "$PROJECT_ROOT" }
-TOML
-
-    cat > "$INTEGRATION_DIR/sqlode.yaml" << YAML
-version: "2"
-sql:
-  - schema: "$PROJECT_ROOT/test/fixtures/all_commands_schema.sql"
-    queries: "$PROJECT_ROOT/test/fixtures/all_commands_query.sql"
-    engine: "sqlite"
-    gen:
-      gleam:
-        out: "$INTEGRATION_DIR/src/db"
-        runtime: "native"
-YAML
+  generate_and_build() {
+    integration_generate "$INTEGRATION_DIR" 2>&1
+    integration_build "$INTEGRATION_DIR" 2>&1
   }
 
   Describe 'raw mode (params + queries + models)'


### PR DESCRIPTION
## Summary
Pull the duplicated gleam.toml / sqlode.yaml / tempdir bootstrap out of `spec/compile_spec.sh` and the four `integration_test/*.sh` scripts into a new `integration_test/lib.sh`. Every compile / generate / build call now goes through the same helper surface, so one config-surface change no longer silently breaks one family of integration scripts while leaving the other green. Closes #305.

## Changes
- `integration_test/lib.sh` (new): shared helpers that callers source after exporting `$PROJECT_ROOT`. Helpers: `integration_clean`, `integration_write_project --dir --name --engine --runtime --schema --queries [--dev-deps]`, `integration_generate`, `integration_build`, `integration_test`. The gleam.toml writer chooses the right driver dependency for the `runtime` / `engine` pair (`pog` for `native:postgresql`, `sqlight` for `native:sqlite`, none otherwise) and emits a `[dev-dependencies]` block only when requested.
- `spec/compile_spec.sh`: drop the six inline `setup_*_project` heredoc-based builders and replace them with one-liner calls into `integration_write_project`. The existing 5 scenarios (PG raw, PG native via pog, SQLite native via sqlight, all-commands SQLite, MySQL raw) stay as-is, just driven by the helper.
- `integration_test/compile_test.sh` / `sqlite_test.sh` / `sqlite_extended_test.sh` / `sqlite_advanced_test.sh`: source the library and call the helpers. The per-scenario script is now down to label, schema / queries paths, optional dev deps, and the fixture it copies into `$INTEGRATION_DIR/test/`.
- `integration_test/fixtures/compile_test_gleam.toml.tmpl` / `compile_test_sqlode.yaml.tmpl`: removed. They existed only so the old `compile_test.sh` could sed-substitute placeholders; the new helper writes the files directly with the correct dependencies.

Net diff: `+257 / -296` lines (eight files).

## Design Decisions
- **Plain `/bin/sh` library, not a Gleam program.** The consumers are ShellSpec (itself shell) and the standalone `integration_test/*.sh` scripts. Keeping the scaffolding in shell means no bootstrap dependency on the code under test; the library runs even when `gleam build` is broken.
- **Pass `--dir` per call, not as an exported global.** `spec/compile_spec.sh` has its own `INTEGRATION_DIR`, each integration script has its own, and several scenarios reuse helpers in sequence. Requiring callers to pass the directory explicitly makes the helpers safe to call from different scopes without accidentally clobbering the wrong tree.
- **Helper picks the driver dependency from `runtime:engine`.** The previous scripts had six near-duplicate heredocs that differed only in which dependency line was present. Centralising that into one case statement means adding a new backend is a one-line change to `_integration_driver_dep`, and the MySQL + PostgreSQL + SQLite combinations stay in sync.
- **Removed the `compile_test_*.tmpl` templates.** They only covered the plain raw-mode PostgreSQL case; extending them would have needed a template per driver or another sed pass. Writing the file in code (via `printf` / heredoc) scales without another layer of template resolution.

## Limitations
- The helpers cover the current five variants (raw/native × PostgreSQL/SQLite, plus MySQL raw). Other drivers (e.g. a future MySQL native driver) need a new case branch in `_integration_driver_dep` before `integration_write_project` works for them.
- Integration tests still `cp` their test-runner `.gleam` file from `integration_test/fixtures/` after generation. That file is scenario-specific (queries it exercises differ) and was intentionally left under the caller's control.
- `integration_test/lib.sh` only provides the bootstrap. The `integration_test/*.sh` scripts still drive their own flow (generate → verify files → copy test module → build → run). Issue #306 is the separate follow-up that would turn those flows into data-driven cases on top of this library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored integration test infrastructure to consolidate shared project setup, code generation, and build logic into reusable helpers, improving test maintainability and consistency.
  * Removed template configuration files in favor of programmatic project generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->