### PR TITLE
refactor(codegen): introduce Block builder to replace raw string chains

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -2,6 +2,7 @@ import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
 import gleam/string
+import sqlode/codegen/builder
 import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
@@ -363,13 +364,19 @@ fn render_decoder(
         })
         |> string.join(", ")
 
-      "{\n"
-      <> string.join(field_lines, "\n")
-      <> "\n    decode.success(models."
-      <> type_name
-      <> "("
-      <> constructor_fields
-      <> "))\n  }"
+      builder.concat([
+        builder.line("{"),
+        builder.lines(field_lines),
+        builder.line(
+          "    decode.success(models."
+          <> type_name
+          <> "("
+          <> constructor_fields
+          <> "))",
+        ),
+        builder.line("  }"),
+      ])
+      |> builder.render
     }
   }
 }
@@ -530,36 +537,50 @@ fn render_adapter_query_result(
   let params_arg = render_params_arg(ctx.naming_ctx, query, has_params)
   let params_str = ctx.config.render_params(query.params, "p")
   let decoder = render_decoder(ctx, query, constructor_name)
+  let return_type = return_type_wrapper <> "(models." <> type_name <> ")"
 
-  string.join(
-    list.flatten([
-      [
-        "pub fn "
-          <> fn_name
-          <> "(db: "
-          <> ctx.config.connection_type
-          <> params_arg
-          <> ") -> Result("
-          <> return_type_wrapper
-          <> "(models."
-          <> type_name
-          <> "), "
-          <> ctx.config.error_type
-          <> ") {",
-        "  let q = queries." <> fn_name <> "()",
-      ],
-      ctx.config.render_query_call(
-        fn_name,
-        params_str,
-        decoder,
-        "q.sql",
-        query.params,
-      ),
-      render_result(),
-      ["}"],
-    ]),
-    "\n",
-  )
+  builder.concat([
+    builder.line(query_fn_signature(
+      fn_name,
+      ctx.config.connection_type,
+      params_arg,
+      return_type,
+      ctx.config.error_type,
+    )),
+    builder.line("  let q = queries." <> fn_name <> "()"),
+    builder.lines(ctx.config.render_query_call(
+      fn_name,
+      params_str,
+      decoder,
+      "q.sql",
+      query.params,
+    )),
+    builder.lines(render_result()),
+    builder.line("}"),
+  ])
+  |> builder.render
+}
+
+/// Render the `pub fn name(db: Conn, p: Params) -> Result(R, E) {` line
+/// shared by every adapter query function. Keeping the signature in a
+/// dedicated helper keeps the callers free of deep `<>` chains.
+fn query_fn_signature(
+  fn_name: String,
+  connection_type: String,
+  params_arg: String,
+  return_type: String,
+  error_type: String,
+) -> String {
+  "pub fn "
+  <> fn_name
+  <> "(db: "
+  <> connection_type
+  <> params_arg
+  <> ") -> Result("
+  <> return_type
+  <> ", "
+  <> error_type
+  <> ") {"
 }
 
 fn render_adapter_exec(
@@ -572,33 +593,26 @@ fn render_adapter_exec(
   let params_arg = render_params_arg(naming_ctx, query, has_params)
   let params_str = config.render_params(query.params, "p")
 
-  string.join(
-    list.flatten([
-      [
-        "pub fn "
-          <> fn_name
-          <> "(db: "
-          <> config.connection_type
-          <> params_arg
-          <> ") -> Result(Nil, "
-          <> config.error_type
-          <> ") {",
-        "  let q = queries." <> fn_name <> "()",
-      ],
-      config.render_query_call(
-        fn_name,
-        params_str,
-        "decode.success(Nil)",
-        "q.sql",
-        query.params,
-      ),
-      [
-        "  |> result.map(fn(_) { Nil })",
-        "}",
-      ],
-    ]),
-    "\n",
-  )
+  builder.concat([
+    builder.line(query_fn_signature(
+      fn_name,
+      config.connection_type,
+      params_arg,
+      "Nil",
+      config.error_type,
+    )),
+    builder.line("  let q = queries." <> fn_name <> "()"),
+    builder.lines(config.render_query_call(
+      fn_name,
+      params_str,
+      "decode.success(Nil)",
+      "q.sql",
+      query.params,
+    )),
+    builder.line("  |> result.map(fn(_) { Nil })"),
+    builder.line("}"),
+  ])
+  |> builder.render
 }
 
 fn render_adapter_exec_rows(
@@ -611,31 +625,26 @@ fn render_adapter_exec_rows(
   let params_arg = render_params_arg(naming_ctx, query, has_params)
   let params_str = config.render_params(query.params, "p")
 
-  string.join(
-    list.flatten([
-      [
-        "pub fn "
-          <> fn_name
-          <> "(db: "
-          <> config.connection_type
-          <> params_arg
-          <> ") -> Result(Int, "
-          <> config.error_type
-          <> ") {",
-        "  let q = queries." <> fn_name <> "()",
-      ],
-      config.render_query_call(
-        fn_name,
-        params_str,
-        "decode.success(Nil)",
-        "q.sql",
-        query.params,
-      ),
-      config.render_exec_rows_result(),
-      ["}"],
-    ]),
-    "\n",
-  )
+  builder.concat([
+    builder.line(query_fn_signature(
+      fn_name,
+      config.connection_type,
+      params_arg,
+      "Int",
+      config.error_type,
+    )),
+    builder.line("  let q = queries." <> fn_name <> "()"),
+    builder.lines(config.render_query_call(
+      fn_name,
+      params_str,
+      "decode.success(Nil)",
+      "q.sql",
+      query.params,
+    )),
+    builder.lines(config.render_exec_rows_result()),
+    builder.line("}"),
+  ])
+  |> builder.render
 }
 
 fn render_adapter_exec_last_id(
@@ -648,24 +657,24 @@ fn render_adapter_exec_last_id(
   let params_arg = render_params_arg(naming_ctx, query, has_params)
   let params_str = config.render_params(query.params, "p")
 
-  string.join(
-    list.flatten([
-      [
-        "pub fn "
-          <> fn_name
-          <> "(db: "
-          <> config.connection_type
-          <> params_arg
-          <> ") -> Result(Int, "
-          <> config.error_type
-          <> ") {",
-        "  let q = queries." <> fn_name <> "()",
-      ],
-      config.render_exec_last_id(fn_name, params_str, "q.sql", query.params),
-      ["}"],
-    ]),
-    "\n",
-  )
+  builder.concat([
+    builder.line(query_fn_signature(
+      fn_name,
+      config.connection_type,
+      params_arg,
+      "Int",
+      config.error_type,
+    )),
+    builder.line("  let q = queries." <> fn_name <> "()"),
+    builder.lines(config.render_exec_last_id(
+      fn_name,
+      params_str,
+      "q.sql",
+      query.params,
+    )),
+    builder.line("}"),
+  ])
+  |> builder.render
 }
 
 // ============================================================

--- a/src/sqlode/codegen/builder.gleam
+++ b/src/sqlode/codegen/builder.gleam
@@ -1,0 +1,61 @@
+//// Minimal line-oriented builder for emitting generated Gleam source code.
+////
+//// A `Block` is an ordered list of already-rendered lines.  Callers stitch
+//// blocks together with `concat`, add blank separators with `blank`, and
+//// attach leading indentation with `indent`.  `render` flattens a block to
+//// the final `String` by joining on `"\n"`.
+////
+//// The builder intentionally does not try to model reflow (Wadler-style
+//// `Doc`) — generated Gleam code is layout-deterministic and lists of
+//// lines are the idiom already used across the codegen modules.
+
+import gleam/list
+import gleam/string
+
+pub opaque type Block {
+  Block(lines: List(String))
+}
+
+/// A block containing no lines at all. Useful for conditional sections.
+pub fn empty() -> Block {
+  Block([])
+}
+
+/// A block containing a single line of text.
+pub fn line(value: String) -> Block {
+  Block([value])
+}
+
+/// A block from an explicit list of pre-split lines.
+pub fn lines(values: List(String)) -> Block {
+  Block(values)
+}
+
+/// A block containing a single empty line, used as a visual separator.
+pub fn blank() -> Block {
+  Block([""])
+}
+
+/// Concatenate the lines of several blocks in order.
+pub fn concat(parts: List(Block)) -> Block {
+  Block(list.flat_map(parts, fn(b) { b.lines }))
+}
+
+/// Prepend `by` spaces to every non-empty line in the block.
+/// Empty lines stay empty so the output never has trailing whitespace.
+pub fn indent(block: Block, by by: Int) -> Block {
+  let prefix = string.repeat(" ", by)
+  Block(
+    list.map(block.lines, fn(l) {
+      case l {
+        "" -> ""
+        _ -> prefix <> l
+      }
+    }),
+  )
+}
+
+/// Render the block by joining its lines with newlines.
+pub fn render(block: Block) -> String {
+  string.join(block.lines, "\n")
+}

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -2,6 +2,7 @@ import gleam/list
 import gleam/option
 import gleam/result
 import gleam/string
+import sqlode/codegen/builder
 import sqlode/model
 
 pub fn has_slices(params: List(model.QueryParam)) -> Bool {
@@ -140,7 +141,12 @@ pub fn runtime_import_path(gleam: model.GleamOutput) -> String {
 ///      UserId(Int)
 ///    }"
 pub fn gleam_type(name: String, body: String) -> String {
-  "pub type " <> name <> " {\n  " <> name <> "(" <> body <> ")\n}"
+  builder.concat([
+    builder.line("pub type " <> name <> " {"),
+    builder.line("  " <> name <> "(" <> body <> ")"),
+    builder.line("}"),
+  ])
+  |> builder.render
 }
 
 /// Render a Gleam function declaration as a single string.
@@ -155,13 +161,12 @@ pub fn gleam_fn(
   return_type: String,
   body: String,
 ) -> String {
-  "pub fn "
-  <> name
-  <> "("
-  <> params
-  <> ") -> "
-  <> return_type
-  <> " {\n  "
-  <> body
-  <> "\n}"
+  builder.concat([
+    builder.line(
+      "pub fn " <> name <> "(" <> params <> ") -> " <> return_type <> " {",
+    ),
+    builder.line("  " <> body),
+    builder.line("}"),
+  ])
+  |> builder.render
 }

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -2,6 +2,7 @@ import gleam/dict.{type Dict}
 import gleam/list
 import gleam/option
 import gleam/string
+import sqlode/codegen/builder
 import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
@@ -108,49 +109,54 @@ fn render_enum_type(enum_def: model.EnumDef) -> String {
   let from_string_fn = type_mapping.enum_from_string_fn(enum_def.name)
 
   let constructors =
-    enum_def.values
-    |> list.map(fn(v) { "  " <> type_mapping.enum_value_name(v) })
-    |> string.join("\n")
+    builder.lines(list.map(enum_def.values, type_mapping.enum_value_name))
+    |> builder.indent(by: 2)
 
   let to_string_cases =
-    enum_def.values
-    |> list.map(fn(v) {
-      "    " <> type_mapping.enum_value_name(v) <> " -> \"" <> v <> "\""
-    })
-    |> string.join("\n")
+    builder.lines(
+      list.map(enum_def.values, fn(v) {
+        type_mapping.enum_value_name(v) <> " -> \"" <> v <> "\""
+      }),
+    )
+    |> builder.indent(by: 4)
 
   let from_string_cases =
-    enum_def.values
-    |> list.map(fn(v) {
-      "    \"" <> v <> "\" -> Ok(" <> type_mapping.enum_value_name(v) <> ")"
-    })
-    |> string.join("\n")
+    builder.lines(
+      list.map(enum_def.values, fn(v) {
+        "\"" <> v <> "\" -> Ok(" <> type_mapping.enum_value_name(v) <> ")"
+      }),
+    )
+    |> builder.indent(by: 4)
 
-  string.join(
-    [
-      "pub type " <> type_name <> " {",
-      constructors,
-      "}",
-      "",
+  builder.concat([
+    builder.line("pub type " <> type_name <> " {"),
+    constructors,
+    builder.line("}"),
+    builder.blank(),
+    builder.line(
       "pub fn " <> to_string_fn <> "(value: " <> type_name <> ") -> String {",
-      "  case value {",
-      to_string_cases,
-      "  }",
-      "}",
-      "",
+    ),
+    builder.line("  case value {"),
+    to_string_cases,
+    builder.line("  }"),
+    builder.line("}"),
+    builder.blank(),
+    builder.line(
       "pub fn "
-        <> from_string_fn
-        <> "(value: String) -> Result("
-        <> type_name
-        <> ", String) {",
-      "  case value {",
-      from_string_cases,
+      <> from_string_fn
+      <> "(value: String) -> Result("
+      <> type_name
+      <> ", String) {",
+    ),
+    builder.line("  case value {"),
+    from_string_cases,
+    builder.line(
       "    _ -> Error(\"Unknown " <> enum_def.name <> " value: \" <> value)",
-      "  }",
-      "}",
-    ],
-    "\n",
-  )
+    ),
+    builder.line("  }"),
+    builder.line("}"),
+  ])
+  |> builder.render
 }
 
 fn render_semantic_type_aliases(
@@ -163,7 +169,11 @@ fn render_semantic_type_aliases(
   |> list.map(fn(scalar_type) {
     let alias_name =
       type_mapping.scalar_type_to_gleam_type(scalar_type, model.RichMapping)
-    "pub type " <> alias_name <> " =\n  String"
+    builder.concat([
+      builder.line("pub type " <> alias_name <> " ="),
+      builder.line("  String"),
+    ])
+    |> builder.render
   })
   |> string.join("\n\n")
 }
@@ -183,9 +193,17 @@ fn render_strong_type_wrappers(
       option.None -> type_name <> "_to_string"
     }
     let body = "let " <> type_name <> "(inner) = value\n  inner"
-    common.gleam_type(type_name, "String")
-    <> "\n\n"
-    <> common.gleam_fn(unwrap_fn, "value: " <> type_name, "String", body)
+    builder.concat([
+      builder.line(common.gleam_type(type_name, "String")),
+      builder.blank(),
+      builder.line(common.gleam_fn(
+        unwrap_fn,
+        "value: " <> type_name,
+        "String",
+        body,
+      )),
+    ])
+    |> builder.render
   })
   |> string.join("\n\n")
 }
@@ -305,14 +323,12 @@ fn render_table_type(
     })
     |> string.join(", ")
 
-  string.join(
-    [
-      "pub type " <> type_name <> " {",
-      "  " <> type_name <> "(" <> fields <> ")",
-      "}",
-    ],
-    "\n",
-  )
+  builder.concat([
+    builder.line("pub type " <> type_name <> " {"),
+    builder.line("  " <> type_name <> "(" <> fields <> ")"),
+    builder.line("}"),
+  ])
+  |> builder.render
 }
 
 fn render_row_type_or_alias(
@@ -327,7 +343,11 @@ fn render_row_type_or_alias(
 
   case dict.get(table_matches, query.base.function_name) {
     Ok(table_type_name) ->
-      "pub type " <> row_type_name <> " =\n  " <> table_type_name
+      builder.concat([
+        builder.line("pub type " <> row_type_name <> " ="),
+        builder.line("  " <> table_type_name),
+      ])
+      |> builder.render
     Error(_) ->
       render_row_type(naming_ctx, query, type_mapping, emit_exact_table_names)
   }
@@ -382,14 +402,12 @@ fn render_row_type(
         })
         |> string.join(", ")
 
-      string.join(
-        [
-          "pub type " <> type_name <> " {",
-          "  " <> type_name <> "(" <> fields <> ")",
-          "}",
-        ],
-        "\n",
-      )
+      builder.concat([
+        builder.line("pub type " <> type_name <> " {"),
+        builder.line("  " <> type_name <> "(" <> fields <> ")"),
+        builder.line("}"),
+      ])
+      |> builder.render
     }
   }
 }

--- a/test/codegen_builder_test.gleam
+++ b/test/codegen_builder_test.gleam
@@ -1,0 +1,67 @@
+import gleeunit
+import gleeunit/should
+import sqlode/codegen/builder
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn render_empty_block_test() {
+  builder.empty()
+  |> builder.render
+  |> should.equal("")
+}
+
+pub fn render_line_test() {
+  builder.line("pub fn greet() -> String {")
+  |> builder.render
+  |> should.equal("pub fn greet() -> String {")
+}
+
+pub fn render_lines_joined_with_newline_test() {
+  builder.lines(["a", "b", "c"])
+  |> builder.render
+  |> should.equal("a\nb\nc")
+}
+
+pub fn render_blank_emits_empty_line_test() {
+  builder.concat([builder.line("a"), builder.blank(), builder.line("b")])
+  |> builder.render
+  |> should.equal("a\n\nb")
+}
+
+pub fn empty_block_is_identity_under_concat_test() {
+  builder.concat([builder.line("a"), builder.empty(), builder.line("b")])
+  |> builder.render
+  |> should.equal("a\nb")
+}
+
+pub fn concat_flattens_nested_blocks_test() {
+  builder.concat([
+    builder.concat([builder.line("a"), builder.line("b")]),
+    builder.line("c"),
+  ])
+  |> builder.render
+  |> should.equal("a\nb\nc")
+}
+
+pub fn indent_prepends_spaces_to_each_line_test() {
+  builder.lines(["a", "b"])
+  |> builder.indent(by: 2)
+  |> builder.render
+  |> should.equal("  a\n  b")
+}
+
+pub fn indent_leaves_empty_lines_without_trailing_whitespace_test() {
+  builder.concat([builder.line("a"), builder.blank(), builder.line("b")])
+  |> builder.indent(by: 4)
+  |> builder.render
+  |> should.equal("    a\n\n    b")
+}
+
+pub fn indent_zero_is_identity_test() {
+  builder.lines(["a", "b"])
+  |> builder.indent(by: 0)
+  |> builder.render
+  |> should.equal("a\nb")
+}


### PR DESCRIPTION
## Summary
Introduce a small line-oriented `Block` builder (`src/sqlode/codegen/builder.gleam`) and migrate the worst `<>` chains in `common.gleam`, `models.gleam`, and `adapter.gleam` off of embedded-`\n` / hand-rolled `\"  \"` indentation. The goal is readability — the generated output is byte-for-byte identical, as verified by the existing substring assertions, shellspec CLI tests, and integration tests.

## Changes
- `src/sqlode/codegen/builder.gleam` (new): opaque `Block` wrapping `List(String)` with `line`, `lines`, `empty`, `blank`, `concat`, `indent`, and `render`. `indent` leaves blank lines empty so generated code never has trailing whitespace.
- `test/codegen_builder_test.gleam` (new): unit tests for each primitive, pinning `indent(blank)` behaviour.
- `src/sqlode/codegen/common.gleam`: `gleam_type` and `gleam_fn` compose through `builder.concat` instead of embedding `\n` in string literals.
- `src/sqlode/codegen/models.gleam`: `render_enum_type` now uses `builder.indent` for constructor / case-branch indentation; `render_table_type`, `render_row_type`, `render_row_type_or_alias`, `render_semantic_type_aliases`, and `render_strong_type_wrappers` collapse their multi-line `string.join` bodies into `builder.concat` blocks.
- `src/sqlode/codegen/adapter.gleam`: `render_decoder`, `render_adapter_query_result`, `render_adapter_exec`, `render_adapter_exec_rows`, and `render_adapter_exec_last_id` now compose via `builder.concat`. Extract `query_fn_signature` so the shared `pub fn name(db: ...) -> Result(...)` line lives in one place.

## Design Decisions
- Rejected a Wadler-style `Doc` with soft breaks — generated Gleam is layout-deterministic and has no reflow requirement. A flat `List(String)` model is what the codebase already uses (`string.join(list.flatten([...]), \"\\n\")`); `Block` just centralises it.
- Left the top-level assembly patterns (conditional import blocks, `string.join(list.flatten([...]), \"\\n\")`) untouched. Block is modelled on that idiom, so rewriting it would add churn without improving readability.
- Kept `render_field_decode_line` as a one-line `<>` chain — it produces a single string with no `\n`, so the builder would only add noise.
- `gleam_type` and `gleam_fn` keep their existing `String`-returning signatures; they just render through a builder internally. Callers don't change.

## Limitations
- `builder.gleam` lives under `src/sqlode/codegen/`, which is effectively internal to the sqlode binary (no external imports). It is not added to `doc/capabilities.md`.
- The `Block` API is minimal; richer helpers (e.g., `gleam_fn_block`, `gleam_type_block`) could be added later if follow-up refactors want a more declarative form.

Closes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored code generation modules to use a new builder utility for assembling Gleam source code, replacing manual string concatenation and improving code consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for the code generation builder, including validation of block creation, concatenation, indentation, and rendering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->