### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-18
+
+### Added
+
+- **Destructive DDL support**: The schema parser now applies `DROP TABLE`,
+  `DROP VIEW`, `DROP TYPE`, `ALTER TABLE ... DROP COLUMN`,
+  `ALTER TABLE ... RENAME TO` / `RENAME COLUMN`,
+  `ALTER TABLE ... ALTER COLUMN TYPE` / `SET NOT NULL` / `DROP NOT NULL`
+  to the catalog. Full migration histories with destructive DDL can now
+  be processed without consolidating into a snapshot.
+- **Ambiguous column detection**: `find_column_in_tables` now errors when
+  a bare column name matches in two or more tables, instead of silently
+  picking the first match. Use a table qualifier (e.g., `table.column`)
+  to resolve the ambiguity.
+- **IR-based column inference**: The column inferencer now uses the
+  structured IR (`SelectStatement.select_items`, `from`, `joins`) for
+  simple SELECT queries, reducing reliance on token-level heuristics.
+  Compound queries (UNION/EXCEPT) and `sqlode.embed()` fall back to the
+  existing token-based path.
+- **Raw decoder generation**: `queries.gleam` now generates standalone
+  `*_decoder()` functions for `:one` / `:many` queries in raw mode,
+  providing type-safe `decode.Decoder(models.Row)` values without
+  requiring a native adapter.
+
 ### Fixed
 
 - `sqlode.embed(TABLE)` is now rewritten into a concrete qualified
@@ -14,6 +38,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `sqlode.embed(...)` text leaked into generated runtime queries, which
   the database rejected as invalid SQL. Embed detection during column
   inference is also now case-insensitive.
+- Table qualifier in `table.column` patterns was silently discarded in
+  `resolve_column_type_from_tokens` and
+  `resolve_column_type_nullable_from_tokens`, causing lookups to search
+  all tables instead of the specified one.
+- `sqlc-compatibility.md` incorrectly stated that batch annotations and
+  `sqlc.*` prefix were implemented. Updated to reflect actual status.
+
+### Changed
+
+- `UnsupportedStatement` schema parse error removed. Destructive DDL
+  statements are now applied rather than rejected.
+- README updated to clarify that sqlode is not a drop-in sqlc
+  replacement and uses the `sqlode.*` macro prefix exclusively.
 
 ## [0.1.0] - 2026-04-13
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.1.0"
+version = "0.2.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.1.0"
+pub const version = "0.2.0"


### PR DESCRIPTION
## Summary

Bump version to 0.2.0 and update CHANGELOG with all changes since v0.1.0.

## Changes

- `gleam.toml`: version 0.1.0 → 0.2.0
- `src/sqlode/version.gleam`: version constant 0.1.0 → 0.2.0
- `CHANGELOG.md`: add v0.2.0 section with Added/Fixed/Changed entries

## v0.2.0 Highlights

- **Destructive DDL support**: DROP TABLE/VIEW/TYPE, ALTER TABLE DROP/RENAME COLUMN, ALTER COLUMN TYPE/SET NOT NULL/DROP NOT NULL
- **Ambiguous column detection**: errors on unqualified column names matching multiple tables
- **IR-based column inference**: uses structured IR for simple SELECT queries
- **Raw decoder generation**: standalone `*_decoder()` functions for :one/:many queries
- **Bug fixes**: embed SQL rewriting, table qualifier handling, documentation alignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema parsing now applies destructive DDL statements (dropping tables/views, handling column changes) instead of rejecting them.
  * Column resolution throws errors on ambiguous bare column names, requiring table qualification to disambiguate.
  * Improved column inference for simple SELECT queries.
  * Raw mode now generates standalone decoder functions for queries.

* **Bug Fixes**
  * Fixed embed functionality to emit qualified column lists and improved detection accuracy.
  * Corrected table qualifier preservation in column resolution.

* **Documentation**
  * Updated compatibility notes and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->