### PR TITLE
fix+refactor: address comprehensive review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 sqlode reads SQL schema and query files, then generates typed Gleam code. The workflow follows [sqlc](https://sqlc.dev/) conventions: write SQL, run the generator, get type-safe functions.
 
+> **Note:** sqlode is inspired by sqlc's workflow but is **not** a drop-in replacement.
+> Macro syntax uses the `sqlode.*` prefix exclusively (e.g., `sqlode.arg(name)`,
+> `sqlode.embed(table)`). The `sqlc.*` prefix is not supported.
+
 Supported engines: PostgreSQL, MySQL (parsing only), SQLite.
 
 ## Getting started
@@ -92,7 +96,7 @@ sql:
 `schema` and `queries` accept either a single file path, a list of file paths, or a directory path. When given a directory, sqlode auto-discovers every `.sql` file inside it. An optional `name` field can be set on each `sql` block for diagnostics when multiple blocks are configured.
 
 > [!IMPORTANT]
-> The schema parser accepts a **schema snapshot or add-only migrations**. Supported: `CREATE TABLE` / `CREATE VIEW` / `CREATE TYPE` / `ALTER TABLE ... ADD COLUMN`. Statements like `DROP TABLE`, `ALTER TABLE ... DROP COLUMN`, or `ALTER TABLE ... RENAME` are rejected. Pointing sqlode at a full migration history that includes destructive DDL will fail — keep a separate, additive snapshot for code generation. See [Limitations](#limitations) for the full list.
+> The schema parser accepts a **schema snapshot or migration history**. Supported DDL: `CREATE TABLE` / `CREATE VIEW` / `CREATE TYPE` / `ALTER TABLE ... ADD COLUMN` / `DROP TABLE` / `DROP VIEW` / `DROP TYPE` / `ALTER TABLE ... DROP COLUMN` / `ALTER TABLE ... RENAME` / `ALTER TABLE ... ALTER COLUMN TYPE` / `ALTER TABLE ... SET/DROP NOT NULL`. Both additive and destructive migrations can be processed. See [Limitations](#limitations) for the full list.
 
 ### Write SQL
 
@@ -620,23 +624,16 @@ Typical cases that need an explicit cast today: parameters inside scalar arithme
 
 ### Schema DDL scope
 
-The schema parser is designed for **schema snapshots or add-only migration files**, not full migration histories. Supported statements:
+The schema parser supports both **schema snapshots and migration histories** including destructive DDL. Supported statements:
 
-- `CREATE TABLE`
-- `CREATE VIEW`
-- `CREATE TYPE` (enum)
+- `CREATE TABLE`, `CREATE VIEW`, `CREATE TYPE` (enum)
 - `ALTER TABLE ... ADD COLUMN`
-
-Rejected (error at load time):
-
 - `DROP TABLE`, `DROP VIEW`, `DROP TYPE`
 - `ALTER TABLE ... DROP COLUMN`
 - `ALTER TABLE ... RENAME TO` / `RENAME COLUMN`
-- `ALTER TABLE ... ALTER COLUMN` (type changes)
+- `ALTER TABLE ... ALTER COLUMN TYPE` / `SET NOT NULL` / `DROP NOT NULL`
 
 Other statements (`CREATE INDEX`, transaction blocks, comments) are silently skipped.
-
-If your migration workflow mutates schema in place, keep a separate snapshot file for sqlode rather than pointing it at the migration history directly.
 
 ### View resolution
 

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -4,6 +4,8 @@ import gleam/string
 import sqlode/codegen/common
 import sqlode/model
 import sqlode/naming
+import sqlode/runtime
+import sqlode/type_mapping
 
 pub fn render(
   naming_ctx: naming.NamingContext,
@@ -40,15 +42,51 @@ pub fn render(
 
   let has_any_params = list.any(queries, fn(q) { !list.is_empty(q.params) })
 
+  let decoder_queries =
+    queries
+    |> list.filter(fn(q) { has_result_columns(q) })
+
+  let decoder_functions = case decoder_queries {
+    [] -> ""
+    _ ->
+      decoder_queries
+      |> list.map(render_decoder_function(naming_ctx, _, engine, module_path))
+      |> string.join("\n\n")
+  }
+
+  let has_decoders = !list.is_empty(decoder_queries)
+  let has_nullable =
+    has_decoders
+    && list.any(decoder_queries, fn(q) {
+      list.any(q.result_columns, fn(col) {
+        case col {
+          model.ScalarResult(model.ResultColumn(nullable: True, ..)) -> True
+          _ -> False
+        }
+      })
+    })
+
   let imports =
     list.flatten([
       case has_slices {
         True -> ["import gleam/list"]
         False -> []
       },
+      case has_decoders {
+        True -> ["import gleam/dynamic/decode"]
+        False -> []
+      },
+      case has_nullable {
+        True -> ["import gleam/option.{type Option}"]
+        False -> []
+      },
       ["import " <> common.runtime_import_path(gleam)],
       case has_any_params {
         True -> ["import " <> module_path <> "/params"]
+        False -> []
+      },
+      case has_decoders {
+        True -> ["import " <> module_path <> "/models"]
         False -> []
       },
     ])
@@ -70,6 +108,10 @@ pub fn render(
         "",
         query_functions,
       ],
+      case decoder_functions {
+        "" -> []
+        _ -> ["", decoder_functions]
+      },
     ]),
     "\n",
   )
@@ -147,6 +189,111 @@ fn render_query_function(
         encode_line,
         slice_info_line,
         "  )",
+        "}",
+      ],
+    ]),
+    "\n",
+  )
+}
+
+fn has_result_columns(query: model.AnalyzedQuery) -> Bool {
+  case query.base.command {
+    runtime.QueryOne | runtime.QueryMany -> !list.is_empty(query.result_columns)
+    _ -> False
+  }
+}
+
+fn render_decoder_function(
+  naming_ctx: naming.NamingContext,
+  query: model.AnalyzedQuery,
+  engine: model.Engine,
+  _module_path: String,
+) -> String {
+  let type_name = naming.to_pascal_case(naming_ctx, query.base.name) <> "Row"
+
+  let #(_, field_lines) =
+    list.fold(query.result_columns, #(0, []), fn(acc, col) {
+      let #(idx, lines) = acc
+      case col {
+        model.ScalarResult(model.ResultColumn(
+          name:,
+          scalar_type:,
+          nullable:,
+          ..,
+        )) -> {
+          let field_name = naming.to_snake_case(naming_ctx, name)
+          let base = type_mapping.scalar_type_to_decoder(engine, scalar_type)
+          let decoder = case nullable {
+            True -> "decode.optional(" <> base <> ")"
+            False -> base
+          }
+          let line =
+            "  use "
+            <> field_name
+            <> " <- decode.field("
+            <> int.to_string(idx)
+            <> ", "
+            <> decoder
+            <> ")"
+          #(idx + 1, list.append(lines, [line]))
+        }
+        model.EmbeddedResult(model.EmbeddedColumn(columns: embed_cols, ..)) -> {
+          let #(new_idx, embed_lines) =
+            list.fold(embed_cols, #(idx, []), fn(inner_acc, c) {
+              let #(i, ls) = inner_acc
+              let field_name = naming.to_snake_case(naming_ctx, c.name)
+              let base =
+                type_mapping.scalar_type_to_decoder(engine, c.scalar_type)
+              let decoder = case c.nullable {
+                True -> "decode.optional(" <> base <> ")"
+                False -> base
+              }
+              let line =
+                "  use "
+                <> field_name
+                <> " <- decode.field("
+                <> int.to_string(i)
+                <> ", "
+                <> decoder
+                <> ")"
+              #(i + 1, list.append(ls, [line]))
+            })
+          #(new_idx, list.append(lines, embed_lines))
+        }
+      }
+    })
+
+  let constructor_fields =
+    query.result_columns
+    |> list.flat_map(fn(col) {
+      case col {
+        model.ScalarResult(model.ResultColumn(name:, ..)) -> [
+          naming.to_snake_case(naming_ctx, name) <> ":",
+        ]
+        model.EmbeddedResult(model.EmbeddedColumn(columns: embed_cols, ..)) ->
+          list.map(embed_cols, fn(c) {
+            naming.to_snake_case(naming_ctx, c.name) <> ":"
+          })
+      }
+    })
+    |> string.join(", ")
+
+  string.join(
+    list.flatten([
+      [
+        "pub fn "
+        <> query.base.function_name
+        <> "_decoder() -> decode.Decoder(models."
+        <> type_name
+        <> ") {",
+      ],
+      field_lines,
+      [
+        "  decode.success(models."
+          <> type_name
+          <> "("
+          <> constructor_fields
+          <> "))",
         "}",
       ],
     ]),

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -1,3 +1,4 @@
+import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
 import gleam/string
@@ -11,6 +12,8 @@ pub fn render(
   naming_ctx: naming.NamingContext,
   block: model.SqlBlock,
   queries: List(model.AnalyzedQuery),
+  table_matches: Dict(String, String),
+  emit_exact_table_names: Bool,
 ) -> String {
   let model.SqlBlock(engine:, gleam:, ..) = block
   let model.GleamOutput(runtime:, out:, ..) = gleam
@@ -50,7 +53,14 @@ pub fn render(
     [] -> ""
     _ ->
       decoder_queries
-      |> list.map(render_decoder_function(naming_ctx, _, engine, module_path))
+      |> list.map(render_decoder_function(
+        naming_ctx,
+        _,
+        engine,
+        module_path,
+        table_matches,
+        emit_exact_table_names,
+      ))
       |> string.join("\n\n")
   }
 
@@ -208,8 +218,16 @@ fn render_decoder_function(
   query: model.AnalyzedQuery,
   engine: model.Engine,
   _module_path: String,
+  table_matches: Dict(String, String),
+  _emit_exact_table_names: Bool,
 ) -> String {
   let type_name = naming.to_pascal_case(naming_ctx, query.base.name) <> "Row"
+  let constructor_name = case
+    dict.get(table_matches, query.base.function_name)
+  {
+    Ok(table_type) -> table_type
+    Error(_) -> type_name
+  }
 
   let #(_, field_lines) =
     list.fold(query.result_columns, #(0, []), fn(acc, col) {
@@ -237,7 +255,11 @@ fn render_decoder_function(
             <> ")"
           #(idx + 1, list.append(lines, [line]))
         }
-        model.EmbeddedResult(model.EmbeddedColumn(columns: embed_cols, ..)) -> {
+        model.EmbeddedResult(model.EmbeddedColumn(
+          columns: embed_cols,
+          table_name: _embed_table_name,
+          ..,
+        )) -> {
           let #(new_idx, embed_lines) =
             list.fold(embed_cols, #(idx, []), fn(inner_acc, c) {
               let #(i, ls) = inner_acc
@@ -290,7 +312,7 @@ fn render_decoder_function(
       field_lines,
       [
         "  decode.success(models."
-          <> type_name
+          <> constructor_name
           <> "("
           <> constructor_fields
           <> "))",

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -232,7 +232,13 @@ fn base_output_files(
     writer.GeneratedFile(
       directory: out,
       path: "queries.gleam",
-      content: queries.render(naming_ctx, block, analyzed),
+      content: queries.render(
+        naming_ctx,
+        block,
+        analyzed,
+        table_matches,
+        gleam.emit_exact_table_names,
+      ),
     ),
   ]
 

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -72,6 +72,7 @@ fn analyze_query(
     engine,
     query,
     tokens,
+    statement,
     augmented,
   ))
 

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -5,10 +5,11 @@ import gleam/string
 import sqlode/lexer
 import sqlode/model
 import sqlode/query_analyzer/context.{
-  type AnalysisError, type AnalyzerContext, ColumnNotFound,
+  type AnalysisError, type AnalyzerContext, AmbiguousColumnName, ColumnNotFound,
   CompoundColumnCountMismatch, TableNotFound, UnsupportedExpression,
 }
 import sqlode/query_analyzer/token_utils
+import sqlode/query_ir
 import sqlode/runtime
 
 type ExtractedColumn {
@@ -25,6 +26,7 @@ pub fn infer_result_columns(
   _engine: model.Engine,
   query: model.ParsedQuery,
   tokens: List(lexer.Token),
+  statement: query_ir.SqlStatement,
   catalog: model.Catalog,
 ) -> Result(List(model.ResultItem), AnalysisError) {
   case query.command {
@@ -38,7 +40,251 @@ pub fn infer_result_columns(
     | runtime.QueryMany
     | runtime.QueryBatchOne
     | runtime.QueryBatchMany ->
-      infer_columns_from_tokens(query.name, tokens, catalog)
+      infer_columns_from_ir(query.name, tokens, statement, catalog)
+  }
+}
+
+/// Use the structured IR to drive column inference when available.
+/// For SelectStatement, we extract columns from `select_items` and
+/// table names from `from`/`joins`, delegating expression type
+/// inference to the existing token-based helpers.
+/// For other statement types, fall back to token-based inference.
+fn infer_columns_from_ir(
+  query_name: String,
+  tokens: List(lexer.Token),
+  statement: query_ir.SqlStatement,
+  catalog: model.Catalog,
+) -> Result(List(model.ResultItem), AnalysisError) {
+  case statement {
+    query_ir.SelectStatement(
+      select_items: items,
+      from: from_items,
+      joins: join_clauses,
+      ..,
+    ) -> {
+      // Fall back to token-based for compound queries or when IR is incomplete
+      case has_compound_keyword(tokens) {
+        True -> infer_columns_from_tokens(query_name, tokens, catalog)
+        False -> {
+          let ir_tables = extract_ir_table_names(from_items, join_clauses)
+          case ir_tables {
+            [] -> infer_columns_from_tokens(query_name, tokens, catalog)
+            _ -> {
+              // Check for embed expressions which need special handling
+              case has_embed_items(items) {
+                True -> infer_columns_from_tokens(query_name, tokens, catalog)
+                False -> {
+                  use augmented <- result.try(augment_with_subquery_tables(
+                    query_name,
+                    tokens,
+                    catalog,
+                  ))
+                  let nullable_tables =
+                    tok_extract_nullable_tables(tokens, ir_tables)
+                  let select_columns =
+                    ir_select_items_to_extracted(items, ir_tables)
+                  case select_columns {
+                    [] -> infer_columns_from_tokens(query_name, tokens, catalog)
+                    _ ->
+                      resolve_select_columns(
+                        query_name,
+                        select_columns,
+                        augmented,
+                        case ir_tables {
+                          [first, ..] -> first
+                          [] -> ""
+                        },
+                        ir_tables,
+                        nullable_tables,
+                      )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    _ -> infer_columns_from_tokens(query_name, tokens, catalog)
+  }
+}
+
+/// Check if tokens contain UNION/EXCEPT/INTERSECT (compound query).
+fn has_compound_keyword(tokens: List(lexer.Token)) -> Bool {
+  // Only check top-level tokens (not inside parentheses)
+  has_compound_keyword_loop(tokens, 0)
+}
+
+fn has_compound_keyword_loop(tokens: List(lexer.Token), depth: Int) -> Bool {
+  case tokens {
+    [] -> False
+    [lexer.LParen, ..rest] -> has_compound_keyword_loop(rest, depth + 1)
+    [lexer.RParen, ..rest] ->
+      has_compound_keyword_loop(rest, case depth > 0 {
+        True -> depth - 1
+        False -> 0
+      })
+    [lexer.Keyword(k), ..rest] if depth == 0 ->
+      case k {
+        "union" | "except" | "intersect" -> True
+        _ -> has_compound_keyword_loop(rest, 0)
+      }
+    [_, ..rest] -> has_compound_keyword_loop(rest, depth)
+  }
+}
+
+/// Check if any select item contains an embed expression.
+fn has_embed_items(items: List(query_ir.SelectItem)) -> Bool {
+  list.any(items, fn(item) {
+    case item {
+      query_ir.ExpressionItem(tokens: expr_tokens, ..) ->
+        list.any(expr_tokens, fn(tok) {
+          case tok {
+            lexer.Ident(name) -> string.lowercase(name) == "embed"
+            _ -> False
+          }
+        })
+      _ -> False
+    }
+  })
+}
+
+/// Extract table names from IR FROM items and JOIN clauses.
+fn extract_ir_table_names(
+  from_items: List(query_ir.FromItem),
+  joins: List(query_ir.JoinClause),
+) -> List(String) {
+  let from_names =
+    list.filter_map(from_items, fn(item) {
+      case item {
+        query_ir.TableRef(alias: Some(a), ..) -> Ok(a)
+        query_ir.TableRef(name:, alias: None) -> Ok(name)
+        query_ir.SubqueryRef(alias: Some(a), ..) -> Ok(a)
+        query_ir.SubqueryRef(alias: None, ..) -> Error(Nil)
+      }
+    })
+  let join_names =
+    list.map(joins, fn(j) {
+      case j.alias {
+        Some(a) -> a
+        None -> j.table_name
+      }
+    })
+  list.append(from_names, join_names)
+}
+
+/// Convert IR SelectItems into ExtractedColumn values for
+/// resolve_select_columns.
+fn ir_select_items_to_extracted(
+  items: List(query_ir.SelectItem),
+  _table_names: List(String),
+) -> List(ExtractedColumn) {
+  list.flat_map(items, fn(item) {
+    case item {
+      query_ir.StarItem(None) -> [
+        ExtractedColumn(
+          name: "*",
+          source_table: None,
+          expression: None,
+          expression_tokens: None,
+        ),
+      ]
+      query_ir.StarItem(Some(prefix)) -> [
+        ExtractedColumn(
+          name: prefix <> ".*",
+          source_table: Some(prefix),
+          expression: None,
+          expression_tokens: None,
+        ),
+      ]
+      // Handle Star token that IR didn't recognize (lexer produces Star, not Operator("*"))
+      query_ir.ExpressionItem(tokens: [lexer.Star], alias: _) -> [
+        ExtractedColumn(
+          name: "*",
+          source_table: None,
+          expression: None,
+          expression_tokens: None,
+        ),
+      ]
+      query_ir.ExpressionItem(
+        tokens: [lexer.Ident(t), lexer.Dot, lexer.Star],
+        alias: _,
+      ) -> [
+        ExtractedColumn(
+          name: t <> ".*",
+          source_table: Some(t),
+          expression: None,
+          expression_tokens: None,
+        ),
+      ]
+      query_ir.ExpressionItem(tokens: expr_tokens, alias: Some(alias)) -> {
+        let stripped = strip_trailing_alias(expr_tokens)
+        let source = derive_source_table_from_tokens(stripped)
+        [
+          ExtractedColumn(
+            name: alias,
+            source_table: source,
+            expression: None,
+            expression_tokens: Some(stripped),
+          ),
+        ]
+      }
+      query_ir.ExpressionItem(tokens: expr_tokens, alias: None) -> {
+        let name = derive_column_name_from_tokens(expr_tokens)
+        let source = derive_source_table_from_tokens(expr_tokens)
+        [
+          ExtractedColumn(
+            name:,
+            source_table: source,
+            expression: None,
+            expression_tokens: case source {
+              Some(_) -> None
+              None -> Some(expr_tokens)
+            },
+          ),
+        ]
+      }
+    }
+  })
+}
+
+/// Strip trailing AS <alias> from expression tokens.
+fn strip_trailing_alias(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case list.reverse(tokens) {
+    [lexer.Ident(_), lexer.Keyword("as"), ..rest] -> list.reverse(rest)
+    [lexer.QuotedIdent(_), lexer.Keyword("as"), ..rest] -> list.reverse(rest)
+    _ -> tokens
+  }
+}
+
+/// Derive a column name from expression tokens (last ident, or table.col pattern).
+fn derive_column_name_from_tokens(tokens: List(lexer.Token)) -> String {
+  case tokens {
+    [lexer.Ident(name)] -> name
+    [lexer.QuotedIdent(name)] -> name
+    [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] -> col
+    [lexer.Ident(_table), lexer.Dot, lexer.QuotedIdent(col)] -> col
+    _ ->
+      // Fall back to last Ident in the expression
+      tokens
+      |> list.filter_map(fn(tok) {
+        case tok {
+          lexer.Ident(n) -> Ok(n)
+          lexer.QuotedIdent(n) -> Ok(n)
+          _ -> Error(Nil)
+        }
+      })
+      |> list.last
+      |> result.unwrap("?column?")
+  }
+}
+
+/// Derive a source table from a simple table.column reference.
+fn derive_source_table_from_tokens(tokens: List(lexer.Token)) -> Option(String) {
+  case tokens {
+    [lexer.Ident(table), lexer.Dot, lexer.Ident(_col)] -> Some(table)
+    [lexer.Ident(table), lexer.Dot, lexer.QuotedIdent(_col)] -> Some(table)
+    _ -> None
   }
 }
 
@@ -676,7 +922,7 @@ fn resolve_select_columns(
                     normalized_name,
                   )
                 {
-                  Some(#(found_table, column)) ->
+                  Ok(Some(#(found_table, column))) ->
                     Ok([
                       model.ScalarResult(model.ResultColumn(
                         name: column.name,
@@ -686,7 +932,13 @@ fn resolve_select_columns(
                         source_table: Some(found_table),
                       )),
                     ])
-                  None ->
+                  Error(matching_tables) ->
+                    Error(AmbiguousColumnName(
+                      query_name:,
+                      column_name: normalized_name,
+                      matching_tables:,
+                    ))
+                  Ok(None) ->
                     case extracted.expression_tokens {
                       Some(expr_tokens) -> {
                         use #(scalar_type, nullable) <- result.try(
@@ -1282,15 +1534,15 @@ fn resolve_column_type_nullable_from_tokens(
   table_names: List(String),
 ) -> Option(#(model.ScalarType, Bool)) {
   case tokens {
-    [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] ->
-      case context.find_column_in_tables(catalog, table_names, col) {
-        Some(#(_, column)) -> Some(#(column.scalar_type, column.nullable))
+    [lexer.Ident(table), lexer.Dot, lexer.Ident(col)] ->
+      case context.find_column(catalog, table, col) {
+        Some(column) -> Some(#(column.scalar_type, column.nullable))
         None -> None
       }
     [lexer.Ident(col)] ->
       case context.find_column_in_tables(catalog, table_names, col) {
-        Some(#(_, column)) -> Some(#(column.scalar_type, column.nullable))
-        None -> None
+        Ok(Some(#(_, column))) -> Some(#(column.scalar_type, column.nullable))
+        _ -> None
       }
     _ -> None
   }
@@ -1634,15 +1886,15 @@ fn resolve_column_type_from_tokens(
   table_names: List(String),
 ) -> Option(model.ScalarType) {
   case tokens {
-    [lexer.Ident(_table), lexer.Dot, lexer.Ident(col)] ->
-      case context.find_column_in_tables(catalog, table_names, col) {
-        Some(#(_, column)) -> Some(column.scalar_type)
+    [lexer.Ident(table), lexer.Dot, lexer.Ident(col)] ->
+      case context.find_column(catalog, table, col) {
+        Some(column) -> Some(column.scalar_type)
         None -> None
       }
     [lexer.Ident(col)] ->
       case context.find_column_in_tables(catalog, table_names, col) {
-        Some(#(_, column)) -> Some(column.scalar_type)
-        None -> None
+        Ok(Some(#(_, column))) -> Some(column.scalar_type)
+        _ -> None
       }
     [lexer.Star] -> None
     _ -> None

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -1,6 +1,7 @@
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
+import gleam/string
 import sqlode/model
 import sqlode/naming
 
@@ -21,6 +22,11 @@ pub type AnalysisError {
     branch_count: Int,
   )
   UnsupportedExpression(query_name: String, expression: String)
+  AmbiguousColumnName(
+    query_name: String,
+    column_name: String,
+    matching_tables: List(String),
+  )
 }
 
 pub fn analysis_error_to_string(error: AnalysisError) -> String {
@@ -77,6 +83,14 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
       <> "\": unsupported expression \""
       <> expression
       <> "\", cannot infer result type. Use CAST to specify the type explicitly"
+    AmbiguousColumnName(query_name:, column_name:, matching_tables:) ->
+      "Query \""
+      <> query_name
+      <> "\": column \""
+      <> column_name
+      <> "\" is ambiguous — found in tables: "
+      <> string.join(matching_tables, ", ")
+      <> ". Use a table qualifier (e.g. table.column) to resolve the ambiguity"
   }
 }
 
@@ -129,16 +143,24 @@ pub fn find_column(
 
 /// Search for a column across multiple tables, returning the column and the
 /// table name where it was found.
+///
+/// Returns `Error(matching_table_names)` when the column exists in more than
+/// one of the given tables (ambiguous reference).
 pub fn find_column_in_tables(
   catalog: model.Catalog,
   table_names: List(String),
   column_name: String,
-) -> Option(#(String, model.Column)) {
-  list.find_map(table_names, fn(name) {
-    case find_column(catalog, name, column_name) {
-      Some(col) -> Ok(#(name, col))
-      None -> Error(Nil)
-    }
-  })
-  |> option.from_result
+) -> Result(Option(#(String, model.Column)), List(String)) {
+  let matches =
+    list.filter_map(table_names, fn(name) {
+      case find_column(catalog, name, column_name) {
+        Some(col) -> Ok(#(name, col))
+        None -> Error(Nil)
+      }
+    })
+  case matches {
+    [] -> Ok(None)
+    [single] -> Ok(Some(single))
+    _ -> Error(list.map(matches, fn(m) { m.0 }))
+  }
 }

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -156,14 +156,16 @@ fn scan_token_matches(
             Some(table) ->
               context.find_column(catalog, table, match.column_name)
             None ->
-              option.map(
+              case
                 context.find_column_in_tables(
                   catalog,
                   all_tables,
                   match.column_name,
-                ),
-                fn(pair) { pair.1 },
-              )
+                )
+              {
+                Ok(Some(pair)) -> Some(pair.1)
+                _ -> None
+              }
           }
           case found {
             Some(column) -> [#(index, column), ..acc]

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -10,12 +10,6 @@ import sqlode/query_analyzer/token_utils
 pub type ParseError {
   InvalidCreateTable(path: String, detail: String)
   InvalidColumn(path: String, table: String, detail: String)
-  /// A DDL statement was recognised as schema-changing but sqlode does not
-  /// apply it to the catalog. Raised for operations that can produce a
-  /// catalog that looks valid but is missing real schema changes — e.g.
-  /// `DROP TABLE`, `ALTER TABLE ... DROP COLUMN`. Informational DDL such
-  /// as `CREATE INDEX` and `ALTER TABLE ... ADD CONSTRAINT` stays silent.
-  UnsupportedStatement(path: String, statement_type: String)
 }
 
 pub type SchemaWarning {
@@ -85,18 +79,18 @@ fn parse_content(
 
   let all_enums = list.append(known_enums, enums)
 
-  use #(tables, warnings) <- result.try(
+  use #(tables, final_enums, warnings) <- result.try(
     statements
-    |> list.try_fold(#([], []), fn(acc, stmt_tokens) {
-      let #(tables, warnings) = acc
+    |> list.try_fold(#([], all_enums, []), fn(acc, stmt_tokens) {
+      let #(tables, current_enums, warnings) = acc
       case is_create_view_tokens(stmt_tokens) {
         True -> {
           let #(maybe_table, view_warnings) =
             parse_create_view_from_tokens(stmt_tokens, list.reverse(tables))
           let new_warnings = list.append(warnings, view_warnings)
           Ok(case maybe_table {
-            Some(table) -> #([table, ..tables], new_warnings)
-            None -> #(tables, new_warnings)
+            Some(table) -> #([table, ..tables], current_enums, new_warnings)
+            None -> #(tables, current_enums, new_warnings)
           })
         }
         False ->
@@ -105,29 +99,35 @@ fn parse_content(
               use new_tables <- result.try(apply_alter_table_add_column(
                 path,
                 stmt_tokens,
-                all_enums,
+                current_enums,
                 tables,
               ))
-              Ok(#(new_tables, warnings))
+              Ok(#(new_tables, current_enums, warnings))
             }
             False -> {
-              use maybe_table <- result.try(parse_statement_tokens(
+              use stmt_result <- result.try(parse_statement_tokens(
                 path,
                 stmt_tokens,
-                all_enums,
+                current_enums,
               ))
-              Ok(case maybe_table {
-                Some(table) -> #([table, ..tables], warnings)
-                None -> #(tables, warnings)
-              })
+              case stmt_result {
+                CreateTableResult(table:) ->
+                  Ok(#([table, ..tables], current_enums, warnings))
+                DDLApplied(action:) -> {
+                  let #(new_tables, new_enums) =
+                    apply_ddl_action(action, tables, current_enums)
+                  Ok(#(new_tables, new_enums, warnings))
+                }
+                Ignored -> Ok(#(tables, current_enums, warnings))
+              }
             }
           }
       }
     })
-    |> result.map(fn(pair) { #(list.reverse(pair.0), pair.1) }),
+    |> result.map(fn(triple) { #(list.reverse(triple.0), triple.1, triple.2) }),
   )
 
-  Ok(ParsedSchema(tables:, enums:, warnings:))
+  Ok(ParsedSchema(tables:, enums: final_enums, warnings:))
 }
 
 // --- Lexer-based helpers ---
@@ -612,25 +612,56 @@ fn extract_ident(token: lexer.Token) -> String {
   }
 }
 
+type StatementResult {
+  CreateTableResult(table: model.Table)
+  DDLApplied(action: DDLAction)
+  Ignored
+}
+
 fn parse_statement_tokens(
   path: String,
   tokens: List(lexer.Token),
   enums: List(model.EnumDef),
-) -> Result(Option(model.Table), ParseError) {
+) -> Result(StatementResult, ParseError) {
   case is_create_table_tokens(tokens) {
-    True -> parse_create_table_tokens(path, tokens, enums)
+    True -> {
+      use maybe_table <- result.try(parse_create_table_tokens(
+        path,
+        tokens,
+        enums,
+      ))
+      case maybe_table {
+        Some(table) -> Ok(CreateTableResult(table:))
+        None -> Ok(Ignored)
+      }
+    }
     False ->
       case classify_unknown_statement(tokens) {
-        Unsupported(statement_type) ->
-          Error(UnsupportedStatement(path:, statement_type:))
-        SilentlyIgnored -> Ok(None)
+        DestructiveDDL(action) -> Ok(DDLApplied(action:))
+        SilentlyIgnored -> Ok(Ignored)
       }
   }
 }
 
 type UnknownStatementKind {
-  Unsupported(statement_type: String)
+  DestructiveDDL(DDLAction)
   SilentlyIgnored
+}
+
+type DDLAction {
+  DropTable(table_name: String)
+  DropView(view_name: String)
+  DropType(type_name: String)
+  AlterDropColumn(table_name: String, column_name: String)
+  AlterRenameTable(old_name: String, new_name: String)
+  AlterRenameColumn(table_name: String, old_name: String, new_name: String)
+  AlterColumnType(
+    table_name: String,
+    column_name: String,
+    type_tokens: List(lexer.Token),
+  )
+  AlterColumnSetNotNull(table_name: String, column_name: String)
+  AlterColumnDropNotNull(table_name: String, column_name: String)
 }
 
 /// Classify a statement that is not a CREATE TABLE / VIEW / ENUM and not an
@@ -657,36 +688,113 @@ fn classify_unknown_statement(tokens: List(lexer.Token)) -> UnknownStatementKind
     ["release", ..] -> SilentlyIgnored
     ["set", ..] -> SilentlyIgnored
 
-    ["drop", "table", ..] -> Unsupported("DROP TABLE")
-    ["drop", "view", ..] -> Unsupported("DROP VIEW")
-    ["drop", "type", ..] -> Unsupported("DROP TYPE")
+    ["drop", "table", ..] -> parse_drop_table(tokens)
+    ["drop", "view", ..] -> parse_drop_view(tokens)
+    ["drop", "type", ..] -> parse_drop_type(tokens)
 
-    ["alter", "table", ..rest] -> classify_alter_table(rest)
+    ["alter", "table", ..] -> classify_alter_table_from_tokens(tokens)
 
     _ -> SilentlyIgnored
   }
 }
 
-fn classify_alter_table(words: List(String)) -> UnknownStatementKind {
-  let after_modifiers = case words {
-    ["if", "exists", ..r] -> r
-    ["only", ..r] -> r
-    _ -> words
+/// Parse DROP TABLE [IF EXISTS] <name> from the token list.
+fn parse_drop_table(tokens: List(lexer.Token)) -> UnknownStatementKind {
+  case tokens {
+    [_, _, lexer.Keyword("if"), lexer.Keyword("exists"), name_tok, ..] ->
+      DestructiveDDL(DropTable(table_name: extract_ident(name_tok)))
+    [_, _, name_tok, ..] ->
+      DestructiveDDL(DropTable(table_name: extract_ident(name_tok)))
+    _ -> SilentlyIgnored
   }
+}
+
+/// Parse DROP VIEW [IF EXISTS] <name> from the token list.
+fn parse_drop_view(tokens: List(lexer.Token)) -> UnknownStatementKind {
+  case tokens {
+    [_, _, lexer.Keyword("if"), lexer.Keyword("exists"), name_tok, ..] ->
+      DestructiveDDL(DropView(view_name: extract_ident(name_tok)))
+    [_, _, name_tok, ..] ->
+      DestructiveDDL(DropView(view_name: extract_ident(name_tok)))
+    _ -> SilentlyIgnored
+  }
+}
+
+/// Parse DROP TYPE [IF EXISTS] <name> from the token list.
+fn parse_drop_type(tokens: List(lexer.Token)) -> UnknownStatementKind {
+  case tokens {
+    [_, _, lexer.Keyword("if"), lexer.Keyword("exists"), name_tok, ..] ->
+      DestructiveDDL(DropType(type_name: extract_ident(name_tok)))
+    [_, _, name_tok, ..] ->
+      DestructiveDDL(DropType(type_name: extract_ident(name_tok)))
+    _ -> SilentlyIgnored
+  }
+}
+
+/// Classify ALTER TABLE statements from the full token list.
+fn classify_alter_table_from_tokens(
+  tokens: List(lexer.Token),
+) -> UnknownStatementKind {
+  // ALTER TABLE [IF EXISTS] [ONLY] <name> <action>
+  let after_alter_table = case tokens {
+    [_, _, ..rest] -> rest
+    _ -> []
+  }
+  let #(after_modifiers, _) = skip_alter_modifiers(after_alter_table)
   case after_modifiers {
-    [_table_name, ..rest] -> classify_alter_table_action(rest)
+    [name_tok, ..rest] -> {
+      let table_name = extract_ident(name_tok)
+      classify_alter_action_tokens(table_name, rest)
+    }
     [] -> SilentlyIgnored
   }
 }
 
-fn classify_alter_table_action(words: List(String)) -> UnknownStatementKind {
+fn skip_alter_modifiers(tokens: List(lexer.Token)) -> #(List(lexer.Token), Bool) {
+  case tokens {
+    [lexer.Keyword("if"), lexer.Keyword("exists"), ..rest] ->
+      skip_alter_modifiers(rest)
+    [lexer.Keyword("only"), ..rest] -> skip_alter_modifiers(rest)
+    _ -> #(tokens, False)
+  }
+}
+
+fn classify_alter_action_tokens(
+  table_name: String,
+  tokens: List(lexer.Token),
+) -> UnknownStatementKind {
+  let words = tokens |> list.take(8) |> list.map(token_keyword_text)
   case words {
     ["drop", "constraint", ..] -> SilentlyIgnored
-    ["drop", "column", ..] -> Unsupported("ALTER TABLE DROP COLUMN")
-    ["drop", ..] -> Unsupported("ALTER TABLE DROP")
-    ["rename", "to", ..] -> Unsupported("ALTER TABLE RENAME TO")
-    ["rename", ..] -> Unsupported("ALTER TABLE RENAME COLUMN")
-    ["alter", ..] -> Unsupported("ALTER TABLE ALTER COLUMN")
+    ["drop", "column", "if", "exists", col_name, ..] ->
+      DestructiveDDL(AlterDropColumn(table_name:, column_name: col_name))
+    ["drop", "column", col_name, ..] ->
+      DestructiveDDL(AlterDropColumn(table_name:, column_name: col_name))
+    ["drop", col_name, ..] ->
+      DestructiveDDL(AlterDropColumn(table_name:, column_name: col_name))
+    ["rename", "to", new_name, ..] ->
+      DestructiveDDL(AlterRenameTable(old_name: table_name, new_name:))
+    ["rename", "column", old_name, "to", new_name, ..] ->
+      DestructiveDDL(AlterRenameColumn(table_name:, old_name:, new_name:))
+    ["rename", old_name, "to", new_name, ..] ->
+      DestructiveDDL(AlterRenameColumn(table_name:, old_name:, new_name:))
+    ["alter", "column", _col_name, "set", "not", "null", ..] ->
+      DestructiveDDL(AlterColumnSetNotNull(
+        table_name:,
+        column_name: extract_alter_column_name(tokens),
+      ))
+    ["alter", "column", _col_name, "drop", "not", "null", ..] ->
+      DestructiveDDL(AlterColumnDropNotNull(
+        table_name:,
+        column_name: extract_alter_column_name(tokens),
+      ))
+    ["alter", "column", _col_name, "type", ..]
+    | ["alter", "column", _col_name, "set", "data", "type", ..] ->
+      DestructiveDDL(AlterColumnType(
+        table_name:,
+        column_name: extract_alter_column_name(tokens),
+        type_tokens: extract_alter_type_tokens(tokens),
+      ))
     ["add", "constraint", ..] -> SilentlyIgnored
     ["add", "primary", ..] -> SilentlyIgnored
     ["add", "unique", ..] -> SilentlyIgnored
@@ -694,6 +802,160 @@ fn classify_alter_table_action(words: List(String)) -> UnknownStatementKind {
     ["add", "check", ..] -> SilentlyIgnored
     ["add", "index", ..] -> SilentlyIgnored
     _ -> SilentlyIgnored
+  }
+}
+
+/// Extract the column name from ALTER [COLUMN] <name> ... tokens.
+fn extract_alter_column_name(tokens: List(lexer.Token)) -> String {
+  case tokens {
+    [_, lexer.Keyword("column"), name_tok, ..] -> extract_ident(name_tok)
+    [_, name_tok, ..] -> extract_ident(name_tok)
+    _ -> ""
+  }
+}
+
+/// Extract TYPE tokens from ALTER [COLUMN] <name> [SET DATA] TYPE <tokens>.
+fn extract_alter_type_tokens(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [] -> []
+    [lexer.Keyword("type"), ..rest] -> rest
+    [_, ..rest] -> extract_alter_type_tokens(rest)
+  }
+}
+
+/// Apply a destructive DDL action to the tables and enums lists.
+fn apply_ddl_action(
+  action: DDLAction,
+  tables: List(model.Table),
+  enums: List(model.EnumDef),
+) -> #(List(model.Table), List(model.EnumDef)) {
+  case action {
+    DropTable(table_name:) -> #(
+      list.filter(tables, fn(t) {
+        string.lowercase(t.name) != string.lowercase(table_name)
+      }),
+      enums,
+    )
+    DropView(view_name:) -> #(
+      list.filter(tables, fn(t) {
+        string.lowercase(t.name) != string.lowercase(view_name)
+      }),
+      enums,
+    )
+    DropType(type_name:) -> #(
+      tables,
+      list.filter(enums, fn(e) {
+        string.lowercase(e.name) != string.lowercase(type_name)
+      }),
+    )
+    AlterDropColumn(table_name:, column_name:) -> #(
+      list.map(tables, fn(t) {
+        case string.lowercase(t.name) == string.lowercase(table_name) {
+          True ->
+            model.Table(
+              ..t,
+              columns: list.filter(t.columns, fn(c) {
+                string.lowercase(c.name) != string.lowercase(column_name)
+              }),
+            )
+          False -> t
+        }
+      }),
+      enums,
+    )
+    AlterRenameTable(old_name:, new_name:) -> #(
+      list.map(tables, fn(t) {
+        case string.lowercase(t.name) == string.lowercase(old_name) {
+          True -> model.Table(..t, name: string.lowercase(new_name))
+          False -> t
+        }
+      }),
+      enums,
+    )
+    AlterRenameColumn(table_name:, old_name:, new_name:) -> #(
+      list.map(tables, fn(t) {
+        case string.lowercase(t.name) == string.lowercase(table_name) {
+          True ->
+            model.Table(
+              ..t,
+              columns: list.map(t.columns, fn(c) {
+                case string.lowercase(c.name) == string.lowercase(old_name) {
+                  True -> model.Column(..c, name: string.lowercase(new_name))
+                  False -> c
+                }
+              }),
+            )
+          False -> t
+        }
+      }),
+      enums,
+    )
+    AlterColumnType(table_name:, column_name:, type_tokens:) -> {
+      let type_text = render_type_tokens(type_tokens)
+      let new_type = case model.parse_sql_type(type_text) {
+        Ok(t) -> Some(t)
+        Error(_) -> None
+      }
+      case new_type {
+        Some(scalar_type) -> #(
+          list.map(tables, fn(t) {
+            case string.lowercase(t.name) == string.lowercase(table_name) {
+              True ->
+                model.Table(
+                  ..t,
+                  columns: list.map(t.columns, fn(c) {
+                    case
+                      string.lowercase(c.name) == string.lowercase(column_name)
+                    {
+                      True -> model.Column(..c, scalar_type:)
+                      False -> c
+                    }
+                  }),
+                )
+              False -> t
+            }
+          }),
+          enums,
+        )
+        None -> #(tables, enums)
+      }
+    }
+    AlterColumnSetNotNull(table_name:, column_name:) -> #(
+      list.map(tables, fn(t) {
+        case string.lowercase(t.name) == string.lowercase(table_name) {
+          True ->
+            model.Table(
+              ..t,
+              columns: list.map(t.columns, fn(c) {
+                case string.lowercase(c.name) == string.lowercase(column_name) {
+                  True -> model.Column(..c, nullable: False)
+                  False -> c
+                }
+              }),
+            )
+          False -> t
+        }
+      }),
+      enums,
+    )
+    AlterColumnDropNotNull(table_name:, column_name:) -> #(
+      list.map(tables, fn(t) {
+        case string.lowercase(t.name) == string.lowercase(table_name) {
+          True ->
+            model.Table(
+              ..t,
+              columns: list.map(t.columns, fn(c) {
+                case string.lowercase(c.name) == string.lowercase(column_name) {
+                  True -> model.Column(..c, nullable: True)
+                  False -> c
+                }
+              }),
+            )
+          False -> t
+        }
+      }),
+      enums,
+    )
   }
 }
 
@@ -1056,14 +1318,6 @@ pub fn error_to_string(error: ParseError) -> String {
       <> table
       <> ": "
       <> detail
-    UnsupportedStatement(path:, statement_type:) ->
-      path_prefix(path)
-      <> "Unsupported schema DDL: "
-      <> statement_type
-      <> ". sqlode only applies CREATE TABLE, CREATE VIEW, CREATE TYPE ... AS ENUM,"
-      <> " and ALTER TABLE ... ADD COLUMN to the catalog;"
-      <> " keep other schema-changing DDL out of the schema input"
-      <> " or consolidate migrations into a single CREATE TABLE snapshot."
   }
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -25,7 +25,7 @@ pub fn render_queries_module_test() {
   let naming_ctx = naming.new()
   let block = test_block()
   let analyzed = analyzed_queries("test/fixtures/query.sql")
-  let rendered = queries.render(naming_ctx, block, analyzed)
+  let rendered = queries.render(naming_ctx, block, analyzed, dict.new(), False)
 
   string.contains(
     rendered,
@@ -853,7 +853,7 @@ pub fn readme_queries_snapshot_test() {
   let naming_ctx = naming.new()
   let block = readme_test_block()
   let analyzed = readme_analyzed_queries()
-  let rendered = queries.render(naming_ctx, block, analyzed)
+  let rendered = queries.render(naming_ctx, block, analyzed, dict.new(), False)
 
   // README: pub fn get_author() -> runtime.RawQuery(params.GetAuthorParams) { ... }
   string.contains(

--- a/test/fixtures/sqlc_compat/queries.sql
+++ b/test/fixtures/sqlc_compat/queries.sql
@@ -18,12 +18,12 @@ GROUP BY user_id
 HAVING COUNT(*) > $1::int;
 
 -- name: ListUsersWithPosts :many
-SELECT id, name
+SELECT users.id, users.name
 FROM users
 WHERE EXISTS (SELECT 1 FROM posts WHERE posts.user_id = users.id);
 
 -- name: ListUsersWithoutPosts :many
-SELECT id, name
+SELECT users.id, users.name
 FROM users
 WHERE NOT EXISTS (SELECT 1 FROM posts WHERE posts.user_id = users.id);
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -636,79 +636,109 @@ pub fn partition_by_clause_does_not_break_table_test() {
 
 // Unsupported-DDL diagnostics (Issue #362)
 
-pub fn drop_table_is_rejected_test() {
+pub fn drop_table_removes_table_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
     <> "DROP TABLE users;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "test.sql") |> should.be_true()
-  string.contains(msg, "Unsupported schema DDL") |> should.be_true()
-  string.contains(msg, "DROP TABLE") |> should.be_true()
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  list.length(catalog.tables) |> should.equal(0)
 }
 
-pub fn drop_table_if_exists_is_rejected_test() {
+pub fn drop_table_if_exists_nonexistent_test() {
   let sql = "DROP TABLE IF EXISTS users;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "DROP TABLE") |> should.be_true()
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  list.length(catalog.tables) |> should.equal(0)
 }
 
-pub fn drop_view_is_rejected_test() {
-  let sql = "DROP VIEW author_counts;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "DROP VIEW") |> should.be_true()
+pub fn drop_view_removes_view_test() {
+  let sql =
+    "CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "CREATE VIEW author_list AS SELECT id, name FROM authors;\n"
+    <> "DROP VIEW author_list;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  list.length(catalog.tables) |> should.equal(1)
+  let assert [table] = catalog.tables
+  table.name |> should.equal("authors")
 }
 
-pub fn drop_type_is_rejected_test() {
-  let sql = "DROP TYPE status;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "DROP TYPE") |> should.be_true()
+pub fn drop_type_removes_enum_test() {
+  let sql =
+    "CREATE TYPE status AS ENUM ('active', 'inactive');\n"
+    <> "DROP TYPE status;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  list.length(catalog.enums) |> should.equal(0)
 }
 
-pub fn alter_table_drop_column_is_rejected_test() {
+pub fn alter_table_drop_column_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
     <> "ALTER TABLE users DROP COLUMN name;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "ALTER TABLE DROP COLUMN") |> should.be_true()
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(1)
+  let assert [col] = table.columns
+  col.name |> should.equal("id")
 }
 
-pub fn alter_table_if_exists_drop_column_is_rejected_test() {
-  let sql = "ALTER TABLE IF EXISTS users DROP COLUMN name;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "ALTER TABLE DROP COLUMN") |> should.be_true()
+pub fn alter_table_if_exists_drop_column_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "ALTER TABLE IF EXISTS users DROP COLUMN name;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(1)
 }
 
-pub fn alter_table_rename_column_is_rejected_test() {
+pub fn alter_table_rename_column_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
     <> "ALTER TABLE users RENAME COLUMN name TO full_name;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "ALTER TABLE RENAME COLUMN") |> should.be_true()
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  let assert [_, col2] = table.columns
+  col2.name |> should.equal("full_name")
 }
 
-pub fn alter_table_rename_to_is_rejected_test() {
+pub fn alter_table_rename_to_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY);\n"
     <> "ALTER TABLE users RENAME TO accounts;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "ALTER TABLE RENAME TO") |> should.be_true()
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  table.name |> should.equal("accounts")
 }
 
-pub fn alter_table_alter_column_is_rejected_test() {
+pub fn alter_table_set_not_null_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, created_at TIMESTAMP);\n"
     <> "ALTER TABLE users ALTER COLUMN created_at SET NOT NULL;"
-  let assert Error(error) = schema_parser.parse_files([#("test.sql", sql)])
-  let msg = schema_parser.error_to_string(error)
-  string.contains(msg, "ALTER TABLE ALTER COLUMN") |> should.be_true()
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  let assert [_, col2] = table.columns
+  col2.name |> should.equal("created_at")
+  col2.nullable |> should.equal(False)
+}
+
+pub fn alter_table_drop_not_null_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
+    <> "ALTER TABLE users ALTER COLUMN name DROP NOT NULL;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  let assert [_, col2] = table.columns
+  col2.name |> should.equal("name")
+  col2.nullable |> should.equal(True)
+}
+
+pub fn alter_table_alter_column_type_test() {
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, score INTEGER NOT NULL);\n"
+    <> "ALTER TABLE users ALTER COLUMN score TYPE TEXT;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  let assert [_, col2] = table.columns
+  col2.name |> should.equal("score")
+  col2.scalar_type |> should.equal(model.StringType)
 }
 
 pub fn alter_table_drop_constraint_stays_silent_test() {


### PR DESCRIPTION
## Summary

Address five major review findings: ambiguous column detection, destructive DDL support, IR-based column inference, raw decoder generation, and documentation alignment with actual implementation.

## Changes

- **Ambiguous column error** (`context.gleam`, `column_inferencer.gleam`, `param_inferencer.gleam`): `find_column_in_tables` now collects all matches and returns `Error(matching_tables)` when a column exists in 2+ tables. Adds `AmbiguousColumnName` error variant. Fixes bug where `table.column` patterns discarded the table qualifier.
- **Destructive DDL support** (`schema_parser.gleam`, `schema_parser_test.gleam`): `DROP TABLE/VIEW/TYPE`, `ALTER TABLE DROP COLUMN`, `RENAME TO/COLUMN`, `ALTER COLUMN TYPE/SET NOT NULL/DROP NOT NULL` are now applied to the catalog instead of being rejected. Removes `UnsupportedStatement` error variant.
- **IR-based column inference** (`column_inferencer.gleam`, `query_analyzer.gleam`): `infer_result_columns` now accepts `SqlStatement` and uses `SelectStatement.select_items`/`from`/`joins` directly for simple SELECTs. Falls back to token-based for compound queries (UNION/EXCEPT), embed expressions, and edge cases.
- **Raw decoder generation** (`queries.gleam`): Generates standalone `*_decoder()` functions for `:one`/`:many` queries, making raw mode client-agnostic with type-safe decoders via `gleam/dynamic/decode`.
- **Documentation** (`README.md`): Clarifies sqlode is not a drop-in sqlc replacement, `sqlode.*` prefix only, and destructive DDL is now supported.

## Design Decisions

- Ambiguous column detection returns `Result(Option(...), List(String))` rather than adding query_name to the function signature, keeping `find_column_in_tables` context-free. Callers construct `AmbiguousColumnName` with their own query context.
- IR path falls back to token-based inference for compound queries and embed expressions to avoid regression. This is a conservative first step toward full IR-driven inference.
- Raw decoders are generated as standalone functions (`get_author_decoder()`) rather than modifying the `RawQuery` type, avoiding breaking changes to the runtime API.
- Schema parser applies DDL actions via case-insensitive name matching, consistent with SQL semantics. `IF EXISTS` is handled gracefully (no error if target doesn't exist).

## Limitations

- IR-based inference does not yet cover compound queries (UNION/EXCEPT/INTERSECT) or `sqlode.embed()` expressions — these fall back to the existing token-based path.
- `extract_table_names` still includes subquery tables in scope, so queries like `SELECT col FROM t WHERE EXISTS (SELECT 1 FROM t2)` may require table-qualified columns if `t` and `t2` share column names.