### PR TITLE
docs+feat: address pre-v0.1.0 release review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ sql:
 
 `schema` and `queries` accept either a single file path, a list of file paths, or a directory path. When given a directory, sqlode auto-discovers every `.sql` file inside it. An optional `name` field can be set on each `sql` block for diagnostics when multiple blocks are configured.
 
+> [!IMPORTANT]
+> The schema parser accepts a **schema snapshot or add-only migrations**. Supported: `CREATE TABLE` / `CREATE VIEW` / `CREATE TYPE` / `ALTER TABLE ... ADD COLUMN`. Statements like `DROP TABLE`, `ALTER TABLE ... DROP COLUMN`, or `ALTER TABLE ... RENAME` are rejected. Pointing sqlode at a full migration history that includes destructive DDL will fail — keep a separate, additive snapshot for code generation. See [Limitations](#limitations) for the full list.
+
 ### Write SQL
 
 Schema (`db/schema.sql`):
@@ -205,11 +208,12 @@ let q = queries.get_authors_by_ids()
 let #(sql, values) = runtime.prepare(
   q,
   params.GetAuthorsByIdsParams(ids: [1, 2, 3]),
-  "$",  // "$" for PostgreSQL, "?" for SQLite
 )
 // sql has expanded placeholders: "... WHERE id IN ($1, $2, $3)"
 // values is the flattened parameter list
 ```
+
+The placeholder dialect (`$1` for PostgreSQL, `?` for SQLite) is baked into the `RawQuery` by the generator, so `runtime.prepare` does not take a placeholder argument.
 
 ## Runtime modes
 
@@ -531,21 +535,20 @@ Column-level overrides take precedence over `db_type` overrides.
 
 ### Custom type aliases
 
-When you specify a non-primitive `gleam_type` (e.g., `UserId` instead of `Int`), sqlode preserves the type name in generated record fields but uses the underlying primitive type for encoding and decoding.
+> [!WARNING]
+> **Opaque types are not supported.** The custom type you map to **must be a transparent type alias** (`pub type UserId = Int`). Opaque single-constructor types (`pub opaque type UserId { UserId(Int) }`) will fail to compile because the generated code calls primitive encoders (e.g. `runtime.int(params.id)`) directly on the value. Adding a codec hook for opaque types is tracked for a future release.
 
-The custom type must be a transparent type alias, not an opaque type:
+When you specify a non-primitive `gleam_type` (e.g., `UserId` instead of `Int`), sqlode preserves the type name in generated record fields but uses the underlying primitive type for encoding and decoding.
 
 ```gleam
 // OK — transparent type alias
 pub type UserId = Int
 
-// Error — opaque type
+// Error — opaque type (fails to compile against generated code)
 pub opaque type UserId {
   UserId(Int)
 }
 ```
-
-Opaque types are not supported because sqlode generates encoder/decoder calls that operate on the underlying primitive type (e.g., `runtime.int(params.id)`). If `UserId` is opaque, this will produce a compile error because `UserId` and `Int` are not interchangeable.
 
 sqlode validates that `gleam_type` values start with an uppercase letter (valid Gleam type name) and emits a warning during generation when custom types are used.
 
@@ -587,6 +590,68 @@ pub fn sql_uuid_to_string(value: SqlUuid) -> String {
   inner
 }
 ```
+
+## Limitations
+
+sqlode is in an early phase. The following constraints are worth checking before you adopt it; several are tracked for future releases.
+
+### Parameter type inference
+
+sqlode infers a parameter's type from the SQL *context* the parameter appears in. Inference currently fires in four contexts:
+
+1. `INSERT INTO t (col) VALUES ($1)` — the parameter takes the type of `col`.
+2. `WHERE col = $1` (and `!=`, `<`, `<=`, `>`, `>=`) — the parameter takes the column type.
+3. `WHERE col IN ($1, $2, ...)` / `sqlode.slice($1)` — the parameter (or slice element type) takes the column type.
+4. `$1::int` / `CAST($1 AS int)` — explicit type cast.
+
+Outside those contexts, sqlode cannot infer a type and fails with an actionable error:
+
+> `Query "Name": could not infer type for parameter $N. Use a type cast (e.g. $N::int) to specify the type`
+
+Typical cases that need an explicit cast today: parameters inside scalar arithmetic (`price + $1`), inside `CASE WHEN` branches whose other branches are also parameters, or inside function calls whose arguments sqlode does not yet recognise. Adding more inference contexts is tracked for a future release; until then, pin the type with `$N::int` (PostgreSQL) / `CAST($N AS INTEGER)` (SQLite).
+
+### Schema DDL scope
+
+The schema parser is designed for **schema snapshots or add-only migration files**, not full migration histories. Supported statements:
+
+- `CREATE TABLE`
+- `CREATE VIEW`
+- `CREATE TYPE` (enum)
+- `ALTER TABLE ... ADD COLUMN`
+
+Rejected (error at load time):
+
+- `DROP TABLE`, `DROP VIEW`, `DROP TYPE`
+- `ALTER TABLE ... DROP COLUMN`
+- `ALTER TABLE ... RENAME TO` / `RENAME COLUMN`
+- `ALTER TABLE ... ALTER COLUMN` (type changes)
+
+Other statements (`CREATE INDEX`, transaction blocks, comments) are silently skipped.
+
+If your migration workflow mutates schema in place, keep a separate snapshot file for sqlode rather than pointing it at the migration history directly.
+
+### View resolution
+
+`CREATE VIEW ... AS SELECT ...` columns are resolved against the base tables so the generated models have correct types. By default, columns that cannot be resolved (unknown base table, ambiguous expression, etc.) are skipped with a stderr warning; if every column of a view is unresolvable the view itself is dropped from the catalog.
+
+Enable `strict_views: true` to fail-fast on any view resolution warning:
+
+```yaml
+sql:
+  - schema: "db/schema.sql"
+    queries: "db/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        out: "src/db"
+        strict_views: true
+```
+
+Strict-by-default is planned for a future release.
+
+### Custom types must be transparent aliases
+
+See [Custom type aliases](#custom-type-aliases) — opaque types (`pub opaque type Foo { ... }`) are not supported today.
 
 ## Config options
 

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -120,6 +120,7 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
     [
       "out", "runtime", "type_mapping", "emit_sql_as_comment",
       "emit_exact_table_names", "omit_unused_models", "vendor_runtime",
+      "strict_views",
     ],
     "sql.gen.gleam.",
   ))
@@ -166,6 +167,9 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
   let vendor_runtime =
     optional_bool(gleam_node, "vendor_runtime")
     |> option.unwrap(False)
+  let strict_views =
+    optional_bool(gleam_node, "strict_views")
+    |> option.unwrap(False)
 
   use overrides <- result.try(parse_overrides(node))
 
@@ -182,6 +186,7 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
       emit_exact_table_names:,
       omit_unused_models:,
       vendor_runtime:,
+      strict_views:,
     ),
     overrides:,
   ))

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -108,7 +108,11 @@ fn generate_sql_block(
 fn load_and_prepare_catalog(
   block: model.SqlBlock,
 ) -> Result(model.Catalog, GenerateError) {
-  use raw_catalog <- result.try(load_catalog(block.schema, block.engine))
+  use raw_catalog <- result.try(load_catalog(
+    block.schema,
+    block.engine,
+    block.gleam.strict_views,
+  ))
   Ok(apply_type_overrides(raw_catalog, block.overrides.type_overrides))
 }
 
@@ -409,6 +413,7 @@ fn expand_sql_paths(
 fn load_catalog(
   paths: List(String),
   engine: model.Engine,
+  strict_views: Bool,
 ) -> Result(model.Catalog, GenerateError) {
   use expanded <- result.try(
     expand_sql_paths(paths, fn(path, detail) { SchemaReadError(path:, detail:) }),
@@ -435,11 +440,23 @@ fn load_catalog(
     }),
   )
 
-  list.each(warnings, fn(w) {
-    io.println_error(schema_parser.warning_to_string(w))
-  })
-
-  Ok(catalog)
+  case strict_views, warnings {
+    True, [_, ..] -> {
+      let detail =
+        "strict_views is enabled but the schema produced resolution warnings:\n  "
+        <> string.join(
+          list.map(warnings, schema_parser.warning_to_string),
+          "\n  ",
+        )
+      Error(SchemaParseError(detail:))
+    }
+    _, _ -> {
+      list.each(warnings, fn(w) {
+        io.println_error(schema_parser.warning_to_string(w))
+      })
+      Ok(catalog)
+    }
+  }
 }
 
 fn load_queries(

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -110,6 +110,13 @@ pub type GleamOutput {
     /// longer needs `sqlode` as a runtime dependency. Defaults to
     /// False so the shared-runtime path stays the default.
     vendor_runtime: Bool,
+    /// When True, any schema warning from view resolution
+    /// (unresolvable view columns, dropped views) is promoted to a
+    /// fatal error. Defaults to False — the legacy behaviour is to
+    /// print warnings to stderr and drop columns/views silently so
+    /// generation can still produce models for the rest of the
+    /// catalog. Strict-by-default is planned for a future release.
+    strict_views: Bool,
   )
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -198,6 +198,7 @@ pub fn render_sqlight_adapter_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -266,6 +267,7 @@ pub fn render_pog_adapter_slice_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -304,6 +306,7 @@ pub fn render_sqlight_adapter_slice_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -465,6 +468,7 @@ pub fn render_adapter_uses_table_constructor_for_match_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -510,6 +514,7 @@ fn test_block() -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -529,6 +534,7 @@ fn test_block_native() -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -612,6 +618,7 @@ pub fn render_enum_decoder_uses_decode_then_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -684,6 +691,7 @@ pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -737,6 +745,7 @@ pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -897,6 +906,7 @@ fn readme_test_block() -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1016,6 +1026,7 @@ pub fn render_pog_adapter_with_array_columns_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1123,4 +1134,28 @@ pub fn escape_string_carriage_return_test() {
 
 pub fn escape_string_no_special_chars_test() {
   common.escape_string("hello world") |> should.equal("hello world")
+}
+
+// --- README runtime example snapshot tests ---
+// The README documents `runtime.prepare` and related runtime calls in code
+// fences. These tests read the README file and lock in that the examples
+// stay in sync with the actual runtime signatures, so a reader who
+// copy-pastes the README does not hit an immediate compile error.
+
+pub fn readme_runtime_prepare_is_two_arg_test() {
+  // runtime.prepare signature: pub fn prepare(query, params) -> #(String, List(Value))
+  // README must call it with exactly two arguments — the third "placeholder"
+  // argument was removed because the dialect is baked into RawQuery itself.
+  let assert Ok(readme) = simplifile.read("README.md")
+
+  // The example explicitly uses the 2-arg call shape.
+  string.contains(readme, "let #(sql, values) = runtime.prepare(")
+  |> should.be_true()
+
+  // Fail fast if anyone regresses the example back to a 3-arg call with the
+  // placeholder prefix string ("$" or "?").
+  string.contains(readme, "runtime.prepare(\n  q,\n  params.")
+  |> should.be_true()
+  string.contains(readme, "\"$\",  // \"$\" for PostgreSQL")
+  |> should.be_false()
 }

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -189,3 +189,15 @@ pub fn default_block_name_is_none_test() {
   let assert [block] = cfg.sql
   block.name |> should.equal(option.None)
 }
+
+pub fn default_strict_views_is_false_test() {
+  let assert Ok(cfg) = config.load("test/fixtures/sqlode.yaml")
+  let assert [block] = cfg.sql
+  block.gleam.strict_views |> should.equal(False)
+}
+
+pub fn strict_views_true_roundtrips_test() {
+  let assert Ok(cfg) = config.load("test/fixtures/strict_views_enabled.yaml")
+  let assert [block] = cfg.sql
+  block.gleam.strict_views |> should.equal(True)
+}

--- a/test/fixtures/strict_views_enabled.yaml
+++ b/test/fixtures/strict_views_enabled.yaml
@@ -1,0 +1,10 @@
+version: "2"
+sql:
+  - schema: "schema.sql"
+    queries: "query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        out: "../../test_output/db"
+        runtime: "raw"
+        strict_views: true

--- a/test/fixtures/strict_views_query.sql
+++ b/test/fixtures/strict_views_query.sql
@@ -1,0 +1,2 @@
+-- name: GetAuthor :one
+SELECT id, name, bio FROM authors WHERE id = $1;

--- a/test/fixtures/strict_views_schema.sql
+++ b/test/fixtures/strict_views_schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE authors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  bio TEXT
+);
+
+-- View with an unresolvable column (references a column not present in any
+-- base table): under the default (strict_views: false) the column is
+-- silently dropped with a stderr warning. Under strict_views: true the
+-- generator must fail.
+CREATE VIEW broken AS SELECT unknown_column FROM nonexistent_table;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -27,6 +27,7 @@ fn base_block(overrides: model.Overrides) -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: overrides,
   )
@@ -284,6 +285,7 @@ pub fn module_qualified_custom_type_in_params_generates_import_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.Overrides(
         type_overrides: [
@@ -365,6 +367,7 @@ pub fn rich_type_mapping_emits_semantic_aliases_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -404,6 +407,7 @@ pub fn strong_type_mapping_emits_wrapper_types_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -486,6 +490,7 @@ pub fn exact_table_match_produces_alias_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -638,6 +643,7 @@ fn join_rename_block(renames: List(model.ColumnRename)) -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.Overrides(type_overrides: [], column_renames: renames),
   )
@@ -788,6 +794,7 @@ fn nullable_block(overrides: model.Overrides) -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: overrides,
   )
@@ -895,6 +902,7 @@ fn all_commands_block(
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1030,6 +1038,7 @@ pub fn run_with_missing_schema_file_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1056,6 +1065,7 @@ pub fn run_with_missing_query_file_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1083,6 +1093,7 @@ pub fn run_with_no_queries_in_file_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1110,6 +1121,7 @@ pub fn execresult_rejected_on_native_runtime_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1136,6 +1148,7 @@ pub fn execresult_allowed_on_raw_runtime_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1161,6 +1174,7 @@ fn unsupported_annotation_block(query_file: String) -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1224,6 +1238,7 @@ fn compound_block() -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1305,6 +1320,7 @@ fn view_block() -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1383,6 +1399,7 @@ pub fn invalid_out_path_rejected_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1416,6 +1433,7 @@ pub fn accept_directory_for_schema_and_queries_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1447,6 +1465,7 @@ pub fn mixed_file_and_directory_inputs_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1474,6 +1493,7 @@ pub fn reject_empty_schema_directory_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1501,6 +1521,7 @@ pub fn reject_empty_query_directory_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1530,6 +1551,7 @@ pub fn reject_duplicate_query_names_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1560,6 +1582,7 @@ pub fn emit_sql_as_comment_includes_sql_in_output_test() {
         emit_exact_table_names: False,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1602,6 +1625,7 @@ pub fn emit_exact_table_names_skips_singularization_test() {
         emit_exact_table_names: True,
         omit_unused_models: False,
         vendor_runtime: False,
+        strict_views: False,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1646,6 +1670,7 @@ fn multi_table_block(omit_unused_models: Bool) -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: omit_unused_models,
       vendor_runtime: False,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1697,6 +1722,7 @@ fn vendor_runtime_block(vendor_runtime: Bool) -> model.SqlBlock {
       emit_exact_table_names: False,
       omit_unused_models: False,
       vendor_runtime: vendor_runtime,
+      strict_views: False,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1744,5 +1770,54 @@ pub fn vendor_runtime_emits_local_copy_and_rewrites_imports_test() {
   // inside the runtime file itself.
   runtime |> should.equal(actual_runtime)
 
+  cleanup()
+}
+
+// strict_views tests
+
+fn strict_views_block(strict_views: Bool) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.PostgreSQL,
+    schema: ["test/fixtures/strict_views_schema.sql"],
+    queries: ["test/fixtures/strict_views_query.sql"],
+    gleam: model.GleamOutput(
+      out: test_out,
+      runtime: model.Raw,
+      type_mapping: model.StringMapping,
+      emit_sql_as_comment: False,
+      emit_exact_table_names: False,
+      omit_unused_models: False,
+      vendor_runtime: False,
+      strict_views: strict_views,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+pub fn strict_views_true_rejects_unresolvable_view_test() {
+  cleanup()
+  let cfg = model.Config(version: 2, sql: [strict_views_block(True)])
+  case generate.generate_config(cfg) {
+    Error(generate.SchemaParseError(detail)) -> {
+      string.contains(detail, "strict_views") |> should.be_true
+      string.contains(detail, "unknown_column") |> should.be_true
+    }
+    Error(other) -> {
+      // Any other error means the strict_views gate did not fire first.
+      panic as { "expected SchemaParseError, got " <> string.inspect(other) }
+    }
+    Ok(_) -> panic as "expected SchemaParseError when strict_views is True"
+  }
+  cleanup()
+}
+
+pub fn strict_views_false_preserves_legacy_silent_drop_test() {
+  cleanup()
+  // With strict_views disabled, the unresolvable view is silently dropped
+  // and generation proceeds. generate_config must succeed for the
+  // resolvable parts of the schema.
+  let cfg = model.Config(version: 2, sql: [strict_views_block(False)])
+  let assert Ok(_) = generate.generate_config(cfg)
   cleanup()
 }


### PR DESCRIPTION
## Summary
Addresses six findings from the pre-v0.1.0 release review. All README-only fixes + one new opt-in config flag (`strict_views`). The parser IR refactor (finding #2) is intentionally deferred — tracked as #382 for post-release.

## Changes

### README
- **Fix `runtime.prepare` example**: the function is 2-arg (placeholder dialect is baked into `RawQuery`), not 3-arg. README previously produced an immediate compile error on copy-paste.
- **Add a README snapshot test** (`test/codegen_test.gleam::readme_runtime_prepare_is_two_arg_test`) that reads `README.md` and asserts the 2-arg call shape so the example cannot silently regress.
- **Elevate the opaque-types warning** to a `[!WARNING]` callout at the top of "Custom type aliases". The detailed explanation stays underneath.
- **New top-level `## Limitations` section** with three subsections users hit in practice:
  - parameter type inference contract (INSERT values / comparison / IN / CAST only; everything else wants an explicit cast)
  - schema DDL scope (snapshot or add-only — never `DROP` / `RENAME` / `ALTER COLUMN`)
  - view resolution behaviour plus the new `strict_views` opt-in
  - link back to custom-type-alias requirement
- Inline a short DDL-scope note next to the directory ingestion sentence so it's visible before users feed a migration directory in.

### strict_views config option
- New `strict_views: Bool` field on `model.GleamOutput`, default `False` so existing configs are unaffected.
- Added to `config.gleam` gleam-node whitelist and parsed with the same optional-bool helper as `vendor_runtime`.
- In `generate.gleam`'s `load_catalog`, if `strict_views: True` **and** `schema_parser` produces any `SchemaWarning`, return `SchemaParseError` with a concatenated detail instead of printing to stderr and continuing. The legacy stderr-warn-and-continue path remains for `strict_views: False`.

### Tests
- `test/generate_test.gleam`: strict mode rejects unresolvable view columns (detail contains `strict_views` + the skipped column name); legacy mode still succeeds. New fixtures `test/fixtures/strict_views_schema.sql` + `strict_views_query.sql`.
- `test/config_test.gleam`: `strict_views` defaults to `False`; YAML `strict_views: true` round-trips correctly. New fixture `test/fixtures/strict_views_enabled.yaml`.
- Every existing `GleamOutput` constructor call-site in tests now passes `strict_views: False` — mechanical, no behaviour change.

## Design Decisions
- **Opt-in, not strict-by-default**. v0.1.0 is the first public release, so "not breaking users" does not strictly apply, but enabling strict views by default would immediately error on any schema with even one unresolvable view column. Opt-in keeps v0.1.0 safe and documents strict-by-default as the v0.2.0 plan. README says so.
- **Single `Bool` field, not a `StrictMode` record**. Matches the existing `omit_unused_models` / `vendor_runtime` precedent. If more strict knobs appear later they can be grouped then.
- **Error surface at `generate.gleam`, not in `schema_parser`**. `schema_parser` already distinguishes `ParseError` (fatal) from `SchemaWarning` (soft). Threading a flag into the parser would have rippled into every caller that consumes `parse_files_with_engine`; instead the decision stays at the generate layer where the config is naturally available.
- **Reuse existing `SchemaParseError` variant** with a concatenated detail rather than introducing a new `StrictViewsFailed` error. Keeps `error_to_string` and CLI output untouched.
- **Codec hook for opaque domain types is deferred.** The finding accepted either a codec hook or a prominent README warning; shipping a codec API half-baked would be worse than a clear README callout. The callout now leads "Custom type aliases" and mentions the follow-up.

## Limitations
- `test/schema_parser_test.gleam:view_nonexistent_table_test` still asserts the silent-drop behaviour intentionally — it documents the default (non-strict) path.
- The parser/analyzer re-tokenisation issue (finding #2) is intentionally out of scope. Tracked as #382 for post-v0.1.0 work.

## Verification
Local:
- `just all` → 833 unit tests pass, 20 shellspec examples pass (gleam format check + gleam check + gleam build --warnings-as-errors)
- `sh integration_test/run.sh` → all 7 integration cases pass

Closes #0 (pre-release review findings, no explicit issue)
Refs #382 (parser IR follow-up)