### PR TITLE
test(integration): add PostgreSQL real-database case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,22 @@ jobs:
   all:
     name: All checks
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sqlode_integration
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v6
 
@@ -45,3 +61,8 @@ jobs:
 
       - name: ShellSpec tests
         run: shellspec
+
+      - name: PostgreSQL integration test
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/sqlode_integration
+        run: sh integration_test/run.sh case_postgresql_real

--- a/integration_test/cases.sh
+++ b/integration_test/cases.sh
@@ -101,7 +101,36 @@ case_sqlite_advanced() {
     test_module_name="sqlite_advanced_test_test.gleam"
 }
 
-# Every case must be listed here to be picked up by run.sh.
+# Requires a running PostgreSQL server reachable through $DATABASE_URL.
+# Not included in ALL_INTEGRATION_CASES because most local runs do not
+# have Postgres available; invoke explicitly:
+#
+#   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/sqlode_test \
+#     sh integration_test/run.sh case_postgresql_real
+#
+# In CI, `.github/workflows/ci.yml` provisions a postgres service
+# container and runs this case with DATABASE_URL pointing at it. The
+# gleeunit test module itself checks DATABASE_URL at startup and
+# prints a skip message if it is missing, so the case still exits 0
+# when executed without Postgres available (e.g. in a local "all
+# integration cases" run that accidentally picks it up).
+case_postgresql_real() {
+  run_integration_case \
+    label="PostgreSQL real database" \
+    project_name="postgresql_real_test" \
+    engine="postgresql" \
+    runtime="native" \
+    schema="$PROJECT_ROOT/test/fixtures/postgresql_schema.sql" \
+    queries="$PROJECT_ROOT/test/fixtures/postgresql_crud_query.sql" \
+    dev_deps="gleeunit+envoy" \
+    expected_files="params.gleam queries.gleam models.gleam pog_adapter.gleam" \
+    test_module_src="$PROJECT_ROOT/integration_test/fixtures/postgresql_real_test.gleam" \
+    test_module_name="postgresql_real_test_test.gleam"
+}
+
+# Every case listed here runs by default in `run.sh` without arguments.
+# `case_postgresql_real` is intentionally excluded because it needs a
+# live Postgres; pass it explicitly to `run.sh` when DATABASE_URL is set.
 ALL_INTEGRATION_CASES="
   case_compile_raw
   case_compile_complex

--- a/integration_test/fixtures/postgresql_real_test.gleam
+++ b/integration_test/fixtures/postgresql_real_test.gleam
@@ -1,0 +1,160 @@
+//// Exercises the generated pog adapter against a real PostgreSQL
+//// server. Runs only when `DATABASE_URL` is set; otherwise the main
+//// function prints a skip message and exits without invoking gleeunit
+//// so CI / local builds without Postgres still succeed.
+////
+//// The schema this test expects matches
+//// `test/fixtures/postgresql_schema.sql`. Each test drops and
+//// recreates the `authors` table inside the current connection so
+//// tests stay independent of each other and the initial DB state.
+
+import db/params
+import db/pog_adapter
+import envoy
+import gleam/dynamic/decode
+import gleam/erlang/process
+import gleam/io
+import gleam/option
+import gleam/otp/actor
+import gleeunit
+import gleeunit/should
+import pog
+
+pub fn main() {
+  case envoy.get("DATABASE_URL") {
+    Error(_) -> {
+      io.println(
+        "DATABASE_URL not set; skipping PostgreSQL real-database integration tests",
+      )
+      Nil
+    }
+    Ok(_) -> gleeunit.main()
+  }
+}
+
+fn connect_or_fail() -> pog.Connection {
+  let assert Ok(url) = envoy.get("DATABASE_URL")
+  let pool_name = process.new_name("sqlode_pg_integration_pool")
+  let assert Ok(config) = pog.url_config(pool_name, url)
+  let assert Ok(actor.Started(_pid, conn)) = pog.start(config)
+  conn
+}
+
+fn ignore() -> decode.Decoder(Nil) {
+  decode.success(Nil)
+}
+
+fn reset_authors(db: pog.Connection) -> Nil {
+  let _ =
+    pog.query("DROP TABLE IF EXISTS authors")
+    |> pog.returning(ignore())
+    |> pog.execute(db)
+  let _ =
+    pog.query(
+      "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT)",
+    )
+    |> pog.returning(ignore())
+    |> pog.execute(db)
+  Nil
+}
+
+fn with_db(run: fn(pog.Connection) -> Nil) -> Nil {
+  let db = connect_or_fail()
+  reset_authors(db)
+  run(db)
+}
+
+pub fn create_and_get_author_test() {
+  use db <- with_db
+  let assert Ok(author_id) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Alice", bio: option.Some("A bio")),
+    )
+  author_id |> should.not_equal(0)
+
+  let assert Ok(option.Some(author)) =
+    pog_adapter.get_author(db, params.GetAuthorParams(id: author_id))
+  author.id |> should.equal(author_id)
+  author.name |> should.equal("Alice")
+  author.bio |> should.equal(option.Some("A bio"))
+}
+
+pub fn list_authors_orders_by_name_test() {
+  use db <- with_db
+  let assert Ok(_) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Bob", bio: option.None),
+    )
+  let assert Ok(_) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Alice", bio: option.Some("bio")),
+    )
+
+  let assert Ok(authors) = pog_adapter.list_authors(db)
+  case authors {
+    [first, second] -> {
+      first.name |> should.equal("Alice")
+      second.name |> should.equal("Bob")
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn create_author_with_null_bio_test() {
+  use db <- with_db
+  let assert Ok(id) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "NoBio", bio: option.None),
+    )
+
+  let assert Ok(option.Some(author)) =
+    pog_adapter.get_author(db, params.GetAuthorParams(id: id))
+  author.bio |> should.equal(option.None)
+}
+
+pub fn get_nonexistent_author_returns_none_test() {
+  use db <- with_db
+  let assert Ok(option.None) =
+    pog_adapter.get_author(db, params.GetAuthorParams(id: 999_999))
+  Nil
+}
+
+pub fn delete_author_test() {
+  use db <- with_db
+  let assert Ok(id) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Charlie", bio: option.None),
+    )
+  let assert Ok(Nil) =
+    pog_adapter.delete_author(db, params.DeleteAuthorParams(id: id))
+  let assert Ok(option.None) =
+    pog_adapter.get_author(db, params.GetAuthorParams(id: id))
+  Nil
+}
+
+pub fn count_authors_returns_row_count_test() {
+  use db <- with_db
+  let assert Ok(_) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "A", bio: option.None),
+    )
+  let assert Ok(_) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "B", bio: option.None),
+    )
+  let assert Ok(_) =
+    pog_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "C", bio: option.None),
+    )
+
+  let assert Ok(option.Some(row)) = pog_adapter.count_authors(db)
+  row.total |> should.equal(3)
+}

--- a/integration_test/lib.sh
+++ b/integration_test/lib.sh
@@ -79,6 +79,9 @@ _integration_dev_deps_block() {
     gleeunit)
       printf '\n[dev-dependencies]\ngleeunit = ">= 1.0.0 and < 2.0.0"\n'
       ;;
+    gleeunit+envoy)
+      printf '\n[dev-dependencies]\ngleeunit = ">= 1.0.0 and < 2.0.0"\nenvoy = ">= 1.0.0 and < 2.0.0"\n'
+      ;;
     *)
       # Passed through verbatim as an entry list separated by newlines.
       printf '\n[dev-dependencies]\n%s\n' "$1"

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -739,8 +739,14 @@ fn render_pog_exec_last_id(
       |> list.filter(fn(l) { l != "" })
   }
 
+  // pog rows decode as positional arrays by default. Using `decode.int`
+  // at the row level tries to interpret the whole row as an integer and
+  // fails with UnexpectedResultType; decode the first column instead.
   let result_lines = [
-    "  |> pog.returning(decode.int)",
+    "  |> pog.returning({",
+    "    use id <- decode.field(0, decode.int)",
+    "    decode.success(id)",
+    "  })",
     "  |> pog.execute(db)",
     ..render_first_or_default("returned", "returned.rows", "0")
   ]

--- a/test/fixtures/postgresql_crud_query.sql
+++ b/test/fixtures/postgresql_crud_query.sql
@@ -1,0 +1,14 @@
+-- name: GetAuthor :one
+SELECT id, name, bio FROM authors WHERE id = $1;
+
+-- name: ListAuthors :many
+SELECT id, name, bio FROM authors ORDER BY name;
+
+-- name: CreateAuthor :execlastid
+INSERT INTO authors (name, bio) VALUES ($1, $2) RETURNING id;
+
+-- name: DeleteAuthor :exec
+DELETE FROM authors WHERE id = $1;
+
+-- name: CountAuthors :one
+SELECT COUNT(*) AS total FROM authors;

--- a/test/fixtures/postgresql_schema.sql
+++ b/test/fixtures/postgresql_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE authors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  bio TEXT
+);


### PR DESCRIPTION
## Summary
Add an end-to-end integration test that drives the generated pog adapter against a real PostgreSQL server, closing the gap between "the generated code compiles" (existing ShellSpec build test) and "the generated code actually works" for PostgreSQL. CI provisions a `postgres:16` service container and runs the new case after the existing gleam / ShellSpec steps. Closes #151.

## Changes
- `test/fixtures/postgresql_schema.sql` / `postgresql_crud_query.sql`: small `authors` schema plus CRUD + count queries covering `:one`, `:many`, `:exec`, `:execlastid`, and an aggregate `:one`.
- `integration_test/fixtures/postgresql_real_test.gleam`: gleeunit test module that drives the generated `pog_adapter` functions end-to-end (create + get, ordered `list_authors`, null-bio round-trip, non-existent `get` returns `None`, delete round-trip, count row). The module checks `DATABASE_URL` at startup and prints a skip message if it is not set so local `run.sh case_postgresql_real` without Postgres still exits cleanly.
- `integration_test/cases.sh`: register `case_postgresql_real`. Intentionally **not** added to `ALL_INTEGRATION_CASES` because most local checkouts do not have Postgres running; invoke it explicitly with `DATABASE_URL=... sh integration_test/run.sh case_postgresql_real`.
- `integration_test/lib.sh`: add a `gleeunit+envoy` dev-deps alias so the new case can depend on `envoy` for `DATABASE_URL` lookup without passing a multi-line TOML through the existing key=value runner interface.
- `.github/workflows/ci.yml`: add a `postgres:16` service container with a health-check and a new CI step that sets `DATABASE_URL` and runs `sh integration_test/run.sh case_postgresql_real`.

### Out-of-scope bug fix caught by the new coverage
- `render_pog_exec_last_id` emitted `|> pog.returning(decode.int)`, which tries to decode an entire row as an integer. pog 4 returns rows as positional arrays, so the decode failed with `UnexpectedResultType([DecodeError("Int", "Array", [])])`. Changed the returning decoder to read the first column instead, matching how `:one` results already decode. Verified against a local `postgres:16` container (all six new tests pass after the fix).

## Design Decisions
- **Skip at `main()` when `DATABASE_URL` is missing.** The alternative — moving the check into every test function — would repeat eight lines of boilerplate per test without preventing anyone from forgetting it on a future test. Short-circuiting from `main` keeps every test in the file free to assume the connection works.
- **Opt-in case, not a default.** Most local contributors do not have Postgres handy. Adding the case to the default list would force them to either run Docker or wait for a skip message for every `run.sh`. An explicit `case_postgresql_real` argument keeps `run.sh` a one-shot happy path locally while still letting CI provision the service and run it.
- **Service container on the same job, not a separate job.** The Gleam build artefacts are already warm by the time the Postgres step runs, so keeping everything on one job avoids re-downloading dependencies and re-building the integration temp tree. Only this step needs the DB; skipping the DB service on other steps would complicate the workflow for no benefit.
- **`envoy` for env-var access instead of a custom FFI shim.** The Gleam `envoy` package is the community default for `os.getenv`, and adding it as an integration-only dev dependency via the new `gleeunit+envoy` alias keeps the core `sqlode` package dependency surface unchanged. A custom Erlang `getenv` shim would have lived in `src/` and forced a separate module to handle a one-line capability.

## Limitations
- The test suite only exercises the six adapter functions that `:one`, `:many`, `:exec`, `:execlastid`, and aggregate `:one` cover. RETURNING clauses, PostgreSQL-specific types (ENUMs, UUIDs, arrays), and slice parameters are not yet covered; those can be added as follow-up cases by registering more functions in `cases.sh`.
- The skip path is observational only — the `gleeunit` main exits 0 without reporting that zero tests ran, which is indistinguishable from "successfully ran nothing". CI always exports `DATABASE_URL`, so the skip path exists primarily for local convenience.
- The shared pool name is a fixed `sqlode_pg_integration_pool` atom. Running two instances of this test in parallel on the same node would conflict; the case keeps things serial inside one process, and CI runs it inside a fresh Erlang VM per job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added PostgreSQL integration test suite validating create, read, update, and delete operations against a live database instance.
  * Tests verify schema management, query execution, null value handling, and row count accuracy.

* **Bug Fixes**
  * Fixed result decoding in the database adapter to correctly extract individual field values instead of misinterpreting entire rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->