### PR TITLE
refactor(parser/analyzer): introduce tokenized query IR

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -16,6 +16,7 @@ import sqlode/config
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
+import sqlode/query_ir
 import sqlode/query_parser
 import sqlode/runtime
 import sqlode/schema_parser
@@ -121,7 +122,7 @@ fn load_and_analyze_queries(
   block: model.SqlBlock,
   catalog: model.Catalog,
 ) -> Result(
-  #(List(model.ParsedQuery), List(model.AnalyzedQuery)),
+  #(List(query_ir.TokenizedQuery), List(model.AnalyzedQuery)),
   GenerateError,
 ) {
   use queries <- result.try(load_queries(naming_ctx, block))
@@ -140,7 +141,7 @@ fn render_output_files(
   naming_ctx: naming.NamingContext,
   block: model.SqlBlock,
   catalog: model.Catalog,
-  queries: List(model.ParsedQuery),
+  queries: List(query_ir.TokenizedQuery),
   analyzed: List(model.AnalyzedQuery),
 ) -> Result(List(writer.GeneratedFile), GenerateError) {
   let model.SqlBlock(gleam:, ..) = block
@@ -462,7 +463,7 @@ fn load_catalog(
 fn load_queries(
   naming_ctx: naming.NamingContext,
   block: model.SqlBlock,
-) -> Result(List(model.ParsedQuery), GenerateError) {
+) -> Result(List(query_ir.TokenizedQuery), GenerateError) {
   let model.SqlBlock(engine:, queries:, ..) = block
 
   use expanded <- result.try(
@@ -494,10 +495,10 @@ fn load_queries(
 }
 
 fn validate_no_duplicate_query_names(
-  queries: List(model.ParsedQuery),
-) -> Result(List(model.ParsedQuery), GenerateError) {
+  queries: List(query_ir.TokenizedQuery),
+) -> Result(List(query_ir.TokenizedQuery), GenerateError) {
   let grouped =
-    list.group(queries, fn(q) { q.name })
+    list.group(queries, fn(q) { q.base.name })
     |> dict.to_list
     |> list.filter(fn(entry) { list.length(entry.1) > 1 })
 
@@ -506,7 +507,7 @@ fn validate_no_duplicate_query_names(
     [#(name, dupes), ..] -> {
       let paths =
         dupes
-        |> list.map(fn(q) { q.source_path })
+        |> list.map(fn(q) { q.base.source_path })
         |> list.unique
       Error(DuplicateQueryName(name:, paths:))
     }

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -10,6 +10,7 @@ import sqlode/query_analyzer/context
 import sqlode/query_analyzer/embed_rewriter
 import sqlode/query_analyzer/param_inferencer
 import sqlode/query_analyzer/placeholder
+import sqlode/query_ir
 
 pub type AnalysisError =
   context.AnalysisError
@@ -22,7 +23,7 @@ pub fn analyze_queries(
   engine: model.Engine,
   catalog: model.Catalog,
   naming_ctx: naming.NamingContext,
-  queries: List(model.ParsedQuery),
+  queries: List(query_ir.TokenizedQuery),
 ) -> Result(List(model.AnalyzedQuery), AnalysisError) {
   let ctx = context.new(naming_ctx)
   list.try_map(queries, analyze_query(ctx, engine, catalog, _))
@@ -32,13 +33,13 @@ fn analyze_query(
   ctx: context.AnalyzerContext,
   engine: model.Engine,
   catalog: model.Catalog,
-  query: model.ParsedQuery,
+  tq: query_ir.TokenizedQuery,
 ) -> Result(model.AnalyzedQuery, AnalysisError) {
+  let query_ir.TokenizedQuery(base: query, tokens: tokens) = tq
   // Surface virtual tables the outer query references — CTEs, VALUES
   // in FROM, and derived-table subqueries — so both result-column and
   // parameter inference see them. Nested subqueries rediscover their
   // own VALUES / derived tables inside infer_columns_from_tokens_scoped.
-  let tokens = lexer.tokenize(query.sql, engine)
   use cte_tables <- result.try(column_inferencer.extract_cte_tables(
     query.name,
     tokens,
@@ -54,11 +55,12 @@ fn analyze_query(
   ))
   let augmented = merge_virtual_tables(with_values, derived_tables)
 
-  let occurrences = placeholder.extract(ctx, engine, query.sql)
+  let occurrences = placeholder.extract(ctx, engine, tokens)
   use params <- result.try(build_params(
     ctx,
     engine,
     query,
+    tokens,
     augmented,
     occurrences,
   ))
@@ -66,6 +68,7 @@ fn analyze_query(
     ctx,
     engine,
     query,
+    tokens,
     augmented,
   ))
 
@@ -119,18 +122,24 @@ fn build_params(
   ctx: context.AnalyzerContext,
   engine: model.Engine,
   query: model.ParsedQuery,
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
   occurrences: List(placeholder.PlaceholderOccurrence),
 ) -> Result(List(model.QueryParam), context.AnalysisError) {
   let inferences =
     list.append(
-      param_inferencer.infer_insert_params(ctx, engine, query, catalog),
-      param_inferencer.infer_equality_params(ctx, engine, query, catalog),
+      param_inferencer.infer_insert_params(ctx, engine, tokens, catalog),
+      param_inferencer.infer_equality_params(ctx, engine, tokens, catalog),
     )
-    |> list.append(param_inferencer.infer_in_params(ctx, engine, query, catalog))
+    |> list.append(param_inferencer.infer_in_params(
+      ctx,
+      engine,
+      tokens,
+      catalog,
+    ))
 
   use cast_dict <- result.try(
-    param_inferencer.extract_type_casts(ctx, engine, query.sql)
+    param_inferencer.extract_type_casts(ctx, engine, tokens)
     |> result.map_error(fn(err) {
       let #(index, cast_type) = err
       context.UnrecognizedCastType(

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -22,8 +22,9 @@ type ExtractedColumn {
 
 pub fn infer_result_columns(
   _ctx: AnalyzerContext,
-  engine: model.Engine,
+  _engine: model.Engine,
   query: model.ParsedQuery,
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
 ) -> Result(List(model.ResultItem), AnalysisError) {
   case query.command {
@@ -36,10 +37,8 @@ pub fn infer_result_columns(
     runtime.QueryOne
     | runtime.QueryMany
     | runtime.QueryBatchOne
-    | runtime.QueryBatchMany -> {
-      let tokens = lexer.tokenize(query.sql, engine)
+    | runtime.QueryBatchMany ->
       infer_columns_from_tokens(query.name, tokens, catalog)
-    }
   }
 }
 

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -12,11 +12,9 @@ import sqlode/query_analyzer/token_utils
 pub fn infer_insert_params(
   _ctx: AnalyzerContext,
   engine: model.Engine,
-  query: model.ParsedQuery,
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
-  let tokens = lexer.tokenize(query.sql, engine)
-
   case token_utils.find_insert_parts(tokens) {
     Some(parts) ->
       map_insert_columns(
@@ -86,10 +84,9 @@ fn map_insert_columns(
 pub fn infer_equality_params(
   _ctx: AnalyzerContext,
   engine: model.Engine,
-  query: model.ParsedQuery,
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
-  let tokens = lexer.tokenize(query.sql, engine)
   let all_tables = token_utils.extract_table_names(tokens)
 
   case all_tables {
@@ -174,10 +171,9 @@ fn scan_token_matches(
 pub fn infer_in_params(
   _ctx: AnalyzerContext,
   engine: model.Engine,
-  query: model.ParsedQuery,
+  tokens: List(lexer.Token),
   catalog: model.Catalog,
 ) -> List(#(Int, model.Column)) {
-  let tokens = lexer.tokenize(query.sql, engine)
   let all_tables = token_utils.extract_table_names(tokens)
 
   case all_tables {
@@ -202,11 +198,10 @@ pub fn infer_in_params(
 pub fn extract_type_casts(
   _ctx: AnalyzerContext,
   engine: model.Engine,
-  sql: String,
+  tokens: List(lexer.Token),
 ) -> Result(dict.Dict(Int, model.ScalarType), #(Int, String)) {
   case engine {
     model.PostgreSQL -> {
-      let tokens = lexer.tokenize(sql, engine)
       let casts = token_utils.find_type_casts(tokens)
       list.try_fold(casts, dict.new(), fn(d, cast) {
         case

--- a/src/sqlode/query_analyzer/placeholder.gleam
+++ b/src/sqlode/query_analyzer/placeholder.gleam
@@ -17,10 +17,10 @@ pub type PlaceholderOccurrence {
 pub fn extract(
   ctx: AnalyzerContext,
   engine: model.Engine,
-  sql: String,
+  tokens: List(lexer.Token),
 ) -> List(PlaceholderOccurrence) {
-  let tokens = placeholder_tokens(engine, sql)
-  build_occurrences(ctx, engine, tokens, 1, dict.new(), [])
+  let placeholder_tokens = token_utils.extract_placeholders(tokens)
+  build_occurrences(ctx, engine, placeholder_tokens, 1, dict.new(), [])
 }
 
 pub fn unique(
@@ -195,11 +195,6 @@ fn build_occurrences(
         }
       }
   }
-}
-
-fn placeholder_tokens(engine: model.Engine, sql: String) -> List(String) {
-  lexer.tokenize(sql, engine)
-  |> token_utils.extract_placeholders
 }
 
 fn default_param_name(ctx: AnalyzerContext, token: String, index: Int) -> String {

--- a/src/sqlode/query_ir.gleam
+++ b/src/sqlode/query_ir.gleam
@@ -1,0 +1,11 @@
+//// Intermediate representation shared between the query parser and the
+//// query analyzer. `TokenizedQuery` carries the expanded token list
+//// alongside the `ParsedQuery` metadata so analyzer layers can walk
+//// tokens without re-tokenizing the SQL string on every pass.
+
+import sqlode/lexer
+import sqlode/model
+
+pub type TokenizedQuery {
+  TokenizedQuery(base: model.ParsedQuery, tokens: List(lexer.Token))
+}

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -7,6 +7,7 @@ import gleam/string
 import sqlode/lexer
 import sqlode/model
 import sqlode/naming
+import sqlode/query_ir
 import sqlode/runtime
 
 pub type ParseError {
@@ -29,7 +30,7 @@ pub fn parse_file(
   engine: model.Engine,
   naming_ctx: naming.NamingContext,
   content: String,
-) -> Result(List(model.ParsedQuery), ParseError) {
+) -> Result(List(query_ir.TokenizedQuery), ParseError) {
   parse_lines(
     naming_ctx,
     string.split(content, "\n"),
@@ -50,9 +51,9 @@ fn parse_lines(
   engine: model.Engine,
   line_number: Int,
   pending: Option(PendingQuery),
-  parsed_rev: List(model.ParsedQuery),
+  parsed_rev: List(query_ir.TokenizedQuery),
   skip_next: Bool,
-) -> Result(List(model.ParsedQuery), ParseError) {
+) -> Result(List(query_ir.TokenizedQuery), ParseError) {
   case lines {
     [] -> finalize_pending(naming_ctx, pending, path, engine, parsed_rev)
     [line, ..rest] -> {
@@ -158,8 +159,8 @@ fn finalize_pending(
   pending: Option(PendingQuery),
   path: String,
   engine: model.Engine,
-  parsed_rev: List(model.ParsedQuery),
-) -> Result(List(model.ParsedQuery), ParseError) {
+  parsed_rev: List(query_ir.TokenizedQuery),
+) -> Result(List(query_ir.TokenizedQuery), ParseError) {
   case pending {
     None -> Ok(parsed_rev)
     Some(PendingQuery(name:, function_name:, command:, start_line:, body_rev:)) -> {
@@ -199,7 +200,7 @@ fn finalize_pending(
           // Phase 5: Count parameters from the already-expanded token list
           let param_count = count_parameters_from_tokens(engine, tokens)
 
-          Ok([
+          let parsed =
             model.ParsedQuery(
               name:,
               function_name:,
@@ -208,7 +209,9 @@ fn finalize_pending(
               source_path: path,
               param_count:,
               macros:,
-            ),
+            )
+          Ok([
+            query_ir.TokenizedQuery(base: parsed, tokens: tokens),
             ..parsed_rev
           ])
         }

--- a/test/dialect_test.gleam
+++ b/test/dialect_test.gleam
@@ -5,6 +5,7 @@ import simplifile
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
+import sqlode/query_ir
 import sqlode/query_parser
 import sqlode/runtime
 import sqlode/schema_parser
@@ -306,7 +307,7 @@ fn parse_queries(
   path: String,
   engine: model.Engine,
   naming_ctx: naming.NamingContext,
-) -> List(model.ParsedQuery) {
+) -> List(query_ir.TokenizedQuery) {
   let assert Ok(content) = simplifile.read(path)
   let assert Ok(queries) =
     query_parser.parse_file(path, engine, naming_ctx, content)

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -450,7 +450,7 @@ pub fn sqlc_embed_rewrite_preserves_queries_without_embed_test() {
   let assert Ok(queries) =
     query_parser.parse_file("plain.sql", model.PostgreSQL, naming_ctx, sql)
   let assert [parsed] = queries
-  let original_sql = parsed.sql
+  let original_sql = parsed.base.sql
 
   let assert Ok(analyzed) =
     query_analyzer.analyze_queries(

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import gleam/result
 import gleam/string
 import gleeunit
 import gleeunit/should
@@ -12,16 +13,25 @@ pub fn main() {
   gleeunit.main()
 }
 
+/// Thin wrapper that unwraps `query_ir.TokenizedQuery` to `model.ParsedQuery`
+/// so the parser-focused assertions in this file can keep accessing
+/// `.name`, `.sql`, `.macros` etc. directly. The analyzer pipeline still
+/// sees the tokenized form.
+fn parse_file(
+  path: String,
+  engine: model.Engine,
+  naming_ctx: naming.NamingContext,
+  content: String,
+) -> Result(List(model.ParsedQuery), query_parser.ParseError) {
+  query_parser.parse_file(path, engine, naming_ctx, content)
+  |> result.map(list.map(_, fn(q) { q.base }))
+}
+
 pub fn parse_queries_from_sqlc_annotations_test() {
   let naming_ctx = naming.new()
   let assert Ok(content) = simplifile.read("test/fixtures/query.sql")
   let assert Ok(queries) =
-    query_parser.parse_file(
-      "test/fixtures/query.sql",
-      model.PostgreSQL,
-      naming_ctx,
-      content,
-    )
+    parse_file("test/fixtures/query.sql", model.PostgreSQL, naming_ctx, content)
 
   list.length(queries) |> should.equal(2)
 
@@ -40,7 +50,7 @@ pub fn reject_query_without_sql_body_test() {
   let content = "-- name: GetAuthor :one\n"
 
   let assert Error(error) =
-    query_parser.parse_file("broken.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("broken.sql", model.PostgreSQL, naming_ctx, content)
 
   query_parser.error_to_string(error)
   |> should.equal("broken.sql:1: query GetAuthor is missing SQL body")
@@ -53,7 +63,7 @@ pub fn count_mysql_placeholders_test() {
     <> "INSERT INTO authors (name, bio) VALUES (?, ?);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("mysql.sql", model.MySQL, naming_ctx, content)
+    parse_file("mysql.sql", model.MySQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -66,7 +76,7 @@ pub fn count_sqlite_named_placeholders_test() {
     <> "SELECT id FROM authors WHERE id = :id OR name = @name OR slug = $slug OR code = ?2;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(4)
@@ -79,7 +89,7 @@ pub fn expand_sqlc_arg_macro_test() {
     <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -96,7 +106,7 @@ pub fn expand_sqlc_narg_macro_test() {
     <> "UPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -116,7 +126,7 @@ pub fn expand_sqlc_arg_mysql_test() {
     <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("arg_mysql.sql", model.MySQL, naming_ctx, content)
+    parse_file("arg_mysql.sql", model.MySQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -132,7 +142,7 @@ pub fn expand_sqlc_arg_single_quoted_test() {
     <> "SELECT id FROM authors WHERE name = sqlode.arg('author_name');"
 
   let assert Ok(queries) =
-    query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -149,7 +159,7 @@ pub fn expand_sqlc_arg_double_quoted_test() {
     <> "SELECT id FROM authors WHERE name = sqlode.arg(\"author_name\");"
 
   let assert Ok(queries) =
-    query_parser.parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -164,7 +174,7 @@ pub fn expand_sqlc_narg_single_quoted_test() {
     <> "UPDATE authors SET bio = sqlode.narg('new_bio') WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -182,7 +192,7 @@ pub fn expand_sqlc_slice_double_quoted_test() {
     <> "SELECT id, name FROM authors WHERE id IN (sqlode.slice(\"ids\"));"
 
   let assert Ok(queries) =
-    query_parser.parse_file("slice.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("slice.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.macros
@@ -198,7 +208,7 @@ pub fn expand_at_name_postgresql_test() {
     <> "SELECT id FROM authors WHERE name = @author_name;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -215,7 +225,7 @@ pub fn expand_at_name_sqlite_test() {
     <> "SELECT id FROM authors WHERE name = @author_name;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("at.sql", model.SQLite, naming_ctx, content)
+    parse_file("at.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -232,7 +242,7 @@ pub fn expand_multiple_at_names_test() {
     <> "UPDATE authors SET bio = @new_bio WHERE id = @author_id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -252,7 +262,7 @@ pub fn expand_at_name_mixed_with_sqlc_arg_test() {
     <> "UPDATE authors SET bio = @new_bio WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -270,7 +280,7 @@ pub fn at_name_not_expanded_on_mysql_test() {
     <> "SELECT id FROM authors WHERE name = @author_name;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("at.sql", model.MySQL, naming_ctx, content)
+    parse_file("at.sql", model.MySQL, naming_ctx, content)
   let assert [query] = queries
 
   query.macros |> should.equal([])
@@ -284,7 +294,7 @@ pub fn invalid_annotation_format_test() {
   let content = "-- name: OnlyName\nSELECT 1;"
 
   let assert Error(error) =
-    query_parser.parse_file("bad.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("bad.sql", model.PostgreSQL, naming_ctx, content)
   let msg = query_parser.error_to_string(error)
   string.contains(msg, "expected") |> should.be_true()
   string.contains(msg, ":one") |> should.be_true()
@@ -296,7 +306,7 @@ pub fn invalid_command_test() {
   let content = "-- name: MyQuery :unknown\nSELECT 1;"
 
   let assert Error(error) =
-    query_parser.parse_file("bad.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("bad.sql", model.PostgreSQL, naming_ctx, content)
   let msg = query_parser.error_to_string(error)
   string.contains(msg, "must be one of") |> should.be_true()
 }
@@ -306,14 +316,14 @@ pub fn file_with_no_annotations_test() {
   let content = "SELECT 1;\nSELECT 2;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("none.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("none.sql", model.PostgreSQL, naming_ctx, content)
   queries |> should.equal([])
 }
 
 pub fn empty_file_test() {
   let naming_ctx = naming.new()
   let assert Ok(queries) =
-    query_parser.parse_file("empty.sql", model.PostgreSQL, naming_ctx, "")
+    parse_file("empty.sql", model.PostgreSQL, naming_ctx, "")
   queries |> should.equal([])
 }
 
@@ -325,7 +335,7 @@ pub fn multiple_queries_test() {
     <> "-- name: Q3 :exec\nINSERT INTO t VALUES (1);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
   list.length(queries) |> should.equal(3)
 
   let assert [q1, q2, q3] = queries
@@ -348,7 +358,7 @@ pub fn all_command_types_test() {
     <> "-- name: F :execlastid\nSELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("cmds.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("cmds.sql", model.PostgreSQL, naming_ctx, content)
   list.length(queries) |> should.equal(6)
 
   let assert [a, b, c, d, e, f] = queries
@@ -371,7 +381,7 @@ pub fn multiline_sql_body_test() {
     <> "WHERE id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.param_count |> should.equal(1)
   // Token-first rendering normalizes keywords to lowercase
@@ -390,7 +400,7 @@ pub fn ignore_placeholder_in_single_quoted_string_test() {
     <> "WHERE note = '$2' OR id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("lit.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("lit.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   // $2 inside string should be ignored, only $1 counts
@@ -406,7 +416,7 @@ pub fn ignore_placeholder_in_line_comment_test() {
     <> "WHERE id = $1; -- $2 is not used"
 
   let assert Ok(queries) =
-    query_parser.parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -422,7 +432,7 @@ pub fn ignore_placeholder_in_block_comment_test() {
     <> "WHERE id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -436,7 +446,7 @@ pub fn ignore_at_name_in_string_literal_test() {
     <> "WHERE note = '@skip_me' AND id = @real_id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   // @skip_me inside string should not be expanded
@@ -452,8 +462,7 @@ pub fn ignore_question_mark_in_string_mysql_test() {
     <> "SELECT id FROM authors\n"
     <> "WHERE note = 'is this a ?' AND id = ?;"
 
-  let assert Ok(queries) =
-    query_parser.parse_file("q.sql", model.MySQL, naming_ctx, content)
+  let assert Ok(queries) = parse_file("q.sql", model.MySQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -466,7 +475,7 @@ pub fn sqlite_repeated_colon_placeholder_dedup_test() {
     <> "SELECT id FROM authors WHERE id = :id OR parent_id = :id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -479,7 +488,7 @@ pub fn sqlite_repeated_dollar_placeholder_dedup_test() {
     <> "SELECT id FROM authors WHERE id = $id OR parent_id = $id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -492,7 +501,7 @@ pub fn sqlite_repeated_at_placeholder_dedup_test() {
     <> "SELECT id FROM authors WHERE id = @id OR parent_id = @id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -505,7 +514,7 @@ pub fn sqlite_distinct_named_placeholders_not_deduped_test() {
     <> "SELECT id FROM authors WHERE id = :id OR name = :name;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -518,7 +527,7 @@ pub fn sqlite_colon_and_at_are_different_params_test() {
     <> "SELECT id FROM authors WHERE id = :id OR parent_id = @id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -531,7 +540,7 @@ pub fn sqlite_bare_question_marks_not_deduped_test() {
     <> "INSERT INTO authors (name, bio) VALUES (?, ?);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -544,7 +553,7 @@ pub fn sqlite_repeated_numbered_placeholder_dedup_test() {
     <> "SELECT id FROM authors WHERE id = ?1 OR parent_id = ?1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -557,7 +566,7 @@ pub fn postgresql_plain_dollar_quoted_string_masks_placeholder_test() {
     <> "SELECT $$literal $1 inside$$, id FROM authors WHERE id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -570,7 +579,7 @@ pub fn postgresql_tagged_dollar_quoted_string_masks_placeholder_test() {
     <> "SELECT $tag$literal $1 inside$tag$, id FROM authors WHERE id = $2;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -583,7 +592,7 @@ pub fn postgresql_dollar_quoted_does_not_affect_real_params_test() {
     <> "SELECT $fn$body with $1 and $2$fn$, id FROM authors WHERE id = $1 AND name = $2;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(2)
@@ -595,7 +604,7 @@ pub fn sqlite_dollar_not_treated_as_dollar_quoted_test() {
     "-- name: SqliteDollar :one\n" <> "SELECT id FROM authors WHERE id = $id;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
+    parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -608,7 +617,7 @@ pub fn sqlc_arg_in_string_literal_ignored_test() {
     <> "SELECT id FROM authors WHERE note = 'sqlode.arg(fake)' AND id = sqlode.arg(real_id);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -626,7 +635,7 @@ pub fn sqlc_narg_in_line_comment_ignored_test() {
     <> "WHERE id = sqlode.arg(real_id);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -642,7 +651,7 @@ pub fn sqlc_slice_in_block_comment_ignored_test() {
     <> "WHERE /* sqlode.slice(phantom) */ id IN (sqlode.slice(real_ids));"
 
   let assert Ok(queries) =
-    query_parser.parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
 
   query.param_count |> should.equal(1)
@@ -679,7 +688,7 @@ pub fn skip_annotation_skips_query_test() {
     <> "SELECT id FROM authors;\n"
 
   let assert Ok(queries) =
-    query_parser.parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
 
   list.length(queries) |> should.equal(1)
   let assert [query] = queries
@@ -699,7 +708,7 @@ pub fn skip_annotation_all_queries_skipped_test() {
     <> "SELECT 2;\n"
 
   let assert Ok(queries) =
-    query_parser.parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
 
   list.length(queries) |> should.equal(0)
 }
@@ -718,7 +727,7 @@ pub fn skip_annotation_middle_query_test() {
     <> "SELECT 3;\n"
 
   let assert Ok(queries) =
-    query_parser.parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
 
   list.length(queries) |> should.equal(2)
   let names = list.map(queries, fn(q) { q.name })
@@ -733,7 +742,7 @@ pub fn parse_block_annotation_one_test() {
     "/* name: GetAuthor :one */\nSELECT id FROM authors WHERE id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("GetAuthor")
   query.function_name |> should.equal("get_author")
@@ -746,7 +755,7 @@ pub fn parse_block_annotation_many_test() {
   let content = "/* name: ListAll :many */\nSELECT * FROM authors;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("ListAll")
   query.command |> should.equal(runtime.QueryMany)
@@ -757,7 +766,7 @@ pub fn parse_block_annotation_exec_test() {
   let content = "/* name: InsertRow :exec */\nINSERT INTO t (v) VALUES ($1);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("InsertRow")
   query.command |> should.equal(runtime.QueryExec)
@@ -768,7 +777,7 @@ pub fn parse_block_annotation_whitespace_tolerance_test() {
   let content = "/*    name:   Spaced   :one    */\nSELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("Spaced")
   query.command |> should.equal(runtime.QueryOne)
@@ -779,7 +788,7 @@ pub fn parse_block_annotation_no_inner_space_test() {
   let content = "/*name: Tight :one*/\nSELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("Tight")
   query.command |> should.equal(runtime.QueryOne)
@@ -798,7 +807,7 @@ pub fn parse_mixed_line_and_block_annotations_test() {
     <> "INSERT INTO t VALUES (1);\n"
 
   let assert Ok(queries) =
-    query_parser.parse_file("mixed.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("mixed.sql", model.PostgreSQL, naming_ctx, content)
   list.length(queries) |> should.equal(3)
 
   let assert [q1, q2, q3] = queries
@@ -821,7 +830,7 @@ pub fn parse_block_annotation_multiline_body_test() {
     <> "WHERE id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("BigQuery")
   query.param_count |> should.equal(1)
@@ -834,7 +843,7 @@ pub fn parse_block_annotation_with_macro_test() {
     <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.param_count |> should.equal(1)
   list.length(query.macros) |> should.equal(1)
@@ -849,7 +858,7 @@ pub fn parse_block_annotation_body_with_regular_block_comment_test() {
     <> "FROM authors WHERE id = $1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("WithComment")
   query.param_count |> should.equal(1)
@@ -861,7 +870,7 @@ pub fn parse_block_comment_other_directive_ignored_test() {
     "-- name: Real :one\n" <> "/* other: bogus :many */\n" <> "SELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("Real")
   query.command |> should.equal(runtime.QueryOne)
@@ -873,7 +882,7 @@ pub fn parse_block_annotation_inline_sql_not_annotation_test() {
   let content = "/* name: X :one */ SELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   queries |> should.equal([])
 }
 
@@ -882,7 +891,7 @@ pub fn parse_block_annotation_unclosed_ignored_test() {
   let content = "/* name: NotReally :one\nSELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   queries |> should.equal([])
 }
 
@@ -892,7 +901,7 @@ pub fn parse_block_annotation_multiline_not_annotation_test() {
   let content = "/* name: Split\n" <> " :one */\n" <> "SELECT 1;"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   queries |> should.equal([])
 }
 
@@ -901,7 +910,7 @@ pub fn parse_block_annotation_invalid_command_test() {
   let content = "/* name: Q :bogus */\nSELECT 1;"
 
   let assert Error(error) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let msg = query_parser.error_to_string(error)
   string.contains(msg, "must be one of") |> should.be_true()
 }
@@ -911,7 +920,7 @@ pub fn parse_block_annotation_missing_command_test() {
   let content = "/* name: OnlyName */\nSELECT 1;"
 
   let assert Error(error) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let msg = query_parser.error_to_string(error)
   string.contains(msg, "/* name:") |> should.be_true()
 }
@@ -921,7 +930,7 @@ pub fn parse_block_annotation_missing_sql_body_test() {
   let content = "/* name: NoBody :one */\n"
 
   let assert Error(error) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
 
   query_parser.error_to_string(error)
   |> should.equal("block.sql:1: query NoBody is missing SQL body")
@@ -938,7 +947,7 @@ pub fn skip_annotation_applies_to_block_annotation_test() {
     <> "SELECT 2;\n"
 
   let assert Ok(queries) =
-    query_parser.parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
+    parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("Kept")
   query.command |> should.equal(runtime.QueryMany)

--- a/test/sqlc_compat_test.gleam
+++ b/test/sqlc_compat_test.gleam
@@ -5,6 +5,7 @@ import simplifile
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
+import sqlode/query_ir
 import sqlode/query_parser
 import sqlode/runtime
 import sqlode/schema_parser
@@ -393,10 +394,10 @@ pub fn macro_duplicate_arg_name_test() {
     )
 
   let assert Ok(search) =
-    list.find(queries, fn(q) { q.name == "SearchByNameOrBio" })
+    list.find(queries, fn(q) { q.base.name == "SearchByNameOrBio" })
   // Two sqlode.arg(search_term) should produce two separate placeholders
-  search.param_count |> should.equal(2)
-  list.length(search.macros) |> should.equal(2)
+  search.base.param_count |> should.equal(2)
+  list.length(search.base.macros) |> should.equal(2)
 }
 
 pub fn macro_mixed_arg_narg_test() {
@@ -527,9 +528,10 @@ pub fn upsert_on_conflict_test() {
       naming_ctx,
     )
 
-  let assert Ok(upsert) = list.find(queries, fn(q) { q.name == "UpsertUser" })
-  upsert.command |> should.equal(runtime.QueryOne)
-  upsert.param_count |> should.equal(2)
+  let assert Ok(upsert) =
+    list.find(queries, fn(q) { q.base.name == "UpsertUser" })
+  upsert.base.command |> should.equal(runtime.QueryOne)
+  upsert.base.param_count |> should.equal(2)
 
   let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
@@ -555,9 +557,9 @@ pub fn distinct_query_test() {
     )
 
   let assert Ok(distinct) =
-    list.find(queries, fn(q) { q.name == "ListPostsByTag" })
-  distinct.command |> should.equal(runtime.QueryMany)
-  distinct.param_count |> should.equal(1)
+    list.find(queries, fn(q) { q.base.name == "ListPostsByTag" })
+  distinct.base.command |> should.equal(runtime.QueryMany)
+  distinct.base.param_count |> should.equal(1)
 }
 
 pub fn group_by_having_test() {
@@ -570,9 +572,9 @@ pub fn group_by_having_test() {
     )
 
   let assert Ok(grouped) =
-    list.find(queries, fn(q) { q.name == "ListActiveUsers" })
-  grouped.command |> should.equal(runtime.QueryMany)
-  grouped.param_count |> should.equal(1)
+    list.find(queries, fn(q) { q.base.name == "ListActiveUsers" })
+  grouped.base.command |> should.equal(runtime.QueryMany)
+  grouped.base.param_count |> should.equal(1)
 }
 
 pub fn exists_subquery_test() {
@@ -586,10 +588,10 @@ pub fn exists_subquery_test() {
     )
 
   let assert Ok(with_posts) =
-    list.find(queries, fn(q) { q.name == "ListUsersWithPosts" })
-  with_posts.command |> should.equal(runtime.QueryMany)
+    list.find(queries, fn(q) { q.base.name == "ListUsersWithPosts" })
+  with_posts.base.command |> should.equal(runtime.QueryMany)
   // No params in the outer query (subquery is correlated, not parameterized)
-  with_posts.param_count |> should.equal(0)
+  with_posts.base.param_count |> should.equal(0)
 
   let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
@@ -613,9 +615,9 @@ pub fn not_exists_subquery_test() {
     )
 
   let assert Ok(without_posts) =
-    list.find(queries, fn(q) { q.name == "ListUsersWithoutPosts" })
-  without_posts.command |> should.equal(runtime.QueryMany)
-  without_posts.param_count |> should.equal(0)
+    list.find(queries, fn(q) { q.base.name == "ListUsersWithoutPosts" })
+  without_posts.base.command |> should.equal(runtime.QueryMany)
+  without_posts.base.param_count |> should.equal(0)
 }
 
 pub fn parameterized_pagination_test() {
@@ -629,9 +631,9 @@ pub fn parameterized_pagination_test() {
     )
 
   let assert Ok(paginate) =
-    list.find(queries, fn(q) { q.name == "PaginateUsers" })
-  paginate.command |> should.equal(runtime.QueryMany)
-  paginate.param_count |> should.equal(2)
+    list.find(queries, fn(q) { q.base.name == "PaginateUsers" })
+  paginate.base.command |> should.equal(runtime.QueryMany)
+  paginate.base.param_count |> should.equal(2)
 
   let assert Ok(analyzed) =
     query_analyzer.analyze_queries(
@@ -655,10 +657,10 @@ pub fn multiple_ctes_test() {
     )
 
   let assert Ok(multi_cte) =
-    list.find(queries, fn(q) { q.name == "RecentPostsWithAuthor" })
-  multi_cte.command |> should.equal(runtime.QueryMany)
+    list.find(queries, fn(q) { q.base.name == "RecentPostsWithAuthor" })
+  multi_cte.base.command |> should.equal(runtime.QueryMany)
   // No parameters in this query
-  multi_cte.param_count |> should.equal(0)
+  multi_cte.base.param_count |> should.equal(0)
 }
 
 pub fn distinct_top_scores_test() {
@@ -671,9 +673,9 @@ pub fn distinct_top_scores_test() {
     )
 
   let assert Ok(top) =
-    list.find(queries, fn(q) { q.name == "TopDistinctScores" })
-  top.command |> should.equal(runtime.QueryMany)
-  top.param_count |> should.equal(1)
+    list.find(queries, fn(q) { q.base.name == "TopDistinctScores" })
+  top.base.command |> should.equal(runtime.QueryMany)
+  top.base.param_count |> should.equal(1)
 }
 
 // ============================================================
@@ -690,7 +692,7 @@ fn parse_queries(
   path: String,
   engine: model.Engine,
   naming_ctx: naming.NamingContext,
-) -> List(model.ParsedQuery) {
+) -> List(query_ir.TokenizedQuery) {
   let assert Ok(content) = simplifile.read(path)
   let assert Ok(queries) =
     query_parser.parse_file(path, engine, naming_ctx, content)


### PR DESCRIPTION
## Summary

- Stop re-tokenizing the same SQL string in six different analyzer code paths. Introduce `query_ir.TokenizedQuery { base: ParsedQuery, tokens }` as the handoff between the parser and every analyzer layer so tokens are produced exactly once.
- Keep the downstream surface (`AnalyzedQuery.base`, codegen, embed rewriter) completely unchanged — this is a pipeline-internal refactor.

## Why

Every layer of the analyzer used to call `lexer.tokenize(query.sql, engine)` on its way in:
- `query_analyzer.analyze_query` (outer tokens)
- `param_inferencer.infer_insert_params`, `infer_equality_params`, `infer_in_params` (one each)
- `param_inferencer.extract_type_casts` (PostgreSQL casts)
- `placeholder.extract` via the private `placeholder_tokens` helper
- `column_inferencer.infer_result_columns`

That was six lex passes per query and made every new inference context (CASE, functions, arithmetic) land a decision about \"which layer walks the tokens.\" #382 calls this out as a drag on future feature work.

## Design

Minimal seam:

- New module `src/sqlode/query_ir.gleam` owns a single record `TokenizedQuery { base: model.ParsedQuery, tokens: List(lexer.Token) }`. No constructors moved, no circular import between `model` and `lexer`.
- `query_parser.parse_file` now returns `List(TokenizedQuery)`. It already had the expanded token list in `finalize_pending`; previously it rendered that list back to a string and threw the tokens away. Now it pairs them with the `ParsedQuery` record.
- `query_analyzer.analyze_queries` accepts the new list type, destructures once, and threads the cached tokens into every consumer:
  - `column_inferencer.infer_result_columns` takes tokens directly (engine arg retained for signature stability, no longer used).
  - `param_inferencer.infer_{insert,equality,in}_params` and `extract_type_casts` take tokens instead of the SQL string.
  - `placeholder.extract` takes tokens; the private `placeholder_tokens` helper is deleted.
- `AnalyzedQuery.base` is still a bare `ParsedQuery`, so codegen (`queries.gleam`, `adapter.gleam`) and the embed rewriter are untouched.

## Test approach

- `query_parser_test` keeps asserting directly on `ParsedQuery` fields via a thin local `parse_file` wrapper that unwraps `.base`.
- Helpers in `sqlc_compat_test` and `dialect_test` return `List(TokenizedQuery)` so the analyzer signature stays typed. A handful of field accesses on find-by-name variables now use `.base.name` / `.base.command` / `.base.param_count`.
- Full `just all` (format-check + gleam check + warnings-as-errors build + 839 gleam tests + 20 shellspec examples) passes.
- Full `sh integration_test/run.sh` (4 compile cases + SQLite basic / extended / advanced) passes.

## Out of scope

No change to the parser's external API shape beyond the return type, no change to the token representation itself, no `Doc` / AST introduction. This is exactly what #382 asked for — nothing more.