### PR TITLE
refactor(codegen/adapter): consume RawQuery.encode via runtime.prepare

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -30,6 +30,12 @@ type AdapterConfig {
     render_exec_last_id: fn(String, String, String, List(model.QueryParam)) ->
       List(String),
     placeholder_prefix: String,
+    /// Gleam source text for a `value_to_<driver>` helper that converts
+    /// a `runtime.Value` into this driver's parameter type. Emitted
+    /// once per adapter file; each generated query function folds
+    /// `runtime.prepare(q, p)` through this helper instead of
+    /// re-encoding parameters per call.
+    value_to_driver_helper: String,
   )
 }
 
@@ -92,6 +98,7 @@ fn pog_adapter_config() -> AdapterConfig {
     render_exec_rows_result: render_pog_exec_rows_result,
     render_exec_last_id: render_pog_exec_last_id,
     placeholder_prefix: "$",
+    value_to_driver_helper: pog_value_to_driver_helper(),
   )
 }
 
@@ -109,7 +116,36 @@ fn sqlight_adapter_config() -> AdapterConfig {
     render_exec_rows_result: render_sqlight_exec_rows_result,
     render_exec_last_id: render_sqlight_exec_last_id,
     placeholder_prefix: "?",
+    value_to_driver_helper: sqlight_value_to_driver_helper(),
   )
+}
+
+fn pog_value_to_driver_helper() -> String {
+  "fn value_to_pog(value: runtime.Value) -> pog.Value {
+  case value {
+    runtime.SqlNull -> pog.null()
+    runtime.SqlString(v) -> pog.text(v)
+    runtime.SqlInt(v) -> pog.int(v)
+    runtime.SqlFloat(v) -> pog.float(v)
+    runtime.SqlBool(v) -> pog.bool(v)
+    runtime.SqlBytes(v) -> pog.bytea(v)
+    runtime.SqlArray(vs) -> pog.array(value_to_pog, vs)
+  }
+}"
+}
+
+fn sqlight_value_to_driver_helper() -> String {
+  "fn value_to_sqlight(value: runtime.Value) -> sqlight.Value {
+  case value {
+    runtime.SqlNull -> sqlight.null()
+    runtime.SqlString(v) -> sqlight.text(v)
+    runtime.SqlInt(v) -> sqlight.int(v)
+    runtime.SqlFloat(v) -> sqlight.float(v)
+    runtime.SqlBool(v) -> sqlight.bool(v)
+    runtime.SqlBytes(v) -> sqlight.blob(v)
+    runtime.SqlArray(_) -> sqlight.null()
+  }
+}"
 }
 
 // ============================================================
@@ -133,10 +169,14 @@ fn render_adapter(
       && !list.is_empty(query.result_columns)
     })
 
-  let has_slices = common.queries_have_slices(queries)
+  let has_params = list.any(queries, fn(q) { !list.is_empty(q.params) })
 
   let has_enums = common.queries_have_enums(queries)
 
+  // `list.fold` / `list.map` are used in every query function that has
+  // parameters; sqlight adapters additionally use `list.map` to feed
+  // the `with:` argument. Whenever any query carries params, the
+  // generated adapter needs the list module.
   let imports =
     list.flatten([
       [
@@ -144,7 +184,7 @@ fn render_adapter(
         "",
         "import gleam/dynamic/decode",
       ],
-      case has_slices {
+      case has_params {
         True -> ["import gleam/list"]
         False -> []
       },
@@ -184,7 +224,17 @@ fn render_adapter(
     |> list.map(render_adapter_function(ctx, _))
     |> string.join("\n\n")
 
-  string.join(list.flatten([imports, ["", functions]]), "\n")
+  let helper = value_to_driver_helper(config)
+
+  string.join(list.flatten([imports, ["", helper, "", functions]]), "\n")
+}
+
+/// Render a single `value_to_pog` / `value_to_sqlight` function per
+/// adapter file. Generated query functions fold the `runtime.Value`
+/// list returned by `runtime.prepare` through this helper, so param
+/// encoding lives in one place instead of being inlined per-param.
+fn value_to_driver_helper(config: AdapterConfig) -> String {
+  config.value_to_driver_helper
 }
 
 fn render_adapter_function(
@@ -624,91 +674,53 @@ fn render_adapter_exec_last_id(
 
 fn render_pog_query_call(
   _fn_name: String,
-  params_str: String,
+  _params_str: String,
   decoder: String,
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = common.has_slices(params)
-
-  let param_lines = case params_str {
-    "" -> []
-    _ ->
-      params_str
-      |> string.split("\n")
-      |> list.filter(fn(l) { l != "" })
-  }
-
-  let slice_expansion =
-    render_slice_expansion_line(params, "runtime.DollarNumbered")
-
-  case has_slices {
-    True ->
-      list.flatten([
-        ["  " <> slice_expansion, "  let query = pog.query(sql)"],
-        param_lines,
-        [
-          "  query",
-          "  |> pog.returning(" <> decoder <> ")",
-          "  |> pog.execute(db)",
-        ],
-      ])
-    False ->
-      list.flatten([
-        ["  " <> slice_expansion, "  pog.query(sql)"],
-        param_lines,
-        ["  |> pog.returning(" <> decoder <> ")", "  |> pog.execute(db)"],
-      ])
-  }
+  list.flatten([
+    render_prepare_lines("pog", "value_to_pog", params),
+    ["  |> pog.returning(" <> decoder <> ")", "  |> pog.execute(db)"],
+  ])
 }
 
-fn render_pog_params(params: List(model.QueryParam), _prefix: String) -> String {
-  let has_slices = common.has_slices(params)
-  case has_slices {
-    True -> render_pog_params_with_slices(params)
-    False -> render_pog_params_simple(params)
+/// No longer generates per-param `pog.parameter(...)` lines. Every
+/// generated query now reuses `runtime.prepare(q, p)` and folds the
+/// returned values through `value_to_pog`, so the param-string is
+/// redundant. Kept for the `AdapterConfig.render_params` field so the
+/// wider shape of the config record does not shift in this change.
+fn render_pog_params(_params: List(model.QueryParam), _prefix: String) -> String {
+  ""
+}
+
+/// Shared prepare-and-fold block used by every pog/sqlight query
+/// function. Emits one of two shapes depending on whether the query
+/// takes parameters: when it does, unpack `runtime.prepare(q, p)` and
+/// fold the returned values into `<driver>.query(sql)` through
+/// `value_to_<driver>`. When it does not, call `prepare(q, Nil)` and
+/// skip the fold entirely.
+fn render_prepare_lines(
+  driver: String,
+  value_to_driver: String,
+  params: List(model.QueryParam),
+) -> List(String) {
+  case list.is_empty(params) {
+    True -> [
+      "  let #(sql, _values) = runtime.prepare(q, Nil)",
+      "  " <> driver <> ".query(sql)",
+    ]
+    False -> [
+      "  let #(sql, values) = runtime.prepare(q, p)",
+      "  let query = " <> driver <> ".query(sql)",
+      "  let query = list.fold(values, query, fn(acc, v) { "
+        <> driver
+        <> ".parameter(acc, "
+        <> value_to_driver
+        <> "(v)) })",
+      "  query",
+    ]
   }
-}
-
-fn render_pog_params_simple(params: List(model.QueryParam)) -> String {
-  params
-  |> list.map(fn(param) {
-    let value_fn =
-      type_mapping.scalar_type_to_value_function(
-        model.PostgreSQL,
-        param.scalar_type,
-      )
-    "  |> pog.parameter("
-    <> render_param_value_expr("pog", value_fn, param)
-    <> ")"
-  })
-  |> string.join("\n")
-}
-
-fn render_pog_params_with_slices(params: List(model.QueryParam)) -> String {
-  params
-  |> list.map(fn(param) {
-    let value_fn =
-      type_mapping.scalar_type_to_value_function(
-        model.PostgreSQL,
-        param.scalar_type,
-      )
-    case param.is_list {
-      True -> {
-        let mapper = render_list_param_value_expr("pog", value_fn, param)
-        "  let query = list.fold(p."
-        <> param.field_name
-        <> ", query, fn(acc, v) { pog.parameter(acc, "
-        <> mapper
-        <> "(v)) })"
-      }
-      False ->
-        "  let query = pog.parameter(query, "
-        <> render_param_value_expr("pog", value_fn, param)
-        <> ")"
-    }
-  })
-  |> string.join("\n")
 }
 
 fn render_pog_one_result() -> List(String) {
@@ -725,23 +737,14 @@ fn render_pog_exec_rows_result() -> List(String) {
 
 fn render_pog_exec_last_id(
   _fn_name: String,
-  params_str: String,
+  _params_str: String,
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let has_slices = common.has_slices(params)
-
-  let param_lines = case params_str {
-    "" -> []
-    _ ->
-      params_str
-      |> string.split("\n")
-      |> list.filter(fn(l) { l != "" })
-  }
-
-  // pog rows decode as positional arrays by default. Using `decode.int`
-  // at the row level tries to interpret the whole row as an integer and
-  // fails with UnexpectedResultType; decode the first column instead.
+  // pog rows decode as positional arrays by default. Decoding
+  // `decode.int` directly at the row level tries to interpret the
+  // whole row as an integer and fails with UnexpectedResultType; we
+  // decode the first column instead.
   let result_lines = [
     "  |> pog.returning({",
     "    use id <- decode.field(0, decode.int)",
@@ -750,24 +753,10 @@ fn render_pog_exec_last_id(
     "  |> pog.execute(db)",
     ..render_first_or_default("returned", "returned.rows", "0")
   ]
-
-  let slice_expansion =
-    render_slice_expansion_line(params, "runtime.DollarNumbered")
-
-  case has_slices {
-    True ->
-      list.flatten([
-        ["  " <> slice_expansion, "  let query = pog.query(sql)"],
-        param_lines,
-        ["  query", ..result_lines],
-      ])
-    False ->
-      list.flatten([
-        ["  " <> slice_expansion, "  pog.query(sql)"],
-        param_lines,
-        result_lines,
-      ])
-  }
+  list.flatten([
+    render_prepare_lines("pog", "value_to_pog", params),
+    result_lines,
+  ])
 }
 
 // ============================================================
@@ -776,83 +765,33 @@ fn render_pog_exec_last_id(
 
 fn render_sqlight_query_call(
   _fn_name: String,
-  params_str: String,
+  _params_str: String,
   decoder: String,
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let slice_expansion =
-    render_slice_expansion_line(params, "runtime.QuestionNumbered")
+  let prepare_line = case list.is_empty(params) {
+    True -> "  let #(sql, values) = runtime.prepare(q, Nil)"
+    False -> "  let #(sql, values) = runtime.prepare(q, p)"
+  }
   [
-    "  " <> slice_expansion,
+    prepare_line,
     "  sqlight.query(",
     "    sql,",
     "    on: db,",
-    "    with: " <> params_str <> ",",
+    "    with: list.map(values, value_to_sqlight),",
     "    expecting: " <> decoder <> ",",
     "  )",
   ]
 }
 
+/// Unused under the prepare-and-fold adapter shape; see
+/// `render_pog_params` for the rationale.
 fn render_sqlight_params(
-  params: List(model.QueryParam),
+  _params: List(model.QueryParam),
   _prefix: String,
 ) -> String {
-  let has_slices = common.has_slices(params)
-  case has_slices {
-    True -> render_sqlight_params_with_slices(params)
-    False -> render_sqlight_params_simple(params)
-  }
-}
-
-fn render_sqlight_params_simple(params: List(model.QueryParam)) -> String {
-  case params {
-    [] -> "[]"
-    _ ->
-      "["
-      <> {
-        params
-        |> list.map(fn(param) {
-          let value_fn =
-            type_mapping.scalar_type_to_value_function(
-              model.SQLite,
-              param.scalar_type,
-            )
-          render_param_value_expr("sqlight", value_fn, param)
-        })
-        |> string.join(", ")
-      }
-      <> "]"
-  }
-}
-
-fn render_sqlight_params_with_slices(params: List(model.QueryParam)) -> String {
-  case params {
-    [] -> "[]"
-    _ ->
-      "list.flatten(["
-      <> {
-        params
-        |> list.map(fn(param) {
-          let value_fn =
-            type_mapping.scalar_type_to_value_function(
-              model.SQLite,
-              param.scalar_type,
-            )
-          case param.is_list {
-            True -> {
-              let mapper =
-                render_list_param_value_expr("sqlight", value_fn, param)
-              "list.map(p." <> param.field_name <> ", " <> mapper <> ")"
-            }
-            False ->
-              "[" <> render_param_value_expr("sqlight", value_fn, param) <> "]"
-          }
-        })
-        |> string.join(", ")
-      }
-      <> "])"
-  }
+  ""
 }
 
 fn render_sqlight_one_result() -> List(String) {
@@ -881,19 +820,21 @@ fn render_sqlight_exec_rows_result() -> List(String) {
 
 fn render_sqlight_exec_last_id(
   _fn_name: String,
-  params_str: String,
+  _params_str: String,
   _sql_expr: String,
   params: List(model.QueryParam),
 ) -> List(String) {
-  let slice_expansion =
-    render_slice_expansion_line(params, "runtime.QuestionNumbered")
+  let prepare_line = case list.is_empty(params) {
+    True -> "  let #(sql, values) = runtime.prepare(q, Nil)"
+    False -> "  let #(sql, values) = runtime.prepare(q, p)"
+  }
   list.flatten([
     [
-      "  " <> slice_expansion,
+      prepare_line,
       "  sqlight.query(",
       "    sql,",
       "    on: db,",
-      "    with: " <> params_str <> ",",
+      "    with: list.map(values, value_to_sqlight),",
       "    expecting: decode.success(Nil),",
       "  )",
       "  |> result.try(fn(_) {",
@@ -953,94 +894,6 @@ fn render_first_or_default(
     "    }",
     "  })",
   ]
-}
-
-fn render_param_value_expr(
-  lib: String,
-  value_fn: String,
-  param: model.QueryParam,
-) -> String {
-  let field_accessor = "p." <> param.field_name
-  case param.nullable {
-    False -> {
-      let field_expr = case param.scalar_type {
-        model.EnumType(name) ->
-          "models."
-          <> type_mapping.enum_to_string_fn(name)
-          <> "("
-          <> field_accessor
-          <> ")"
-        _ -> field_accessor
-      }
-      lib <> "." <> value_fn <> "(" <> field_expr <> ")"
-    }
-    True ->
-      case param.scalar_type {
-        model.EnumType(name) ->
-          lib
-          <> ".nullable(fn(v) { "
-          <> lib
-          <> "."
-          <> value_fn
-          <> "(models."
-          <> type_mapping.enum_to_string_fn(name)
-          <> "(v)) }, "
-          <> field_accessor
-          <> ")"
-        _ ->
-          lib
-          <> ".nullable("
-          <> lib
-          <> "."
-          <> value_fn
-          <> ", "
-          <> field_accessor
-          <> ")"
-      }
-  }
-}
-
-fn render_list_param_value_expr(
-  lib: String,
-  value_fn: String,
-  param: model.QueryParam,
-) -> String {
-  case param.scalar_type {
-    model.EnumType(name) ->
-      "fn(v) { "
-      <> lib
-      <> "."
-      <> value_fn
-      <> "(models."
-      <> type_mapping.enum_to_string_fn(name)
-      <> "(v)) }"
-    _ -> lib <> "." <> value_fn
-  }
-}
-
-fn render_slice_expansion_line(
-  params: List(model.QueryParam),
-  _style_expr: String,
-) -> String {
-  let slice_entries =
-    params
-    |> list.filter(fn(p) { p.is_list })
-    |> list.map(fn(p) {
-      "#("
-      <> int.to_string(p.index)
-      <> ", list.length(p."
-      <> p.field_name
-      <> "))"
-    })
-    |> string.join(", ")
-
-  let total_params = list.length(params)
-
-  "let sql = runtime.expand_slice_placeholders(q.sql, ["
-  <> slice_entries
-  <> "], "
-  <> int.to_string(total_params)
-  <> ", q.placeholder_style)"
 }
 
 fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -164,10 +164,17 @@ pub fn render_pog_adapter_test() {
   string.contains(rendered, "import db/queries") |> should.be_true()
   string.contains(rendered, "pub fn get_author(db: pog.Connection")
   |> should.be_true()
-  string.contains(rendered, "runtime.expand_slice_placeholders(")
+  string.contains(
+    rendered,
+    "fn value_to_pog(value: runtime.Value) -> pog.Value",
+  )
   |> should.be_true()
+  string.contains(rendered, "runtime.prepare(q, p)") |> should.be_true()
   string.contains(rendered, "pog.query(sql)") |> should.be_true()
-  string.contains(rendered, "pog.parameter(pog.int(p.id))")
+  string.contains(
+    rendered,
+    "list.fold(values, query, fn(acc, v) { pog.parameter(acc, value_to_pog(v)) })",
+  )
   |> should.be_true()
   string.contains(rendered, "decode.success(models.GetAuthorRow(")
   |> should.be_true()
@@ -265,14 +272,16 @@ pub fn render_pog_adapter_slice_test() {
   let analyzed = analyzed_slice_queries(model.PostgreSQL)
   let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
 
-  // Should import runtime for slice expansion
+  // Should import runtime for slice expansion via runtime.prepare
   string.contains(rendered, "import sqlode/runtime")
   |> should.be_true()
-  // Should call expand_slice_placeholders
-  string.contains(rendered, "runtime.expand_slice_placeholders(")
-  |> should.be_true()
-  // Should use list.fold for slice param binding
-  string.contains(rendered, "list.fold(p.ids")
+  // Should call runtime.prepare(q, p) to unpack sql + values
+  string.contains(rendered, "runtime.prepare(q, p)") |> should.be_true()
+  // Should fold the Value list into pog parameters via value_to_pog
+  string.contains(
+    rendered,
+    "list.fold(values, query, fn(acc, v) { pog.parameter(acc, value_to_pog(v)) })",
+  )
   |> should.be_true()
   // Should use let query = style
   string.contains(rendered, "let query = pog.query(sql)")
@@ -301,13 +310,16 @@ pub fn render_sqlight_adapter_slice_test() {
   let analyzed = analyzed_slice_queries(model.SQLite)
   let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
 
-  // Should call expand_slice_placeholders with "?" prefix
-  string.contains(rendered, "runtime.expand_slice_placeholders(")
+  // Should use runtime.prepare to get sql + values in one call
+  string.contains(rendered, "runtime.prepare(q, p)") |> should.be_true()
+  // Should convert runtime.Value list into sqlight.Value list
+  string.contains(rendered, "list.map(values, value_to_sqlight)")
   |> should.be_true()
-  // Should use list.flatten for sqlight params
-  string.contains(rendered, "list.flatten(")
-  |> should.be_true()
-  string.contains(rendered, "list.map(p.ids, sqlight.")
+  // Helper function is emitted once at the top of the file
+  string.contains(
+    rendered,
+    "fn value_to_sqlight(value: runtime.Value) -> sqlight.Value",
+  )
   |> should.be_true()
 }
 
@@ -677,11 +689,24 @@ pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
     )
   let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
 
-  // Slice enum params should call to_string before pog.text
+  // Under the prepare-and-fold shape, enum conversion happens in the
+  // params module's `*_values` function, not in the adapter. The
+  // adapter just folds `runtime.Value`s through `value_to_pog`, so the
+  // adapter source should contain the helper and the fold, and must
+  // not contain per-param enum-to-string conversions (those have
+  // already happened upstream in `params.*_values`).
+  string.contains(
+    rendered,
+    "fn value_to_pog(value: runtime.Value) -> pog.Value",
+  )
+  |> should.be_true()
+  string.contains(
+    rendered,
+    "list.fold(values, query, fn(acc, v) { pog.parameter(acc, value_to_pog(v)) })",
+  )
+  |> should.be_true()
   string.contains(rendered, "models.status_to_string(v)")
-  |> should.be_true()
-  string.contains(rendered, "pog.text(models.status_to_string(v))")
-  |> should.be_true()
+  |> should.be_false()
 }
 
 pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
@@ -717,14 +742,18 @@ pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
     )
   let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
 
-  // Slice enum params should call to_string before sqlight.text
-  string.contains(rendered, "models.status_to_string(v)")
-  |> should.be_true()
+  // Same story as the pog side: enum conversion now happens in
+  // `params.*_values`, so the adapter has the sqlight helper and
+  // the list.map-to-driver step instead of per-param conversions.
   string.contains(
     rendered,
-    "fn(v) { sqlight.text(models.status_to_string(v)) }",
+    "fn value_to_sqlight(value: runtime.Value) -> sqlight.Value",
   )
   |> should.be_true()
+  string.contains(rendered, "list.map(values, value_to_sqlight)")
+  |> should.be_true()
+  string.contains(rendered, "models.status_to_string(v)")
+  |> should.be_false()
 }
 
 // --- README snapshot tests ---
@@ -999,11 +1028,16 @@ pub fn render_pog_adapter_with_array_columns_test() {
   string.contains(rendered, "decode.list(decode.int)")
   |> should.be_true()
 
-  // Parameter encoding should use pog.array for array params
-  string.contains(rendered, "pog.array(pog.text)")
-  |> should.be_true()
-  string.contains(rendered, "pog.array(pog.int)")
-  |> should.be_true()
+  // With `runtime.prepare`, parameter encoding of array columns lives
+  // in the `params.*_values` function (which emits `runtime.array`).
+  // The adapter just folds `runtime.Value`s through `value_to_pog`,
+  // whose SqlArray case recurses with `pog.array(value_to_pog, ...)`.
+  // So the adapter should contain the recursive helper, but not
+  // `pog.array(pog.text)` / `pog.array(pog.int)` calls produced
+  // per-param by the old codegen path.
+  string.contains(rendered, "pog.array(value_to_pog, vs)") |> should.be_true()
+  string.contains(rendered, "pog.array(pog.text)") |> should.be_false()
+  string.contains(rendered, "pog.array(pog.int)") |> should.be_false()
 }
 
 fn array_test_catalog() -> model.Catalog {


### PR DESCRIPTION
## Summary
Rework the native `pog` / `sqlight` adapter codegen so generated query functions consume the same `RawQuery.encode` pipeline that powers `runtime.prepare`. Each adapter file now declares a single `value_to_<driver>` helper, and every query function walks the encoded `List(Value)` through `list.fold`, eliminating the per-parameter driver encoding calls and the ad-hoc slice expansion logic.

## Changes
- `src/sqlode/codegen/adapter.gleam`
  - Emit `value_to_pog` / `value_to_sqlight` helper at the top of the file, mapping `runtime.Value` → driver `Value`
  - New `render_prepare_lines` helper centralises the `runtime.prepare(q, p)` + `list.fold` scaffolding
  - Rewrite `render_pog_query_call` / `render_pog_exec_last_id` / `render_sqlight_query_call` / `render_sqlight_exec_last_id` to use the helper
  - Delete `render_param_value_expr`, `render_list_param_value_expr`, `render_slice_expansion_line`, `render_pog_params_simple`, `render_pog_params_with_slices`, `render_sqlight_params_simple`, `render_sqlight_params_with_slices`
  - Gate `gleam/list` import on `has_params` instead of `has_slices`
- `test/codegen_test.gleam`
  - Update assertions for the new prepare + fold shape
  - Flip enum/array expectations: `models.status_to_string(v)` / `pog.array(pog.text)` now live in the params module, not the adapter

## Design Decisions
- A single `value_to_<driver>` helper per adapter file keeps the generated code small and recursive array support is a natural one-liner (`pog.array(value_to_pog, vs)`).
- Slice expansion is already handled by `runtime.prepare`, so the adapter layer only needs to fold the resulting `List(Value)`; this removes a large amount of conditional rendering.
- Enum → string conversion and array encoding now belong to the params module output, so the adapter stays driver-agnostic and does not re-encode.

## Limitations
- `sqlight` has no native array type, so `SqlArray` falls through to `sqlight.null()` in `value_to_sqlight`. Array support for SQLite remains a separate concern.

Closes #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SQL adapter code generation to use a unified parameter binding approach with driver-specific value conversion helpers.
  * Simplified parameter handling by removing placeholder expansion logic in favor of a prepare-and-fold pattern.
  * Updated test assertions to reflect the new code generation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->