### PR TITLE
feat: add one-line installer and v0.1.0 release prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         run: gleam build
 
       - name: Publish to Hex
-        run: gleam publish -y
+        run: echo 'I am not using semantic versioning' | gleam publish -y
         env:
           HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # sqlode
 
+[![Hex](https://img.shields.io/hexpm/v/sqlode)](https://hex.pm/packages/sqlode)
+[![Hex Downloads](https://img.shields.io/hexpm/dt/sqlode)](https://hex.pm/packages/sqlode)
+[![CI](https://github.com/nao1215/sqlode/actions/workflows/ci.yml/badge.svg)](https://github.com/nao1215/sqlode/actions/workflows/ci.yml)
 [![license](https://img.shields.io/github/license/nao1215/sqlode)](./LICENSE)
 
 sqlode reads SQL schema and query files, then generates typed Gleam code. The workflow follows [sqlc](https://sqlc.dev/) conventions: write SQL, run the generator, get type-safe functions.
@@ -10,15 +13,20 @@ Supported engines: PostgreSQL, MySQL (parsing only), SQLite.
 
 ### Install
 
-There are two ways to install sqlode:
+sqlode ships as an Erlang escript. Every install path therefore needs an Erlang/OTP runtime on the host (`escript` on PATH). The easiest way to cover both downloading the escript and detecting a missing runtime is the one-line installer:
 
-#### Option A: Standalone CLI (escript)
-
-Download the pre-built escript from [GitHub Releases](https://github.com/nao1215/sqlode/releases) and place it on your PATH. Requires Erlang/OTP runtime on the host machine.
+#### Option A: One-line install (recommended)
 
 ```console
-chmod +x sqlode
-./sqlode generate --config=sqlode.yaml
+curl -fsSL https://raw.githubusercontent.com/nao1215/sqlode/main/scripts/install.sh | sh
+```
+
+The script downloads the latest release's escript into `$HOME/.local/bin/sqlode`, makes it executable, and warns if Erlang/OTP is missing (with a per-distro install hint). Override the target with `SQLODE_INSTALL_DIR=/usr/local/bin` or pin a version with `SQLODE_VERSION=v0.1.0`.
+
+If `$HOME/.local/bin` is not on your `PATH`, add it to your shell config:
+
+```console
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 You still need sqlode as a project dependency because generated code imports `sqlode/runtime`:
@@ -27,9 +35,18 @@ You still need sqlode as a project dependency because generated code imports `sq
 gleam add sqlode
 ```
 
-#### Option B: Run via Gleam
+#### Option B: Manual escript download
 
-Add sqlode as a dependency and invoke the CLI through `gleam run`:
+Download the pre-built escript from [GitHub Releases](https://github.com/nao1215/sqlode/releases) and place it on your `PATH`:
+
+```console
+chmod +x sqlode
+./sqlode generate --config=sqlode.yaml
+```
+
+#### Option C: Run via Gleam
+
+If you already have a Gleam project, you can invoke the CLI through `gleam run` without downloading a separate binary:
 
 ```console
 gleam add sqlode

--- a/README.md
+++ b/README.md
@@ -21,7 +21,19 @@ sqlode ships as an Erlang escript. Every install path therefore needs an Erlang/
 curl -fsSL https://raw.githubusercontent.com/nao1215/sqlode/main/scripts/install.sh | sh
 ```
 
-The script downloads the latest release's escript into `$HOME/.local/bin/sqlode`, makes it executable, and warns if Erlang/OTP is missing (with a per-distro install hint). Override the target with `SQLODE_INSTALL_DIR=/usr/local/bin` or pin a version with `SQLODE_VERSION=v0.1.0`.
+Prefer to inspect the script before executing it? Download it first, read it, then run it:
+
+```console
+curl -fsSL -o install.sh https://raw.githubusercontent.com/nao1215/sqlode/main/scripts/install.sh
+sh install.sh
+```
+
+The installer writes the latest release's escript to `$HOME/.local/bin/sqlode`, makes it executable, and warns if Erlang/OTP is missing (with a per-distro install hint).
+
+Environment variables:
+
+- `SQLODE_VERSION=v0.1.0` — pin a specific release tag instead of `latest`.
+- `SQLODE_INSTALL_DIR=/path/to/bin` — install into a different directory. System paths such as `/usr/local/bin` require elevated privileges, e.g. `curl -fsSL ... | sudo SQLODE_INSTALL_DIR=/usr/local/bin sh`.
 
 If `$HOME/.local/bin` is not on your `PATH`, add it to your shell config:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# One-line installer for sqlode. Downloads the released escript into a
+# user-writable directory and verifies it runs.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/nao1215/sqlode/main/scripts/install.sh | sh
+#
+# Environment overrides:
+#   SQLODE_VERSION    - tag to install (default: latest). Example: v0.1.0
+#   SQLODE_INSTALL_DIR - directory to install into (default: $HOME/.local/bin)
+
+set -eu
+
+REPO="nao1215/sqlode"
+BIN_NAME="sqlode"
+VERSION="${SQLODE_VERSION:-latest}"
+INSTALL_DIR="${SQLODE_INSTALL_DIR:-$HOME/.local/bin}"
+
+info() { printf '==> %s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+need_cmd curl
+need_cmd uname
+
+# sqlode ships as an escript, which is a portable Erlang archive. It needs
+# `escript` (part of the Erlang/OTP runtime) on the PATH at run time.
+detect_distro_id() {
+  if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    (. /etc/os-release; printf '%s' "${ID:-}")
+  fi
+}
+
+check_erlang() {
+  if command -v escript >/dev/null 2>&1; then
+    return 0
+  fi
+
+  warn "Erlang/OTP runtime not found on PATH."
+  os="$(uname -s)"
+  case "$os" in
+    Linux)
+      case "$(detect_distro_id)" in
+        ubuntu|debian) warn "install it with: sudo apt-get install -y erlang" ;;
+        fedora|rhel|centos) warn "install it with: sudo dnf install -y erlang" ;;
+        arch|manjaro) warn "install it with: sudo pacman -S --noconfirm erlang" ;;
+        alpine) warn "install it with: sudo apk add erlang" ;;
+        *) warn "install Erlang/OTP via your distribution's package manager" ;;
+      esac
+      ;;
+    Darwin)
+      warn "install it with: brew install erlang"
+      ;;
+    *)
+      warn "see https://www.erlang.org/downloads for install options"
+      ;;
+  esac
+  warn "sqlode will still be downloaded, but you must install Erlang/OTP before running it."
+}
+
+resolve_version() {
+  if [ "$VERSION" = "latest" ]; then
+    url="https://api.github.com/repos/${REPO}/releases/latest"
+    tag="$(curl -fsSL "$url" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
+    if [ -z "$tag" ]; then
+      die "could not determine latest release tag. Set SQLODE_VERSION=vX.Y.Z to pin a version."
+    fi
+    VERSION="$tag"
+  fi
+}
+
+download() {
+  url="https://github.com/${REPO}/releases/download/${VERSION}/${BIN_NAME}"
+  info "downloading ${BIN_NAME} ${VERSION} from ${url}"
+  tmp="$(mktemp -t sqlode.XXXXXX)"
+  if ! curl -fsSL -o "$tmp" "$url"; then
+    rm -f "$tmp"
+    die "failed to download ${url}. Check SQLODE_VERSION or visit https://github.com/${REPO}/releases."
+  fi
+  DOWNLOAD="$tmp"
+}
+
+install_bin() {
+  mkdir -p "$INSTALL_DIR"
+  dest="$INSTALL_DIR/$BIN_NAME"
+  mv "$DOWNLOAD" "$dest"
+  chmod +x "$dest"
+  INSTALLED="$dest"
+}
+
+verify() {
+  if ! command -v escript >/dev/null 2>&1; then
+    info "skipping run check (Erlang/OTP not on PATH yet)"
+    return 0
+  fi
+  if ! "$INSTALLED" --help >/dev/null 2>&1; then
+    warn "${INSTALLED} was installed but --help failed. Inspect manually."
+  fi
+}
+
+path_hint() {
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+      warn "$INSTALL_DIR is not on your PATH."
+      warn "add it to your shell config, e.g. for bash/zsh:"
+      warn "  export PATH=\"$INSTALL_DIR:\$PATH\""
+      ;;
+  esac
+}
+
+main() {
+  check_erlang
+  resolve_version
+  download
+  install_bin
+  verify
+  path_hint
+  info "installed ${BIN_NAME} ${VERSION} at ${INSTALLED}"
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,9 +16,19 @@ BIN_NAME="sqlode"
 VERSION="${SQLODE_VERSION:-latest}"
 INSTALL_DIR="${SQLODE_INSTALL_DIR:-$HOME/.local/bin}"
 
+DOWNLOAD=""
+
 info() { printf '==> %s\n' "$*"; }
 warn() { printf 'warning: %s\n' "$*" >&2; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# Clean up any half-downloaded temp file on early exit (ctrl-C, mkdir/mv
+# failure, etc). install_bin clears DOWNLOAD after a successful move so the
+# trap becomes a no-op.
+cleanup() {
+  [ -n "$DOWNLOAD" ] && [ -e "$DOWNLOAD" ] && rm -f "$DOWNLOAD"
+}
+trap cleanup EXIT INT HUP TERM
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
@@ -64,14 +74,27 @@ check_erlang() {
 }
 
 resolve_version() {
-  if [ "$VERSION" = "latest" ]; then
-    url="https://api.github.com/repos/${REPO}/releases/latest"
-    tag="$(curl -fsSL "$url" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
-    if [ -z "$tag" ]; then
-      die "could not determine latest release tag. Set SQLODE_VERSION=vX.Y.Z to pin a version."
-    fi
-    VERSION="$tag"
+  [ "$VERSION" = "latest" ] || return 0
+
+  # Prefer the JSON API because it gives a clean tag name, but it is rate
+  # limited to 60 req/h for unauthenticated clients. Fall back to parsing
+  # the Location header from /releases/latest, which is not subject to the
+  # same limit.
+  api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  tag="$(curl -fsSL "$api_url" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)"
+
+  if [ -z "$tag" ]; then
+    redirect_url="https://github.com/${REPO}/releases/latest"
+    tag="$(curl -fsSI "$redirect_url" \
+      | sed -n 's/^[Ll]ocation: .*\/releases\/tag\/\([^[:space:]]*\).*/\1/p' \
+      | tr -d '\r' \
+      | tail -n1)"
   fi
+
+  if [ -z "$tag" ]; then
+    die "could not determine latest release tag (GitHub API rate limit or no releases yet). Set SQLODE_VERSION=vX.Y.Z to pin a version."
+  fi
+  VERSION="$tag"
 }
 
 download() {
@@ -86,11 +109,22 @@ download() {
 }
 
 install_bin() {
-  mkdir -p "$INSTALL_DIR"
+  # Detect non-writable targets up front so the user sees an actionable
+  # hint instead of a raw `mv: Permission denied` from `set -e`.
+  if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+    die "cannot create $INSTALL_DIR. Re-run with sudo (e.g. 'sudo SQLODE_INSTALL_DIR=$INSTALL_DIR sh') or pick a user-writable path like \$HOME/.local/bin."
+  fi
+  if [ ! -w "$INSTALL_DIR" ]; then
+    die "$INSTALL_DIR is not writable. Re-run with sudo (e.g. 'sudo SQLODE_INSTALL_DIR=$INSTALL_DIR sh') or pick a user-writable path like \$HOME/.local/bin."
+  fi
+
   dest="$INSTALL_DIR/$BIN_NAME"
   mv "$DOWNLOAD" "$dest"
   chmod +x "$dest"
   INSTALLED="$dest"
+  # Successful move: the temp file no longer exists, so clear the trap
+  # state to avoid a stray `rm -f` on EXIT.
+  DOWNLOAD=""
 }
 
 verify() {


### PR DESCRIPTION
## Summary
Lower the friction of the public install story (Issue #136) and make the repo ready for a clean v0.1.0 Hex publish. All changes are docs / scripts / CI — no source code touched.

## Changes
- `scripts/install.sh` (new): POSIX installer invoked via `curl -fsSL ... | sh`. Resolves the latest release tag through the GitHub API, downloads the escript into `$HOME/.local/bin/sqlode`, chmods it, and warns when Erlang/OTP is missing (with per-distro install hints: apt / dnf / pacman / apk / brew). Respects `SQLODE_VERSION` and `SQLODE_INSTALL_DIR` overrides. Notes when the install directory is not on `PATH`.
- `README.md`: promote the one-line installer as the primary path. Kept the manual escript download and the `gleam run` workflow as alternatives. Added Hex version, Hex downloads, and CI badges in the same layout `nao1215/oaspec` uses.
- `.github/workflows/release.yml`: pipe `I am not using semantic versioning` into `gleam publish -y`, matching oaspec's workaround so the interactive pre-1.0 semver confirmation does not hang the publish step.

## Design Decisions
- Kept the escript artifact as the canonical release asset. Shipping fully static binaries or bundling BEAM is out of scope; the installer just automates downloading it and guides the user to Erlang/OTP. This is the cheapest first-class install path that still works without users having an existing Gleam project.
- Used the GitHub Releases API with `sed` (no `jq` dependency) so the installer runs on minimal environments.
- `install.sh` is committed unexecuted-on-fetch — users invoke it via a piped `sh`. The raw-github URL in the README targets `main`, so tagged releases are unaffected if we later move the script.
- Did not create a Homebrew tap repo. That is best handled in a follow-up alongside an actual v0.1.0 publish, since the formula needs a valid release SHA.

## Limitations
- Requires `curl` and `sh` on the host; works on Linux and macOS, not evaluated on Windows (expected to work from Git Bash / WSL).
- Per-distro Erlang hints are advisory only — the installer does not attempt to invoke the package manager.
- Local verification: `just all` (828 gleam tests + 20 shellspec examples) green. The installer's download path cannot be smoke-tested until a v0.1.0 release asset exists.

Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-line installation script for simplified setup and binary downloads.

* **Documentation**
  * Updated installation guide with Erlang/OTP runtime requirements and multiple installation options.
  * Added badges for version tracking and CI status.
  * Documented environment variables for customizing installation directories and versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->