### PR TITLE
feat(capabilities): pin public capability surface to a tracked manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Initial sqlc-style code generator for Gleam
 - PostgreSQL, MySQL, and SQLite engine support
-- Query annotations: `:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid`, `:batchone`, `:batchmany`, `:batchexec`, `:copyfrom`
+- Query annotations `:one`, `:many`, `:exec`, `:execresult`, `:execrows`, `:execlastid` supported end-to-end. `:batchone`, `:batchmany`, `:batchexec`, and `:copyfrom` are parsed for sqlc compatibility but currently fail generation with an unsupported-annotation error.
 - sqlode macros: `sqlode.arg`, `sqlode.narg`, `sqlode.slice`, `sqlode.embed`
 - Type mapping for INT, FLOAT, BOOL, TEXT, BYTEA, UUID, JSON, TIMESTAMP, DATE, TIME
 - PostgreSQL ENUM type support

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -1,0 +1,57 @@
+# sqlode capability manifest
+
+This file is generated from `src/sqlode/capabilities.gleam` and
+verified by `test/capabilities_test.gleam`. Do not edit by hand;
+update the capabilities module and run `just test` to refresh.
+
+## Engines
+
+- `postgresql`
+- `mysql`
+- `sqlite`
+
+## Runtimes
+
+- `raw`
+- `native`
+
+## Type mappings
+
+- `string`
+- `rich`
+- `strong`
+
+## Query annotations
+
+### Fully supported
+
+- `:one`
+- `:many`
+- `:exec`
+- `:execresult`
+- `:execrows`
+- `:execlastid`
+
+### Parsed but rejected at generation time
+
+These annotations exist in sqlc and are still parseable in
+`.sql` files, but sqlode currently refuses to emit code for
+them. See `validate_unsupported_annotations` in `generate.gleam`.
+
+- `:batchone`
+- `:batchmany`
+- `:batchexec`
+- `:copyfrom`
+
+## Macros
+
+- `sqlode.arg(...)`
+- `sqlode.narg(...)`
+- `sqlode.slice(...)`
+- `sqlode.embed(...)`
+
+## Placeholder styles
+
+- `postgresql` → `runtime.DollarNumbered`
+- `mysql` → `runtime.QuestionPositional`
+- `sqlite` → `runtime.QuestionNumbered`

--- a/src/sqlode/capabilities.gleam
+++ b/src/sqlode/capabilities.gleam
@@ -1,0 +1,180 @@
+//// Single source of truth for the capabilities that sqlode currently
+//// advertises to public consumers.
+////
+//// `CHANGELOG.md`, `README.md`, and any other release-facing document
+//// that needs to claim "supported X" values should derive from the
+//// lists below or from `manifest_markdown()` instead of restating them
+//// by hand. The accompanying `test/capabilities_test.gleam` pins the
+//// rendered manifest against the tracked file `doc/capabilities.md` so
+//// any change to the supported set forces a conscious doc refresh.
+////
+//// The split between fully-supported and planned query commands
+//// matches what `generate.gleam` enforces at generation time: the
+//// planned commands are currently rejected with an
+//// `UnsupportedAnnotation` error, so listing them as "Added" without
+//// qualification (as `CHANGELOG.md` did before this module) gives a
+//// false impression to public users.
+
+import gleam/list
+import gleam/string
+import sqlode/model
+import sqlode/runtime
+
+pub fn supported_engines() -> List(model.Engine) {
+  [model.PostgreSQL, model.MySQL, model.SQLite]
+}
+
+pub fn supported_runtimes() -> List(model.Runtime) {
+  [model.Raw, model.Native]
+}
+
+pub fn supported_type_mappings() -> List(model.TypeMapping) {
+  [model.StringMapping, model.RichMapping, model.StrongMapping]
+}
+
+/// Query annotations that are fully supported end-to-end: parsing,
+/// analysis, and code generation all complete without the
+/// `validate_unsupported_annotations` guard rejecting them.
+pub fn fully_supported_query_commands() -> List(runtime.QueryCommand) {
+  [
+    runtime.QueryOne,
+    runtime.QueryMany,
+    runtime.QueryExec,
+    runtime.QueryExecResult,
+    runtime.QueryExecRows,
+    runtime.QueryExecLastId,
+  ]
+}
+
+/// Query annotations that the parser accepts for sqlc source
+/// compatibility but that generation currently refuses with an
+/// `UnsupportedAnnotation` error.
+pub fn planned_query_commands() -> List(runtime.QueryCommand) {
+  [
+    runtime.QueryBatchOne,
+    runtime.QueryBatchMany,
+    runtime.QueryBatchExec,
+    runtime.QueryCopyFrom,
+  ]
+}
+
+/// Macro helpers sqlode recognises inside query files. Emitted names
+/// include the `sqlode.` prefix that appears in user SQL.
+pub fn supported_macros() -> List(String) {
+  ["sqlode.arg", "sqlode.narg", "sqlode.slice", "sqlode.embed"]
+}
+
+/// Placeholder styles emitted for the three engines sqlode targets.
+/// The pair matches the mapping in `codegen/queries.gleam`.
+pub fn supported_placeholder_styles() -> List(#(model.Engine, String)) {
+  [
+    #(model.PostgreSQL, "DollarNumbered"),
+    #(model.MySQL, "QuestionPositional"),
+    #(model.SQLite, "QuestionNumbered"),
+  ]
+}
+
+/// Render a Markdown manifest that the test suite pins against
+/// `doc/capabilities.md`. The generated shape is intentionally stable:
+/// adding a new capability changes the file, adding a new *section*
+/// changes this function.
+pub fn manifest_markdown() -> String {
+  string.join(
+    [
+      "# sqlode capability manifest",
+      "",
+      "This file is generated from `src/sqlode/capabilities.gleam` and",
+      "verified by `test/capabilities_test.gleam`. Do not edit by hand;",
+      "update the capabilities module and run `just test` to refresh.",
+      "",
+      "## Engines",
+      "",
+      bullet_list(
+        list.map(supported_engines(), fn(engine) {
+          "- `" <> model.engine_to_string(engine) <> "`"
+        }),
+      ),
+      "",
+      "## Runtimes",
+      "",
+      bullet_list(
+        list.map(supported_runtimes(), fn(runtime) {
+          "- `" <> model.runtime_to_string(runtime) <> "`"
+        }),
+      ),
+      "",
+      "## Type mappings",
+      "",
+      bullet_list(
+        list.map(supported_type_mappings(), fn(mapping) {
+          "- `" <> model.type_mapping_to_string(mapping) <> "`"
+        }),
+      ),
+      "",
+      "## Query annotations",
+      "",
+      "### Fully supported",
+      "",
+      bullet_list(
+        list.map(fully_supported_query_commands(), fn(command) {
+          "- `" <> command_annotation(command) <> "`"
+        }),
+      ),
+      "",
+      "### Parsed but rejected at generation time",
+      "",
+      "These annotations exist in sqlc and are still parseable in",
+      "`.sql` files, but sqlode currently refuses to emit code for",
+      "them. See `validate_unsupported_annotations` in `generate.gleam`.",
+      "",
+      bullet_list(
+        list.map(planned_query_commands(), fn(command) {
+          "- `" <> command_annotation(command) <> "`"
+        }),
+      ),
+      "",
+      "## Macros",
+      "",
+      bullet_list(
+        list.map(supported_macros(), fn(name) { "- `" <> name <> "(...)`" }),
+      ),
+      "",
+      "## Placeholder styles",
+      "",
+      bullet_list(
+        list.map(supported_placeholder_styles(), fn(entry) {
+          let #(engine, style) = entry
+          "- `"
+          <> model.engine_to_string(engine)
+          <> "` → `runtime."
+          <> style
+          <> "`"
+        }),
+      ),
+      "",
+    ],
+    "\n",
+  )
+}
+
+fn bullet_list(lines: List(String)) -> String {
+  case lines {
+    [] -> "(none)"
+    _ -> string.join(lines, "\n")
+  }
+}
+
+fn command_annotation(command: runtime.QueryCommand) -> String {
+  case command {
+    runtime.QueryOne -> ":one"
+    runtime.QueryMany -> ":many"
+    runtime.QueryExec -> ":exec"
+    runtime.QueryExecResult -> ":execresult"
+    runtime.QueryExecRows -> ":execrows"
+    runtime.QueryExecLastId -> ":execlastid"
+    runtime.QueryBatchOne -> ":batchone"
+    runtime.QueryBatchMany -> ":batchmany"
+    runtime.QueryBatchExec -> ":batchexec"
+    runtime.QueryCopyFrom -> ":copyfrom"
+  }
+}

--- a/test/capabilities_test.gleam
+++ b/test/capabilities_test.gleam
@@ -1,0 +1,65 @@
+import gleam/string
+import gleeunit/should
+import simplifile
+import sqlode/capabilities
+
+/// The tracked capability manifest must equal what the module renders
+/// right now. Any drift means either the code's supported set changed
+/// without the doc catching up, or the doc was edited by hand. Refresh
+/// `doc/capabilities.md` by copy-pasting the rendered output (see the
+/// hint the test prints on failure).
+pub fn manifest_matches_tracked_file_test() {
+  let tracked = case simplifile.read("doc/capabilities.md") {
+    Ok(content) -> content
+    Error(_) -> ""
+  }
+
+  let rendered = capabilities.manifest_markdown()
+
+  case tracked == rendered {
+    True -> Nil
+    False -> {
+      let message =
+        "doc/capabilities.md is out of sync with src/sqlode/capabilities.gleam.\n"
+        <> "Regenerate the file with:\n"
+        <> "  gleam run -m sqlode/scripts/print_capabilities > doc/capabilities.md\n"
+        <> "or copy the expected output below verbatim:\n"
+        <> "--- expected ---\n"
+        <> rendered
+        <> "--- end expected ---"
+      should.equal(message, "")
+    }
+  }
+}
+
+/// Guard against accidentally dropping a supported capability — the
+/// lists should be non-empty for every category sqlode actually ships.
+/// If a category is genuinely empty (e.g. the macro list after a
+/// sweeping rename), update the capability module alongside the change.
+pub fn supported_categories_are_not_empty_test() {
+  should.be_true(capabilities.supported_engines() != [])
+  should.be_true(capabilities.supported_runtimes() != [])
+  should.be_true(capabilities.supported_type_mappings() != [])
+  should.be_true(capabilities.fully_supported_query_commands() != [])
+  should.be_true(capabilities.supported_macros() != [])
+  should.be_true(capabilities.supported_placeholder_styles() != [])
+}
+
+/// The Markdown manifest must at least name every category it
+/// advertises. Catches structural regressions (e.g. deleting a
+/// section in `manifest_markdown`) without re-asserting the exact
+/// output — that part is what the snapshot test covers.
+pub fn manifest_lists_every_section_test() {
+  let md = capabilities.manifest_markdown()
+  should.be_true(string.contains(md, "## Engines"))
+  should.be_true(string.contains(md, "## Runtimes"))
+  should.be_true(string.contains(md, "## Type mappings"))
+  should.be_true(string.contains(md, "## Query annotations"))
+  should.be_true(string.contains(md, "### Fully supported"))
+  should.be_true(string.contains(
+    md,
+    "### Parsed but rejected at generation time",
+  ))
+  should.be_true(string.contains(md, "## Macros"))
+  should.be_true(string.contains(md, "## Placeholder styles"))
+}


### PR DESCRIPTION
## Summary
Make sqlode's public capability claims traceable to a single source of truth, so future CHANGELOG / README / doc edits cannot silently drift from what the code actually supports. Introduces a tiny `capabilities` module, a tracked `doc/capabilities.md` snapshot, a Gleam test that pins the two against each other, and fixes the CHANGELOG entry that overclaimed `:batchone` / `:batchmany` / `:batchexec` / `:copyfrom` as shipped features. Closes #365.

## Changes
- `src/sqlode/capabilities.gleam` (new): exports the supported engine, runtime, type-mapping, macro, and placeholder-style lists, plus a split between fully-supported query annotations and the ones parsed for sqlc compatibility but currently rejected by `generate.validate_unsupported_annotations`. Each list uses `model` / `runtime` values so a capability cannot be emitted without the enum variant existing; `manifest_markdown/0` renders them into a stable Markdown manifest.
- `doc/capabilities.md` (new, tracked): the committed snapshot.
- `test/capabilities_test.gleam` (new): asserts `capabilities.manifest_markdown() == doc/capabilities.md` contents and prints the expected output on failure so regenerating is a copy/paste. Also pins that every advertised section is present in the render and that no capability list goes empty.
- `CHANGELOG.md`: replace the line that claimed all ten query annotations were "added" with wording that mirrors `generate.gleam` and the README's "Planned annotations" section — six are fully supported, four are parsed-but-rejected.

## Design Decisions
- **Lists live in code, prose lives in Markdown.** The capabilities module is not a documentation file; it is plain Gleam that the rest of the compiler could also consume if it wanted to. The Markdown render exists to give humans one place to eyeball the current surface, pinned by the test.
- **Snapshot test prints the expected content on failure.** Regenerating the file is always "copy everything between the `--- expected ---` markers into `doc/capabilities.md`". No external script or separate `just capabilities` recipe to get out of sync.
- **Fully-supported vs. parsed-but-rejected is explicit.** sqlc parses `:batchone` / `:batchmany` / `:batchexec` / `:copyfrom`, and so does sqlode's parser, but generation currently refuses them. Listing both groups with distinct headings matches the README's "Planned annotations" section and makes the gap visible to anyone reading the manifest.
- **`doc/reference/` stays gitignored.** The Issue explicitly flagged it as research material that should be disposable. The tracked public surface now lives at the new `doc/capabilities.md` instead, so users reading the repo do not see the stale drift.

## Limitations
- The manifest only covers claims that are easy to enumerate: engines, runtimes, type mappings, query annotations, macros, placeholder styles. README tables about configuration fields and SQL dialect coverage still rely on hand-written prose; they are unchanged by this PR but can be driven by the same module once we also enumerate them there.
- The test pins exact Markdown output, which means any cosmetic tweak to `manifest_markdown` forces a doc update. That is intentional — the point of the snapshot is to catch unreviewed changes to the public surface — but it does mean the manifest's wording is part of the test contract.
- `doc/reference/specs/sqlc-compatibility.md` and `doc/reference/design/sqlode-architecture.md` are not touched here because `doc/reference/` is gitignored. They can still drift locally; the Issue's "treat as disposable" position stands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive capabilities documentation detailing supported databases (PostgreSQL, MySQL, SQLite), runtimes, type mappings, query annotations, and SQL macros.
* Updated CHANGELOG to clarify which query annotations are fully supported versus planned for future implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->