### PR TITLE
fix: rewrite sqlode.embed(TABLE) into valid emitted SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `sqlode.embed(TABLE)` is now rewritten into a concrete qualified
+  column list in the emitted SQL. Previously the literal
+  `sqlode.embed(...)` text leaked into generated runtime queries, which
+  the database rejected as invalid SQL. Embed detection during column
+  inference is also now case-insensitive.
+
 ## [0.1.0] - 2026-04-13
 
 ### Added

--- a/integration_test/fixtures/sqlite_advanced_test.gleam
+++ b/integration_test/fixtures/sqlite_advanced_test.gleam
@@ -1,3 +1,4 @@
+import db/models
 import db/params
 import db/sqlight_adapter
 import gleam/option.{None, Some}
@@ -131,7 +132,33 @@ pub fn left_join_with_valid_author_test() {
   Nil
 }
 
-// Note: sqlode.embed() runtime test is skipped because the generated SQL
-// retains the sqlode.embed(...) macro text which is not valid SQL.
-// The embed codegen (nested type generation + decoder) is verified
-// at the unit test level in codegen_test.gleam.
+// ---- Test sqlode.embed() runtime ----
+pub fn sqlode_embed_returns_nested_row_test() {
+  let db = setup_db()
+
+  let assert Ok(_) =
+    sqlight_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Alice", bio: Some("Author bio")),
+    )
+  let assert Ok(_) =
+    sqlight_adapter.create_post(
+      db,
+      params.CreatePostParams(
+        title: "Hello World",
+        body: "body text",
+        author_id: 1,
+      ),
+    )
+
+  let assert Ok(Some(row)) =
+    sqlight_adapter.get_post_with_author_embed(
+      db,
+      params.GetPostWithAuthorEmbedParams(id: 1),
+    )
+  let assert True = row.title == "Hello World"
+  let assert models.Author(id: 1, name: "Alice", bio: Some("Author bio")) =
+    row.authors
+
+  Nil
+}

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -7,6 +7,7 @@ import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer/column_inferencer
 import sqlode/query_analyzer/context
+import sqlode/query_analyzer/embed_rewriter
 import sqlode/query_analyzer/param_inferencer
 import sqlode/query_analyzer/placeholder
 
@@ -68,7 +69,36 @@ fn analyze_query(
     augmented,
   ))
 
-  Ok(model.AnalyzedQuery(base: query, params:, result_columns:))
+  let rewritten = rewrite_embed_sql(engine, query, tokens, result_columns)
+  Ok(model.AnalyzedQuery(base: rewritten, params:, result_columns:))
+}
+
+/// Expand any `sqlode.embed(TABLE)` macro calls in the query's SQL into
+/// concrete column lists so the emitted runtime SQL is valid. The token
+/// list is the already-tokenized form of `query.sql`; reusing it avoids a
+/// redundant lex pass when no embed is present.
+fn rewrite_embed_sql(
+  engine: model.Engine,
+  query: model.ParsedQuery,
+  tokens: List(lexer.Token),
+  result_columns: List(model.ResultItem),
+) -> model.ParsedQuery {
+  let rewritten_tokens = embed_rewriter.rewrite(tokens, result_columns)
+  case rewritten_tokens == tokens {
+    True -> query
+    False -> {
+      let rewritten_sql =
+        lexer.tokens_to_string(
+          rewritten_tokens,
+          lexer.TokenRenderOptions(
+            uppercase_keywords: False,
+            preserve_quotes: True,
+            engine: Some(engine),
+          ),
+        )
+      model.ParsedQuery(..query, sql: rewritten_sql)
+    }
+  }
 }
 
 fn merge_virtual_tables(

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -583,14 +583,14 @@ fn resolve_select_columns(
     _ ->
       list.try_map(columns, fn(extracted) {
         let trimmed = string.trim(extracted.name)
-        case string.starts_with(trimmed, "sqlode.embed(") {
+        let lowered = string.lowercase(trimmed)
+        case string.starts_with(lowered, "sqlode.embed(") {
           True -> {
             let embed_name =
-              trimmed
+              lowered
               |> string.replace("sqlode.embed(", "")
               |> string.replace(")", "")
               |> string.trim
-              |> string.lowercase
 
             case
               catalog.tables

--- a/src/sqlode/query_analyzer/embed_rewriter.gleam
+++ b/src/sqlode/query_analyzer/embed_rewriter.gleam
@@ -1,0 +1,123 @@
+//// Expand `sqlode.embed(TABLE)` macro calls into concrete qualified column
+//// lists inside an already-tokenized query. The rewriter is meant to run
+//// after `column_inferencer.infer_result_columns` so that the
+//// `EmbeddedResult` entries it receives already have the table's column
+//// list resolved against the catalog.
+
+import gleam/list
+import gleam/string
+import sqlode/lexer
+import sqlode/model
+
+/// Rewrite token list, replacing every `sqlode.embed(TABLE)` occurrence with
+/// a comma-separated list of qualified columns derived from the matching
+/// `EmbeddedResult` in `result_columns`.
+///
+/// If `result_columns` contains no `EmbeddedResult`, tokens are returned
+/// unchanged — callers can use this to short-circuit re-rendering when
+/// there is nothing to do.
+pub fn rewrite(
+  tokens: List(lexer.Token),
+  result_columns: List(model.ResultItem),
+) -> List(lexer.Token) {
+  let embeds = collect_embeds(result_columns)
+  case embeds {
+    [] -> tokens
+    _ -> do_rewrite(tokens, embeds, [])
+  }
+}
+
+fn collect_embeds(
+  result_columns: List(model.ResultItem),
+) -> List(model.EmbeddedColumn) {
+  list.filter_map(result_columns, fn(item) {
+    case item {
+      model.EmbeddedResult(embed) -> Ok(embed)
+      model.ScalarResult(_) -> Error(Nil)
+    }
+  })
+}
+
+fn do_rewrite(
+  tokens: List(lexer.Token),
+  embeds: List(model.EmbeddedColumn),
+  acc: List(lexer.Token),
+) -> List(lexer.Token) {
+  case try_match_embed(tokens) {
+    Ok(#(table_token, rest)) ->
+      case find_embed(embeds, table_token) {
+        Ok(embed) -> {
+          let replacement = build_column_tokens(embed)
+          do_rewrite(rest, embeds, prepend_reversed(replacement, acc))
+        }
+        Error(Nil) -> advance_one(tokens, embeds, acc)
+      }
+    Error(Nil) -> advance_one(tokens, embeds, acc)
+  }
+}
+
+fn advance_one(
+  tokens: List(lexer.Token),
+  embeds: List(model.EmbeddedColumn),
+  acc: List(lexer.Token),
+) -> List(lexer.Token) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [t, ..rest] -> do_rewrite(rest, embeds, [t, ..acc])
+  }
+}
+
+fn try_match_embed(
+  tokens: List(lexer.Token),
+) -> Result(#(String, List(lexer.Token)), Nil) {
+  case tokens {
+    [
+      lexer.Ident(sqlode_tok),
+      lexer.Dot,
+      lexer.Ident(embed_tok),
+      lexer.LParen,
+      lexer.Ident(table_tok),
+      lexer.RParen,
+      ..rest
+    ] ->
+      case
+        string.lowercase(sqlode_tok) == "sqlode"
+        && string.lowercase(embed_tok) == "embed"
+      {
+        True -> Ok(#(table_tok, rest))
+        False -> Error(Nil)
+      }
+    _ -> Error(Nil)
+  }
+}
+
+fn find_embed(
+  embeds: List(model.EmbeddedColumn),
+  table_token: String,
+) -> Result(model.EmbeddedColumn, Nil) {
+  let key = string.lowercase(table_token)
+  list.find(embeds, fn(e) { e.table_name == key })
+}
+
+fn build_column_tokens(embed: model.EmbeddedColumn) -> List(lexer.Token) {
+  embed.columns
+  |> list.index_map(fn(col, idx) {
+    let prefix = case idx {
+      0 -> []
+      _ -> [lexer.Comma]
+    }
+    list.append(prefix, [
+      lexer.Ident(embed.table_name),
+      lexer.Dot,
+      lexer.Ident(col.name),
+    ])
+  })
+  |> list.flatten
+}
+
+fn prepend_reversed(items: List(a), acc: List(a)) -> List(a) {
+  case items {
+    [] -> acc
+    [x, ..rest] -> prepend_reversed(rest, [x, ..acc])
+  }
+}

--- a/test/fixtures/sqlite_advanced_query.sql
+++ b/test/fixtures/sqlite_advanced_query.sql
@@ -18,3 +18,9 @@ WHERE posts.id = ?1;
 
 -- name: ListAuthors :many
 SELECT id, name, bio FROM authors ORDER BY name;
+
+-- name: GetPostWithAuthorEmbed :one
+SELECT sqlode.embed(authors), posts.title
+FROM posts
+JOIN authors ON posts.author_id = authors.id
+WHERE posts.id = ?1;

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -395,6 +395,74 @@ pub fn sqlc_embed_expands_table_columns_test() {
   title_col.name |> should.equal("title")
 }
 
+pub fn sqlc_embed_rewrites_sql_to_column_list_test() {
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: GetBookFull :one\nSELECT sqlode.embed(authors), books.title FROM books JOIN authors ON books.author_id = authors.id WHERE books.id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("embed.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+
+  // The literal sqlode.embed(...) macro must not leak into emitted SQL.
+  string.contains(query.base.sql, "sqlode.embed(") |> should.be_false()
+  // Every column of the embedded table must appear as a qualified reference.
+  string.contains(query.base.sql, "authors.id") |> should.be_true()
+  string.contains(query.base.sql, "authors.name") |> should.be_true()
+  string.contains(query.base.sql, "authors.bio") |> should.be_true()
+  // Non-embed parts of the query are preserved.
+  string.contains(query.base.sql, "books.title") |> should.be_true()
+}
+
+pub fn sqlc_embed_rewrite_ignores_case_and_whitespace_test() {
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: GetBookFull :one\nSELECT Sqlode.Embed( authors ), books.title FROM books JOIN authors ON books.author_id = authors.id WHERE books.id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("embed.sql", model.PostgreSQL, naming_ctx, sql)
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  string.contains(query.base.sql, "embed(") |> should.be_false()
+  string.contains(query.base.sql, "authors.id") |> should.be_true()
+}
+
+pub fn sqlc_embed_rewrite_preserves_queries_without_embed_test() {
+  let naming_ctx = naming.new()
+  let catalog = join_catalog()
+  let sql =
+    "-- name: GetBookTitle :one\nSELECT books.title FROM books WHERE books.id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("plain.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert [parsed] = queries
+  let original_sql = parsed.sql
+
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  query.base.sql |> should.equal(original_sql)
+}
+
 pub fn returning_clause_result_columns_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -127,6 +127,18 @@ pub fn sqlc_embed_expands_table_columns_test() {
   query_analyzer_test.sqlc_embed_expands_table_columns_test()
 }
 
+pub fn sqlc_embed_rewrites_sql_to_column_list_test() {
+  query_analyzer_test.sqlc_embed_rewrites_sql_to_column_list_test()
+}
+
+pub fn sqlc_embed_rewrite_ignores_case_and_whitespace_test() {
+  query_analyzer_test.sqlc_embed_rewrite_ignores_case_and_whitespace_test()
+}
+
+pub fn sqlc_embed_rewrite_preserves_queries_without_embed_test() {
+  query_analyzer_test.sqlc_embed_rewrite_preserves_queries_without_embed_test()
+}
+
 pub fn returning_clause_result_columns_test() {
   query_analyzer_test.returning_clause_result_columns_test()
 }


### PR DESCRIPTION
## Summary

- Expand `sqlode.embed(TABLE)` into a concrete qualified column list before the generated runtime SQL is emitted, so the documented embed macro executes correctly against SQLite / PostgreSQL / MySQL.
- Make the string-level embed detector in `column_inferencer` case-insensitive to match the token-level detector already used for nested-type extraction.
- Add a real SQLite integration test that executes an embed query end-to-end and verifies the nested row type is decoded correctly, replacing the prior skip comment.

## Background

`sqlode.embed(authors)` was already documented and already drove nested
row-type codegen, but the macro text was never rewritten; the emitted
SQL still contained the literal `sqlode.embed(...)` call and the
database rejected it. The existing unit tests exercised only the codegen
path (nested type + decoder), and the sqlite advanced integration test
explicitly skipped the runtime check, so the bug never surfaced in CI.

## Design

- Rewrite the macro at the token level inside `query_analyzer.analyze_query`, **after** `column_inferencer.infer_result_columns` has resolved each `EmbeddedResult` against the catalog. The analyzer already owns the catalog, so no plumbing change is needed in the parser.
- New module `src/sqlode/query_analyzer/embed_rewriter.gleam`: walks the token list, matches the six-token pattern `Ident(\"sqlode\") Dot Ident(\"embed\") LParen Ident(TABLE) RParen` (case-insensitive on `sqlode` / `embed`), and swaps it for a comma-separated qualified column list whose order matches the `EmbeddedColumn.columns` list the adapter decoder already reads at consecutive indices.
- If no `EmbeddedResult` is present or the rewrite is a no-op, the original `ParsedQuery.sql` is returned unchanged — the analyzer avoids a redundant re-render pass.
- `column_inferencer.gleam` previously compared the raw extracted text with `starts_with(trimmed, \"sqlode.embed(\")`. That missed `Sqlode.Embed(...)` spellings even though the token-level detector already handled them. Lowered the trim result before the prefix check.

## Test plan

- [x] `gleam test` — 839 passed, no failures (includes 3 new unit tests for the rewrite: expansion, case/whitespace, no-embed pass-through).
- [x] `just all` — format-check, check, build (warnings-as-errors), gleam test, shellspec (20 examples, 0 failures).
- [x] `sh integration_test/run.sh` — all SQLite + compile cases pass, including the new `sqlode_embed_returns_nested_row_test` that inserts rows and verifies the nested `Author` record is decoded correctly.