### PR TITLE
refactor: replace thin IR with expression-aware SQL IR (#393)

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -55,7 +55,15 @@ fn analyze_query(
     tokens,
     with_values,
   ))
-  let augmented = merge_virtual_tables(with_values, derived_tables)
+  let with_derived = merge_virtual_tables(with_values, derived_tables)
+  // Register `FROM table AS alias` / `JOIN table AS alias` aliases so
+  // qualified refs like `p.user_id` in a query that writes
+  // `FROM posts AS p` resolve to `posts`. This is the single hook
+  // that lets the expression-aware IR reason about aliased column
+  // references without re-implementing alias resolution everywhere.
+  let alias_tables =
+    column_inferencer.extract_table_aliases(tokens, with_derived)
+  let augmented = merge_virtual_tables(with_derived, alias_tables)
 
   let occurrences = placeholder.extract(ctx, engine, tokens)
   use params <- result.try(build_params(

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -8,7 +8,9 @@ import sqlode/query_analyzer/context.{
   type AnalysisError, type AnalyzerContext, AmbiguousColumnName, ColumnNotFound,
   CompoundColumnCountMismatch, TableNotFound, UnsupportedExpression,
 }
+import sqlode/query_analyzer/expr_parser
 import sqlode/query_analyzer/token_utils
+import sqlode/query_analyzer/type_inference
 import sqlode/query_ir
 import sqlode/runtime
 
@@ -321,9 +323,19 @@ pub fn infer_columns_from_tokens_scoped(
   ))
   case tok_extract_returning_columns(tokens) {
     Some(returning_cols) -> {
-      let table_names = token_utils.extract_table_names(tokens)
-      let nullable_tables = tok_extract_nullable_tables(tokens, table_names)
-      case effective_tables(table_names, outer_tables) {
+      // RETURNING resolves against the DML target (INSERT/UPDATE/
+      // DELETE target table) — never against other tables that
+      // happen to appear in the same statement (CTE inputs, INSERT..
+      // SELECT source tables, alias virtual tables). Without this
+      // restriction, fixture 4 in Issue #393 sees `id` reported as
+      // ambiguous across `posts`, `audit_log` and `changed_posts`.
+      let dml_target = detect_dml_target(tokens)
+      let scope_tables = case dml_target {
+        Some(target) -> [target]
+        None -> token_utils.extract_table_names(tokens)
+      }
+      let nullable_tables = tok_extract_nullable_tables(tokens, scope_tables)
+      case effective_tables(scope_tables, outer_tables) {
         [] -> Ok([])
         [primary, ..] as tables ->
           resolve_select_columns(
@@ -365,6 +377,29 @@ pub fn infer_columns_from_tokens_scoped(
   }
 }
 
+/// Locate the table targeted by a DML statement (INSERT INTO table,
+/// UPDATE table, DELETE FROM table). Skips any leading WITH clause
+/// so `WITH … INSERT INTO target` still picks `target`. Returns
+/// `None` for SELECT / unrecognised statements.
+fn detect_dml_target(tokens: List(lexer.Token)) -> Option(String) {
+  let stripped = tok_strip_cte(tokens)
+  case stripped {
+    [lexer.Keyword("insert"), lexer.Keyword("into"), ..rest] -> {
+      let #(name, _) = token_utils.read_table_name(rest)
+      name
+    }
+    [lexer.Keyword("update"), ..rest] -> {
+      let #(name, _) = token_utils.read_table_name(rest)
+      name
+    }
+    [lexer.Keyword("delete"), lexer.Keyword("from"), ..rest] -> {
+      let #(name, _) = token_utils.read_table_name(rest)
+      name
+    }
+    _ -> None
+  }
+}
+
 fn augment_with_subquery_tables(
   query_name: String,
   tokens: List(lexer.Token),
@@ -377,7 +412,9 @@ fn augment_with_subquery_tables(
     tokens,
     with_values,
   ))
-  Ok(augment_catalog_with(with_values, derived))
+  let with_derived = augment_catalog_with(with_values, derived)
+  let aliases = extract_table_aliases(tokens, with_derived)
+  Ok(augment_catalog_with(with_derived, aliases))
 }
 
 /// Pick the scope the resolver should use: the inner FROM tables if any,
@@ -645,6 +682,99 @@ fn build_values_columns(
       model.Column(name: name, scalar_type: st, nullable: nullable),
       ..build_values_columns(rest_names, rest_types)
     ]
+  }
+}
+
+/// Register table aliases as virtual tables pointing at the underlying
+/// table's columns. Scans the token stream for
+/// `FROM/JOIN/UPDATE table [AS] alias` patterns and emits a
+/// `model.Table(name: alias, columns: …)` copy for each alias whose
+/// underlying table exists in the catalog. Aliases that shadow an
+/// existing catalog entry are skipped so we don't accidentally
+/// replace a real base table. This is what lets `p.user_id` resolve
+/// to `posts.user_id` when the query writes `FROM posts AS p`.
+pub fn extract_table_aliases(
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> List(model.Table) {
+  scan_aliases_loop(tokens, catalog, [])
+  |> list.reverse
+}
+
+fn scan_aliases_loop(
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+  acc: List(model.Table),
+) -> List(model.Table) {
+  case tokens {
+    [] -> acc
+    [lexer.Keyword(kw), ..rest]
+      if kw == "from" || kw == "join" || kw == "update" || kw == "into"
+    -> {
+      let #(alias_pair, remaining) = read_table_with_alias(rest)
+      let next_acc = case alias_pair {
+        Some(#(table_name, alias_name)) ->
+          case alias_name != table_name {
+            True ->
+              case list.find(catalog.tables, fn(t) { t.name == table_name }) {
+                Ok(found) ->
+                  case list.any(acc, fn(t) { t.name == alias_name }) {
+                    True -> acc
+                    False ->
+                      case
+                        list.any(catalog.tables, fn(t) { t.name == alias_name })
+                      {
+                        True -> acc
+                        False -> [
+                          model.Table(name: alias_name, columns: found.columns),
+                          ..acc
+                        ]
+                      }
+                  }
+                Error(_) -> acc
+              }
+            False -> acc
+          }
+        None -> acc
+      }
+      scan_aliases_loop(remaining, catalog, next_acc)
+    }
+    [_, ..rest] -> scan_aliases_loop(rest, catalog, acc)
+  }
+}
+
+fn read_table_with_alias(
+  tokens: List(lexer.Token),
+) -> #(Option(#(String, String)), List(lexer.Token)) {
+  case tokens {
+    [
+      lexer.Ident(_),
+      lexer.Dot,
+      lexer.Ident(name),
+      lexer.Keyword("as"),
+      lexer.Ident(alias),
+      ..rest
+    ] -> #(Some(#(string.lowercase(name), string.lowercase(alias))), rest)
+    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), lexer.Ident(alias), ..rest]
+      if alias != "on" && alias != "where" && alias != "using"
+    -> #(Some(#(string.lowercase(name), string.lowercase(alias))), rest)
+    [lexer.Ident(name), lexer.Keyword("as"), lexer.Ident(alias), ..rest] -> #(
+      Some(#(string.lowercase(name), string.lowercase(alias))),
+      rest,
+    )
+    [lexer.QuotedIdent(name), lexer.Keyword("as"), lexer.Ident(alias), ..rest] -> #(
+      Some(#(string.lowercase(name), string.lowercase(alias))),
+      rest,
+    )
+    [lexer.Ident(name), lexer.Ident(alias), ..rest] -> #(
+      Some(#(string.lowercase(name), string.lowercase(alias))),
+      rest,
+    )
+    [lexer.Ident(name), ..rest] -> #(
+      Some(#(string.lowercase(name), string.lowercase(name))),
+      rest,
+    )
+    _ -> #(None, tokens)
   }
 }
 
@@ -975,10 +1105,45 @@ fn resolve_select_columns(
 }
 
 // ============================================================
-// Token-based expression type inference (#342, #298)
+// Expression type inference
 // ============================================================
+//
+// `infer_expression_type_from_tokens` first tries the IR-driven path
+// (`expr_parser.parse_expr` → `type_inference.infer_expr_type`). When
+// the expression-aware IR can type the expression, the result flows
+// through unchanged. When the IR cannot (e.g. a construct not yet in
+// the expression grammar), we fall through to the legacy token-scan
+// path so existing coverage is preserved. Over time the token path
+// shrinks as the IR grows; both produce the same `(ScalarType, Bool)`
+// contract expected by the select-column resolver.
 
 fn infer_expression_type_from_tokens(
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+  table_names: List(String),
+  query_name: String,
+) -> Result(#(model.ScalarType, Bool), AnalysisError) {
+  let ir_expr = expr_parser.parse_expr(tokens)
+  case ir_expr {
+    query_ir.RawExpr(..) ->
+      infer_expression_type_token_path(tokens, catalog, table_names, query_name)
+    _ -> {
+      let scope = type_inference.scope(query_name, catalog, table_names, [])
+      case type_inference.infer_expr_type(scope, ir_expr) {
+        Ok(type_inference.InferredType(scalar: t, nullable: n)) -> Ok(#(t, n))
+        Error(_) ->
+          infer_expression_type_token_path(
+            tokens,
+            catalog,
+            table_names,
+            query_name,
+          )
+      }
+    }
+  }
+}
+
+fn infer_expression_type_token_path(
   tokens: List(lexer.Token),
   catalog: model.Catalog,
   table_names: List(String),
@@ -2071,10 +2236,33 @@ fn tok_nullable_loop(
 ) -> #(List(String), Bool) {
   case tokens {
     [] -> #(acc, primary_nullable)
-    // LEFT [OUTER] JOIN table → joined table is nullable
+    // LEFT [OUTER] JOIN table → joined table is nullable.
+    // Also handles `LEFT [OUTER] JOIN LATERAL (subquery) AS alias`
+    // so the alias from a LATERAL subquery is marked nullable too.
     [lexer.Keyword("left"), ..rest] -> {
       let rest2 = tok_skip_keyword(rest, "outer")
       case rest2 {
+        [
+          lexer.Keyword("join"),
+          lexer.Keyword("lateral"),
+          lexer.LParen,
+          ..after_lp
+        ] -> {
+          let remaining = token_utils.skip_parens(after_lp, 1)
+          case token_utils.read_subquery_alias(remaining) {
+            #(Some(n), after_alias) ->
+              tok_nullable_loop(after_alias, [n, ..acc], primary_nullable)
+            #(None, after) -> tok_nullable_loop(after, acc, primary_nullable)
+          }
+        }
+        [lexer.Keyword("join"), lexer.LParen, ..after_lp] -> {
+          let remaining = token_utils.skip_parens(after_lp, 1)
+          case token_utils.read_subquery_alias(remaining) {
+            #(Some(n), after_alias) ->
+              tok_nullable_loop(after_alias, [n, ..acc], primary_nullable)
+            #(None, after) -> tok_nullable_loop(after, acc, primary_nullable)
+          }
+        }
         [lexer.Keyword("join"), ..after_join] -> {
           let #(name, remaining) = token_utils.read_table_name(after_join)
           case name {
@@ -2255,6 +2443,24 @@ fn tok_parse_regular_column(tokens: List(lexer.Token)) -> ExtractedColumn {
           ExtractedColumn(
             name: name,
             source_table: None,
+            expression: None,
+            expression_tokens: None,
+          )
+        // A bare keyword like `action` / `name` / `order` appearing in
+        // a SELECT or RETURNING list is a non-reserved identifier used
+        // as a column name. Treat it as a plain column ref so catalog
+        // lookup can pick up the column from the DML target.
+        [lexer.Keyword(name)] ->
+          ExtractedColumn(
+            name: name,
+            source_table: None,
+            expression: None,
+            expression_tokens: None,
+          )
+        [lexer.Ident(table), lexer.Dot, lexer.Keyword(col)] ->
+          ExtractedColumn(
+            name: col,
+            source_table: Some(string.lowercase(table)),
             expression: None,
             expression_tokens: None,
           )

--- a/src/sqlode/query_analyzer/expr_parser.gleam
+++ b/src/sqlode/query_analyzer/expr_parser.gleam
@@ -1,0 +1,1825 @@
+//// Recursive-descent parser that turns a list of SQL tokens into the
+//// expression-aware IR (`query_ir.Expr` / `query_ir.SelectCore` /
+//// `query_ir.Stmt`).
+////
+//// The parser is deliberately permissive: it models the SQL subset
+//// sqlode needs to reason about (the constructs exercised by the
+//// fixtures in `test/fixtures/complex_sql/`) and falls back to
+//// `query_ir.RawExpr` / `query_ir.UnstructuredStmt` with an explicit
+//// `reason` string when it hits a construct it does not understand.
+//// The downstream analyzer surfaces these as
+//// `AnalysisError.UnsupportedExpression`, so "silent fallback to
+//// StringType" never happens — every gap is tied to a concrete IR
+//// node an operator can point at.
+////
+//// Precedence roughly follows PostgreSQL's operator table:
+////
+////   1. OR
+////   2. AND
+////   3. NOT
+////   4. IS [NOT] NULL/TRUE/FALSE, IS [NOT] DISTINCT FROM
+////   5. =, <>, !=, <, >, <=, >=, LIKE, ILIKE, IN, BETWEEN, SIMILAR TO,
+////      @>, <@, ?|, ?&, &&
+////   6. +, -, ||, JSON ops (->, ->>, #>, #>>)
+////   7. *, /, %
+////   8. unary -, +
+////   9. ::type cast
+////  10. function calls / atoms
+
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/string
+import sqlode/lexer
+import sqlode/naming
+import sqlode/query_ir
+
+/// Parse a full statement from its token list. Never fails; unknown
+/// constructs surface as `UnstructuredStmt(reason, tokens)` with the
+/// raw tokens preserved for legacy passes and the reason string
+/// bubbled up to analyzer diagnostics.
+pub fn parse_stmt(tokens: List(lexer.Token)) -> query_ir.Stmt {
+  let #(ctes, recursive, after_ctes) = parse_with_clause(tokens)
+  case after_ctes {
+    [lexer.Keyword("select"), ..] -> {
+      let #(core, _rest) = parse_select_core(after_ctes)
+      query_ir.SelectStmt(ctes: attach_recursive(ctes, recursive), core: core)
+    }
+    [lexer.Keyword("insert"), ..rest] ->
+      parse_insert_body(attach_recursive(ctes, recursive), rest)
+    [lexer.Keyword("update"), ..rest] ->
+      parse_update_body(attach_recursive(ctes, recursive), rest)
+    [lexer.Keyword("delete"), ..rest] ->
+      parse_delete_body(attach_recursive(ctes, recursive), rest)
+    _ ->
+      query_ir.UnstructuredStmt(
+        reason: "unrecognised top-level statement",
+        tokens: tokens,
+      )
+  }
+}
+
+fn attach_recursive(
+  ctes: List(query_ir.CteDef),
+  recursive: Bool,
+) -> List(query_ir.CteDef) {
+  case recursive {
+    False -> ctes
+    True ->
+      list.map(ctes, fn(cte) {
+        query_ir.CteDef(
+          name: cte.name,
+          columns: cte.columns,
+          body: cte.body,
+          recursive: True,
+        )
+      })
+  }
+}
+
+// ============================================================
+// WITH-clause parsing
+// ============================================================
+
+fn parse_with_clause(
+  tokens: List(lexer.Token),
+) -> #(List(query_ir.CteDef), Bool, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("with"), lexer.Keyword("recursive"), ..rest] -> {
+      let #(ctes, remaining) = parse_cte_list(rest, [])
+      #(ctes, True, remaining)
+    }
+    [lexer.Keyword("with"), ..rest] -> {
+      let #(ctes, remaining) = parse_cte_list(rest, [])
+      #(ctes, False, remaining)
+    }
+    _ -> #([], False, tokens)
+  }
+}
+
+fn parse_cte_list(
+  tokens: List(lexer.Token),
+  acc: List(query_ir.CteDef),
+) -> #(List(query_ir.CteDef), List(lexer.Token)) {
+  case parse_single_cte(tokens) {
+    Some(#(cte, after)) ->
+      case after {
+        [lexer.Comma, ..more] -> parse_cte_list(more, [cte, ..acc])
+        _ -> #(list.reverse([cte, ..acc]), after)
+      }
+    None -> #(list.reverse(acc), tokens)
+  }
+}
+
+fn parse_single_cte(
+  tokens: List(lexer.Token),
+) -> Option(#(query_ir.CteDef, List(lexer.Token))) {
+  case tokens {
+    [lexer.Ident(name), ..after_name] -> parse_cte_after_name(name, after_name)
+    [lexer.QuotedIdent(name), ..after_name] ->
+      parse_cte_after_name(name, after_name)
+    _ -> None
+  }
+}
+
+fn parse_cte_after_name(
+  name: String,
+  tokens: List(lexer.Token),
+) -> Option(#(query_ir.CteDef, List(lexer.Token))) {
+  let #(columns, after_cols) = case tokens {
+    [lexer.LParen, ..after_lp] -> {
+      let #(inside, after) = collect_parens(after_lp)
+      #(parse_ident_list(inside), after)
+    }
+    _ -> #([], tokens)
+  }
+  case after_cols {
+    [lexer.Keyword("as"), lexer.LParen, ..after_as_lp] -> {
+      let #(inner, after) = collect_parens(after_as_lp)
+      let body = parse_stmt(inner)
+      Some(#(
+        query_ir.CteDef(
+          name: string.lowercase(name),
+          columns: columns,
+          body: body,
+          recursive: False,
+        ),
+        after,
+      ))
+    }
+    _ -> None
+  }
+}
+
+fn parse_ident_list(tokens: List(lexer.Token)) -> List(String) {
+  tokens
+  |> split_on_top_commas()
+  |> list.filter_map(fn(group) {
+    case group {
+      [lexer.Ident(n)] -> Ok(string.lowercase(n))
+      [lexer.QuotedIdent(n)] -> Ok(string.lowercase(n))
+      _ -> Error(Nil)
+    }
+  })
+}
+
+// ============================================================
+// SELECT parsing
+// ============================================================
+
+pub fn parse_select_core(
+  tokens: List(lexer.Token),
+) -> #(query_ir.SelectCore, List(lexer.Token)) {
+  let #(distinct, after_distinct) = case tokens {
+    [lexer.Keyword("select"), lexer.Keyword("distinct"), ..rest] -> #(
+      True,
+      rest,
+    )
+    [lexer.Keyword("select"), ..rest] -> #(False, rest)
+    _ -> #(False, tokens)
+  }
+  let #(select_tokens, rest_after_select) =
+    collect_until_keyword(after_distinct, [
+      "from", "where", "group", "having", "order", "limit", "offset", "union",
+      "intersect", "except", "window",
+    ])
+  let items = parse_select_items(select_tokens)
+  let #(from_list, rest_after_from) = case rest_after_select {
+    [lexer.Keyword("from"), ..rest] -> parse_from_clause(rest)
+    _ -> #([], rest_after_select)
+  }
+  let #(where_expr, rest_after_where) = case rest_after_from {
+    [lexer.Keyword("where"), ..rest] -> {
+      let #(where_toks, after) =
+        collect_until_keyword(rest, [
+          "group", "having", "order", "limit", "offset", "union", "intersect",
+          "except", "window",
+        ])
+      #(Some(parse_expr(where_toks)), after)
+    }
+    _ -> #(None, rest_after_from)
+  }
+  let #(group_by, rest_after_group) = case rest_after_where {
+    [lexer.Keyword("group"), lexer.Keyword("by"), ..rest] -> {
+      let #(gb_toks, after) =
+        collect_until_keyword(rest, [
+          "having", "order", "limit", "offset", "union", "intersect", "except",
+          "window",
+        ])
+      #(parse_expr_list(gb_toks), after)
+    }
+    _ -> #([], rest_after_where)
+  }
+  let #(having_expr, rest_after_having) = case rest_after_group {
+    [lexer.Keyword("having"), ..rest] -> {
+      let #(h_toks, after) =
+        collect_until_keyword(rest, [
+          "order", "limit", "offset", "union", "intersect", "except", "window",
+        ])
+      #(Some(parse_expr(h_toks)), after)
+    }
+    _ -> #(None, rest_after_group)
+  }
+  let rest_after_window = case rest_after_having {
+    [lexer.Keyword("window"), ..rest] -> {
+      let #(_, after) =
+        collect_until_keyword(rest, [
+          "order", "limit", "offset", "union", "intersect", "except",
+        ])
+      after
+    }
+    _ -> rest_after_having
+  }
+  let #(order_by, rest_after_order) = case rest_after_window {
+    [lexer.Keyword("order"), lexer.Keyword("by"), ..rest] -> {
+      let #(o_toks, after) =
+        collect_until_keyword(rest, [
+          "limit", "offset", "union", "intersect", "except",
+        ])
+      #(parse_order_keys(o_toks), after)
+    }
+    _ -> #([], rest_after_window)
+  }
+  let #(limit, rest_after_limit) = case rest_after_order {
+    [lexer.Keyword("limit"), ..rest] -> {
+      let #(l_toks, after) =
+        collect_until_keyword(rest, ["offset", "union", "intersect", "except"])
+      #(Some(parse_expr(l_toks)), after)
+    }
+    _ -> #(None, rest_after_order)
+  }
+  let #(offset, rest_after_offset) = case rest_after_limit {
+    [lexer.Keyword("offset"), ..rest] -> {
+      let #(o_toks, after) =
+        collect_until_keyword(rest, ["union", "intersect", "except"])
+      #(Some(parse_expr(o_toks)), after)
+    }
+    _ -> #(None, rest_after_limit)
+  }
+  let #(set_op, remaining) = parse_set_op(rest_after_offset)
+  #(
+    query_ir.SelectCore(
+      distinct: distinct,
+      select_items: items,
+      from: from_list,
+      where_: where_expr,
+      group_by: group_by,
+      having: having_expr,
+      order_by: order_by,
+      limit: limit,
+      offset: offset,
+      set_op: set_op,
+    ),
+    remaining,
+  )
+}
+
+fn parse_set_op(
+  tokens: List(lexer.Token),
+) -> #(Option(query_ir.SetOp), List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword(kw), ..rest]
+      if kw == "union" || kw == "intersect" || kw == "except"
+    -> {
+      let #(all, rest2) = case rest {
+        [lexer.Keyword("all"), ..more] -> #(True, more)
+        _ -> #(False, rest)
+      }
+      let #(core, after) = parse_select_core(rest2)
+      let kind = case kw {
+        "union" -> query_ir.Union
+        "intersect" -> query_ir.Intersect
+        _ -> query_ir.Except
+      }
+      #(Some(query_ir.SetOp(kind: kind, all: all, right: core)), after)
+    }
+    _ -> #(None, tokens)
+  }
+}
+
+fn parse_order_keys(tokens: List(lexer.Token)) -> List(query_ir.OrderKey) {
+  tokens
+  |> split_on_top_commas()
+  |> list.map(parse_order_key)
+}
+
+fn parse_order_key(tokens: List(lexer.Token)) -> query_ir.OrderKey {
+  let reversed = list.reverse(tokens)
+  let #(nulls, reversed2) = case reversed {
+    [lexer.Keyword("first"), lexer.Keyword("nulls"), ..rest] -> #(
+      Some(query_ir.NullsFirst),
+      rest,
+    )
+    [lexer.Keyword("last"), lexer.Keyword("nulls"), ..rest] -> #(
+      Some(query_ir.NullsLast),
+      rest,
+    )
+    _ -> #(None, reversed)
+  }
+  let #(descending, reversed3) = case reversed2 {
+    [lexer.Keyword("desc"), ..rest] -> #(True, rest)
+    [lexer.Keyword("asc"), ..rest] -> #(False, rest)
+    _ -> #(False, reversed2)
+  }
+  let expr_tokens = list.reverse(reversed3)
+  query_ir.OrderKey(
+    expr: parse_expr(expr_tokens),
+    descending: descending,
+    nulls: nulls,
+  )
+}
+
+// ============================================================
+// SELECT items
+// ============================================================
+
+fn parse_select_items(tokens: List(lexer.Token)) -> List(query_ir.SelectItemEx) {
+  tokens
+  |> split_on_top_commas()
+  |> list.map(parse_select_item)
+}
+
+fn parse_select_item(tokens: List(lexer.Token)) -> query_ir.SelectItemEx {
+  case tokens {
+    [lexer.Operator("*")] -> query_ir.StarEx(table_prefix: None)
+    [lexer.Star] -> query_ir.StarEx(table_prefix: None)
+    [lexer.Ident(t), lexer.Dot, lexer.Operator("*")] ->
+      query_ir.StarEx(table_prefix: Some(string.lowercase(t)))
+    [lexer.Ident(t), lexer.Dot, lexer.Star] ->
+      query_ir.StarEx(table_prefix: Some(string.lowercase(t)))
+    _ -> {
+      let #(expr_tokens, alias) = split_trailing_alias(tokens)
+      query_ir.ExprItem(expr: parse_expr(expr_tokens), alias: alias)
+    }
+  }
+}
+
+fn split_trailing_alias(
+  tokens: List(lexer.Token),
+) -> #(List(lexer.Token), Option(String)) {
+  case list.reverse(tokens) {
+    [lexer.Ident(name), lexer.Keyword("as"), ..rest] -> #(
+      list.reverse(rest),
+      Some(naming.normalize_identifier(name)),
+    )
+    [lexer.QuotedIdent(name), lexer.Keyword("as"), ..rest] -> #(
+      list.reverse(rest),
+      Some(naming.normalize_identifier(name)),
+    )
+    // `expr alias` (no AS) — only accept this when the prior token
+    // clearly ends an expression (ident / paren / literal), to avoid
+    // misreading `SELECT tier` as `SELECT <no-expr> tier`.
+    [lexer.Ident(name), prev, ..rest] ->
+      case is_expr_end(prev) {
+        True -> #(
+          list.reverse([prev, ..rest]),
+          Some(naming.normalize_identifier(name)),
+        )
+        False -> #(tokens, None)
+      }
+    _ -> #(tokens, None)
+  }
+}
+
+fn is_expr_end(token: lexer.Token) -> Bool {
+  case token {
+    lexer.RParen -> True
+    lexer.Ident(_) -> True
+    lexer.QuotedIdent(_) -> True
+    lexer.StringLit(_) -> True
+    lexer.NumberLit(_) -> True
+    lexer.Placeholder(_) -> True
+    lexer.Star -> True
+    _ -> False
+  }
+}
+
+// ============================================================
+// FROM / JOIN
+// ============================================================
+
+fn parse_from_clause(
+  tokens: List(lexer.Token),
+) -> #(List(query_ir.FromItemEx), List(lexer.Token)) {
+  let #(items_tokens, rest) =
+    collect_until_keyword(tokens, [
+      "where", "group", "having", "order", "limit", "offset", "union",
+      "intersect", "except", "window", "returning",
+    ])
+  let groups = split_on_top_commas(items_tokens)
+  let from_items = list.map(groups, parse_from_element)
+  #(from_items, rest)
+}
+
+fn parse_from_element(tokens: List(lexer.Token)) -> query_ir.FromItemEx {
+  let #(first, after_first) = parse_primary_from(tokens)
+  parse_join_tail(first, after_first)
+}
+
+fn parse_primary_from(
+  tokens: List(lexer.Token),
+) -> #(query_ir.FromItemEx, List(lexer.Token)) {
+  case tokens {
+    [lexer.LParen, lexer.Keyword("values"), ..rest] -> {
+      let #(_, after) = collect_parens([lexer.Keyword("values"), ..rest])
+      let #(body, _) = collect_parens([lexer.Keyword("values"), ..rest])
+      parse_values_from_body(body, after)
+    }
+    [lexer.LParen, lexer.Keyword("select"), ..] -> {
+      let #(inner, after_rp) = collect_parens(drop_first(tokens))
+      let #(core, _) = parse_select_core(inner)
+      parse_subquery_alias(core, after_rp, False)
+    }
+    [lexer.LParen, lexer.Keyword("with"), ..] -> {
+      let #(inner, after_rp) = collect_parens(drop_first(tokens))
+      let stmt = parse_stmt(inner)
+      let core = case stmt {
+        query_ir.SelectStmt(core: c, ..) -> c
+        _ -> empty_core()
+      }
+      parse_subquery_alias(core, after_rp, False)
+    }
+    [lexer.Keyword("lateral"), lexer.LParen, lexer.Keyword("select"), ..] -> {
+      let #(inner, after_rp) = collect_parens(drop_first(drop_first(tokens)))
+      let #(core, _) = parse_select_core(inner)
+      parse_subquery_alias(core, after_rp, True)
+    }
+    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), ..rest] -> {
+      let #(alias, rest2) = parse_optional_alias(rest)
+      #(query_ir.FromTable(name: string.lowercase(name), alias: alias), rest2)
+    }
+    [lexer.Ident(name), ..rest] -> {
+      let #(alias, rest2) = parse_optional_alias(rest)
+      #(query_ir.FromTable(name: string.lowercase(name), alias: alias), rest2)
+    }
+    [lexer.QuotedIdent(name), ..rest] -> {
+      let #(alias, rest2) = parse_optional_alias(rest)
+      #(query_ir.FromTable(name: string.lowercase(name), alias: alias), rest2)
+    }
+    _ -> #(query_ir.FromTable(name: "", alias: None), tokens)
+  }
+}
+
+fn parse_values_from_body(
+  body: List(lexer.Token),
+  after: List(lexer.Token),
+) -> #(query_ir.FromItemEx, List(lexer.Token)) {
+  let rows = parse_values_rows(body)
+  let #(alias_opt, col_aliases, rest) = parse_aliased_column_list(after)
+  let alias = option.unwrap(alias_opt, "")
+  #(
+    query_ir.FromValues(rows: rows, alias: alias, column_aliases: col_aliases),
+    rest,
+  )
+}
+
+fn parse_values_rows(body: List(lexer.Token)) -> List(List(query_ir.Expr)) {
+  case body {
+    [lexer.Keyword("values"), ..rest] -> collect_values_rows(rest, [])
+    _ -> []
+  }
+}
+
+fn collect_values_rows(
+  tokens: List(lexer.Token),
+  acc: List(List(query_ir.Expr)),
+) -> List(List(query_ir.Expr)) {
+  case tokens {
+    [lexer.LParen, ..rest] -> {
+      let #(inner, after) = collect_parens(rest)
+      let row = list.map(split_on_top_commas(inner), parse_expr)
+      case after {
+        [lexer.Comma, ..more] -> collect_values_rows(more, [row, ..acc])
+        _ -> list.reverse([row, ..acc])
+      }
+    }
+    _ -> list.reverse(acc)
+  }
+}
+
+fn parse_subquery_alias(
+  core: query_ir.SelectCore,
+  after: List(lexer.Token),
+  lateral: Bool,
+) -> #(query_ir.FromItemEx, List(lexer.Token)) {
+  let #(alias_opt, col_aliases, rest) = parse_aliased_column_list(after)
+  let alias = option.unwrap(alias_opt, "")
+  let item =
+    query_ir.FromSubquery(core: core, alias: alias, column_aliases: col_aliases)
+  case lateral {
+    True -> #(
+      query_ir.FromJoin(
+        left: query_ir.FromTable(name: "", alias: None),
+        right: item,
+        kind: query_ir.CrossJoin,
+        on: query_ir.JoinNoCondition,
+        lateral: True,
+      ),
+      rest,
+    )
+    False -> #(item, rest)
+  }
+}
+
+fn parse_aliased_column_list(
+  tokens: List(lexer.Token),
+) -> #(Option(String), List(String), List(lexer.Token)) {
+  let after_as = case tokens {
+    [lexer.Keyword("as"), ..rest] -> rest
+    _ -> tokens
+  }
+  case after_as {
+    [lexer.Ident(alias), lexer.LParen, ..after_lp] -> {
+      let #(cols, after) = collect_parens(after_lp)
+      #(Some(string.lowercase(alias)), parse_ident_list(cols), after)
+    }
+    [lexer.QuotedIdent(alias), lexer.LParen, ..after_lp] -> {
+      let #(cols, after) = collect_parens(after_lp)
+      #(Some(string.lowercase(alias)), parse_ident_list(cols), after)
+    }
+    [lexer.Ident(alias), ..rest] -> #(Some(string.lowercase(alias)), [], rest)
+    [lexer.QuotedIdent(alias), ..rest] -> #(
+      Some(string.lowercase(alias)),
+      [],
+      rest,
+    )
+    _ -> #(None, [], after_as)
+  }
+}
+
+fn parse_optional_alias(
+  tokens: List(lexer.Token),
+) -> #(Option(String), List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("as"), lexer.Ident(name), ..rest] -> #(
+      Some(string.lowercase(name)),
+      rest,
+    )
+    [lexer.Keyword("as"), lexer.QuotedIdent(name), ..rest] -> #(
+      Some(string.lowercase(name)),
+      rest,
+    )
+    [lexer.Ident(name), ..rest] ->
+      case is_reserved_after_table(name) {
+        True -> #(None, tokens)
+        False -> #(Some(string.lowercase(name)), rest)
+      }
+    [lexer.QuotedIdent(name), ..rest] -> #(Some(string.lowercase(name)), rest)
+    _ -> #(None, tokens)
+  }
+}
+
+fn is_reserved_after_table(name: String) -> Bool {
+  let lowered = string.lowercase(name)
+  list.contains(
+    [
+      "on", "where", "group", "having", "order", "limit", "offset", "union",
+      "intersect", "except", "returning", "using", "lateral", "left", "right",
+      "inner", "outer", "cross", "full", "natural", "join", "window",
+    ],
+    lowered,
+  )
+}
+
+fn parse_join_tail(
+  left: query_ir.FromItemEx,
+  tokens: List(lexer.Token),
+) -> query_ir.FromItemEx {
+  case detect_join(tokens) {
+    Some(#(kind, after_kw, lateral)) -> {
+      let #(right_raw, after_right) = parse_primary_from(after_kw)
+      let #(on, after_on) = parse_join_on(after_right)
+      let right = parse_join_tail(right_raw, after_on)
+      parse_join_tail(
+        query_ir.FromJoin(
+          left: left,
+          right: right,
+          kind: kind,
+          on: on,
+          lateral: lateral,
+        ),
+        [],
+      )
+    }
+    None -> left
+  }
+}
+
+fn detect_join(
+  tokens: List(lexer.Token),
+) -> Option(#(query_ir.JoinKind, List(lexer.Token), Bool)) {
+  case tokens {
+    [lexer.Keyword("join"), lexer.Keyword("lateral"), ..rest] ->
+      Some(#(query_ir.InnerJoin, rest, True))
+    [lexer.Keyword("join"), ..rest] -> Some(#(query_ir.InnerJoin, rest, False))
+    [lexer.Keyword("inner"), lexer.Keyword("join"), ..rest] ->
+      Some(#(query_ir.InnerJoin, rest, False))
+    [lexer.Keyword("cross"), lexer.Keyword("join"), ..rest] ->
+      Some(#(query_ir.CrossJoin, rest, False))
+    [
+      lexer.Keyword("left"),
+      lexer.Keyword("join"),
+      lexer.Keyword("lateral"),
+      ..rest
+    ] -> Some(#(query_ir.LeftJoin, rest, True))
+    [
+      lexer.Keyword("left"),
+      lexer.Keyword("outer"),
+      lexer.Keyword("join"),
+      lexer.Keyword("lateral"),
+      ..rest
+    ] -> Some(#(query_ir.LeftJoin, rest, True))
+    [
+      lexer.Keyword("left"),
+      lexer.Keyword("outer"),
+      lexer.Keyword("join"),
+      ..rest
+    ] -> Some(#(query_ir.LeftJoin, rest, False))
+    [lexer.Keyword("left"), lexer.Keyword("join"), ..rest] ->
+      Some(#(query_ir.LeftJoin, rest, False))
+    [
+      lexer.Keyword("right"),
+      lexer.Keyword("outer"),
+      lexer.Keyword("join"),
+      ..rest
+    ] -> Some(#(query_ir.RightJoin, rest, False))
+    [lexer.Keyword("right"), lexer.Keyword("join"), ..rest] ->
+      Some(#(query_ir.RightJoin, rest, False))
+    [
+      lexer.Keyword("full"),
+      lexer.Keyword("outer"),
+      lexer.Keyword("join"),
+      ..rest
+    ] -> Some(#(query_ir.FullJoin, rest, False))
+    [lexer.Keyword("full"), lexer.Keyword("join"), ..rest] ->
+      Some(#(query_ir.FullJoin, rest, False))
+    _ -> None
+  }
+}
+
+fn parse_join_on(
+  tokens: List(lexer.Token),
+) -> #(query_ir.JoinOn, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("on"), ..rest] -> {
+      let #(on_toks, after) =
+        collect_until_keyword(rest, [
+          "join", "inner", "left", "right", "full", "cross", "natural", "where",
+          "group", "having", "order", "limit", "offset", "union", "intersect",
+          "except", "returning", "window",
+        ])
+      #(query_ir.JoinOnExpr(expr: parse_expr(on_toks)), after)
+    }
+    [lexer.Keyword("using"), lexer.LParen, ..rest] -> {
+      let #(cols, after) = collect_parens(rest)
+      #(query_ir.JoinUsing(columns: parse_ident_list(cols)), after)
+    }
+    _ -> #(query_ir.JoinNoCondition, tokens)
+  }
+}
+
+// ============================================================
+// INSERT / UPDATE / DELETE bodies
+// ============================================================
+
+fn parse_insert_body(
+  ctes: List(query_ir.CteDef),
+  tokens: List(lexer.Token),
+) -> query_ir.Stmt {
+  case tokens {
+    [lexer.Keyword("into"), ..after_into] ->
+      parse_insert_target(ctes, after_into)
+    _ ->
+      query_ir.UnstructuredStmt(reason: "INSERT without INTO", tokens: [
+        lexer.Keyword("insert"),
+        ..tokens
+      ])
+  }
+}
+
+fn parse_insert_target(
+  ctes: List(query_ir.CteDef),
+  tokens: List(lexer.Token),
+) -> query_ir.Stmt {
+  let #(table_name, after_name) = read_qualified_name(tokens)
+  let #(columns, after_cols) = case after_name {
+    [lexer.LParen, ..after_lp] -> {
+      let #(inside, after) = collect_parens(after_lp)
+      #(parse_ident_list(inside), after)
+    }
+    _ -> #([], after_name)
+  }
+  let #(source, after_source) = parse_insert_source(after_cols)
+  let returning = parse_returning(after_source)
+  query_ir.InsertStmt(
+    ctes: ctes,
+    table: table_name,
+    columns: columns,
+    source: source,
+    returning: returning,
+  )
+}
+
+fn parse_insert_source(
+  tokens: List(lexer.Token),
+) -> #(query_ir.InsertSource, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("default"), lexer.Keyword("values"), ..rest] -> #(
+      query_ir.InsertDefaultValues,
+      rest,
+    )
+    [lexer.Keyword("values"), ..rest] -> {
+      let rows = collect_values_rows(rest, [])
+      // After the values rows, the stream is already past the closing
+      // paren of the last row. Scan forward until RETURNING / end.
+      let after = skip_to_returning_or_end(rest)
+      #(query_ir.InsertValues(rows: rows), after)
+    }
+    [lexer.Keyword("select"), ..] -> {
+      let #(core, after) = parse_select_core(tokens)
+      #(query_ir.InsertSelect(core: core), after)
+    }
+    [lexer.Keyword("with"), ..] -> {
+      let stmt = parse_stmt(tokens)
+      case stmt {
+        query_ir.SelectStmt(core: c, ..) -> #(
+          query_ir.InsertSelect(core: c),
+          [],
+        )
+        _ -> #(query_ir.InsertValues(rows: []), tokens)
+      }
+    }
+    _ -> #(query_ir.InsertValues(rows: []), tokens)
+  }
+}
+
+fn skip_to_returning_or_end(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [] -> []
+    [lexer.Keyword("returning"), ..] as t -> t
+    [_, ..rest] -> skip_to_returning_or_end(rest)
+  }
+}
+
+fn parse_update_body(
+  ctes: List(query_ir.CteDef),
+  tokens: List(lexer.Token),
+) -> query_ir.Stmt {
+  let #(table_name, after_name) = read_qualified_name(tokens)
+  let #(alias, after_alias) = parse_optional_alias(after_name)
+  case after_alias {
+    [lexer.Keyword("set"), ..after_set] -> {
+      let #(set_toks, after_set_block) =
+        collect_until_keyword(after_set, ["from", "where", "returning"])
+      let assignments = parse_assignments(set_toks)
+      let #(from_list, after_from) = case after_set_block {
+        [lexer.Keyword("from"), ..rest] -> parse_from_clause(rest)
+        _ -> #([], after_set_block)
+      }
+      let #(where_expr, after_where) = case after_from {
+        [lexer.Keyword("where"), ..rest] -> {
+          let #(where_toks, after) = collect_until_keyword(rest, ["returning"])
+          #(Some(parse_expr(where_toks)), after)
+        }
+        _ -> #(None, after_from)
+      }
+      let returning = parse_returning(after_where)
+      query_ir.UpdateStmt(
+        ctes: ctes,
+        table: table_name,
+        alias: alias,
+        assignments: assignments,
+        from: from_list,
+        where_: where_expr,
+        returning: returning,
+      )
+    }
+    _ ->
+      query_ir.UnstructuredStmt(reason: "UPDATE without SET", tokens: [
+        lexer.Keyword("update"),
+        ..tokens
+      ])
+  }
+}
+
+fn parse_assignments(tokens: List(lexer.Token)) -> List(query_ir.Assignment) {
+  tokens
+  |> split_on_top_commas()
+  |> list.filter_map(parse_assignment)
+}
+
+fn parse_assignment(
+  tokens: List(lexer.Token),
+) -> Result(query_ir.Assignment, Nil) {
+  case tokens {
+    [lexer.Ident(col), lexer.Operator("="), ..rest] ->
+      Ok(query_ir.Assignment(
+        column: string.lowercase(col),
+        value: parse_expr(rest),
+      ))
+    [lexer.QuotedIdent(col), lexer.Operator("="), ..rest] ->
+      Ok(query_ir.Assignment(
+        column: string.lowercase(col),
+        value: parse_expr(rest),
+      ))
+    _ -> Error(Nil)
+  }
+}
+
+fn parse_delete_body(
+  ctes: List(query_ir.CteDef),
+  tokens: List(lexer.Token),
+) -> query_ir.Stmt {
+  case tokens {
+    [lexer.Keyword("from"), ..after_from] -> {
+      let #(table_name, after_name) = read_qualified_name(after_from)
+      let #(alias, after_alias) = parse_optional_alias(after_name)
+      let #(using_list, after_using) = case after_alias {
+        [lexer.Keyword("using"), ..rest] -> parse_from_clause(rest)
+        _ -> #([], after_alias)
+      }
+      let #(where_expr, after_where) = case after_using {
+        [lexer.Keyword("where"), ..rest] -> {
+          let #(where_toks, after) = collect_until_keyword(rest, ["returning"])
+          #(Some(parse_expr(where_toks)), after)
+        }
+        _ -> #(None, after_using)
+      }
+      let returning = parse_returning(after_where)
+      query_ir.DeleteStmt(
+        ctes: ctes,
+        table: table_name,
+        alias: alias,
+        using: using_list,
+        where_: where_expr,
+        returning: returning,
+      )
+    }
+    _ ->
+      query_ir.UnstructuredStmt(reason: "DELETE without FROM", tokens: [
+        lexer.Keyword("delete"),
+        ..tokens
+      ])
+  }
+}
+
+fn parse_returning(tokens: List(lexer.Token)) -> List(query_ir.SelectItemEx) {
+  case tokens {
+    [lexer.Keyword("returning"), ..rest] -> {
+      let filtered =
+        list.filter(rest, fn(t) {
+          case t {
+            lexer.Semicolon -> False
+            _ -> True
+          }
+        })
+      parse_select_items(filtered)
+    }
+    _ -> []
+  }
+}
+
+// ============================================================
+// Expressions
+// ============================================================
+
+pub fn parse_expr(tokens: List(lexer.Token)) -> query_ir.Expr {
+  let #(expr, rest) = parse_or(trim_noise(tokens))
+  case rest {
+    [] -> expr
+    _ ->
+      query_ir.RawExpr(
+        reason: "trailing tokens after expression",
+        tokens: tokens,
+      )
+  }
+}
+
+fn parse_expr_list(tokens: List(lexer.Token)) -> List(query_ir.Expr) {
+  tokens
+  |> split_on_top_commas()
+  |> list.map(parse_expr)
+}
+
+fn parse_or(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(left, rest) = parse_and(tokens)
+  parse_or_tail(left, rest)
+}
+
+fn parse_or_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("or"), ..rest] -> {
+      let #(right, after) = parse_and(rest)
+      parse_or_tail(query_ir.Binary(op: "or", left: left, right: right), after)
+    }
+    _ -> #(left, tokens)
+  }
+}
+
+fn parse_and(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(left, rest) = parse_not(tokens)
+  parse_and_tail(left, rest)
+}
+
+fn parse_and_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("and"), ..rest] -> {
+      let #(right, after) = parse_not(rest)
+      parse_and_tail(
+        query_ir.Binary(op: "and", left: left, right: right),
+        after,
+      )
+    }
+    _ -> #(left, tokens)
+  }
+}
+
+fn parse_not(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("not"), ..rest] -> {
+      let #(inner, after) = parse_not(rest)
+      #(query_ir.Unary(op: "not", arg: inner), after)
+    }
+    _ -> parse_comparison(tokens)
+  }
+}
+
+fn parse_comparison(
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(left, rest) = parse_additive(tokens)
+  parse_comparison_tail(left, rest)
+}
+
+fn parse_comparison_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Operator(op), ..rest]
+      if op == "="
+      || op == "<>"
+      || op == "!="
+      || op == "<"
+      || op == ">"
+      || op == "<="
+      || op == ">="
+      || op == "@>"
+      || op == "<@"
+      || op == "?|"
+      || op == "?&"
+      || op == "&&"
+    -> {
+      case rest {
+        [lexer.Keyword("any"), lexer.LParen, ..after_lp] -> {
+          let #(inner, after) = collect_parens(after_lp)
+          let right = parse_expr(inner)
+          #(
+            query_ir.Quantified(
+              op: op,
+              left: left,
+              quantifier: query_ir.QAny,
+              right: right,
+            ),
+            after,
+          )
+        }
+        [lexer.Keyword("all"), lexer.LParen, ..after_lp] -> {
+          let #(inner, after) = collect_parens(after_lp)
+          let right = parse_expr(inner)
+          #(
+            query_ir.Quantified(
+              op: op,
+              left: left,
+              quantifier: query_ir.QAll,
+              right: right,
+            ),
+            after,
+          )
+        }
+        _ -> {
+          let #(right, after) = parse_additive(rest)
+          #(query_ir.Binary(op: op, left: left, right: right), after)
+        }
+      }
+    }
+    [lexer.Keyword("is"), lexer.Keyword("not"), lexer.Keyword("null"), ..rest] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsNull, negated: True),
+      rest,
+    )
+    [lexer.Keyword("is"), lexer.Keyword("null"), ..rest] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsNull, negated: False),
+      rest,
+    )
+    [lexer.Keyword("is"), lexer.Keyword("not"), lexer.Keyword("true"), ..rest] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsTrue, negated: True),
+      rest,
+    )
+    [lexer.Keyword("is"), lexer.Keyword("true"), ..rest] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsTrue, negated: False),
+      rest,
+    )
+    [lexer.Keyword("is"), lexer.Keyword("not"), lexer.Keyword("false"), ..rest] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsFalse, negated: True),
+      rest,
+    )
+    [lexer.Keyword("is"), lexer.Keyword("false"), ..rest] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsFalse, negated: False),
+      rest,
+    )
+    [
+      lexer.Keyword("is"),
+      lexer.Keyword("not"),
+      lexer.Keyword("unknown"),
+      ..rest
+    ] -> #(
+      query_ir.IsCheck(expr: left, predicate: query_ir.IsUnknown, negated: True),
+      rest,
+    )
+    [lexer.Keyword("is"), lexer.Keyword("unknown"), ..rest] -> #(
+      query_ir.IsCheck(
+        expr: left,
+        predicate: query_ir.IsUnknown,
+        negated: False,
+      ),
+      rest,
+    )
+    [lexer.Keyword("not"), lexer.Keyword("in"), ..rest] ->
+      parse_in_tail(left, rest, True)
+    [lexer.Keyword("in"), ..rest] -> parse_in_tail(left, rest, False)
+    [lexer.Keyword("not"), lexer.Keyword("between"), ..rest] ->
+      parse_between_tail(left, rest, True)
+    [lexer.Keyword("between"), ..rest] -> parse_between_tail(left, rest, False)
+    [lexer.Keyword("not"), lexer.Keyword("like"), ..rest] ->
+      parse_like_tail(left, rest, query_ir.Like, True)
+    [lexer.Keyword("like"), ..rest] ->
+      parse_like_tail(left, rest, query_ir.Like, False)
+    [lexer.Keyword("not"), lexer.Keyword("ilike"), ..rest] ->
+      parse_like_tail(left, rest, query_ir.Ilike, True)
+    [lexer.Keyword("ilike"), ..rest] ->
+      parse_like_tail(left, rest, query_ir.Ilike, False)
+    _ -> #(left, tokens)
+  }
+}
+
+fn parse_in_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+  negated: Bool,
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.LParen, lexer.Keyword("select"), ..] -> {
+      let #(inner, after) = collect_parens(drop_first(tokens))
+      let #(core, _) = parse_select_core(inner)
+      #(
+        query_ir.InExpr(
+          expr: left,
+          source: query_ir.InSubquery(core: core),
+          negated: negated,
+        ),
+        after,
+      )
+    }
+    [lexer.LParen, ..rest] -> {
+      let #(inner, after) = collect_parens(rest)
+      case detect_slice_macro(inner) {
+        Some(name) -> #(
+          query_ir.InExpr(
+            expr: left,
+            source: query_ir.InSliceMacro(name: name),
+            negated: negated,
+          ),
+          after,
+        )
+        None -> {
+          let values = parse_expr_list(inner)
+          #(
+            query_ir.InExpr(
+              expr: left,
+              source: query_ir.InList(values: values),
+              negated: negated,
+            ),
+            after,
+          )
+        }
+      }
+    }
+    _ -> #(
+      query_ir.RawExpr(reason: "IN without paren list", tokens: tokens),
+      [],
+    )
+  }
+}
+
+fn detect_slice_macro(tokens: List(lexer.Token)) -> Option(String) {
+  case tokens {
+    [
+      lexer.Ident(s),
+      lexer.Dot,
+      lexer.Ident(sl),
+      lexer.LParen,
+      lexer.Ident(name),
+      lexer.RParen,
+    ] ->
+      case string.lowercase(s), string.lowercase(sl) {
+        "sqlode", "slice" -> Some(string.lowercase(name))
+        _, _ -> None
+      }
+    _ -> None
+  }
+}
+
+fn parse_between_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+  negated: Bool,
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(low, rest) = parse_additive(tokens)
+  case rest {
+    [lexer.Keyword("and"), ..after_and] -> {
+      let #(high, after) = parse_additive(after_and)
+      #(
+        query_ir.Between(expr: left, low: low, high: high, negated: negated),
+        after,
+      )
+    }
+    _ -> #(query_ir.RawExpr(reason: "BETWEEN without AND", tokens: tokens), [])
+  }
+}
+
+fn parse_like_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+  op: query_ir.LikeOp,
+  negated: Bool,
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(pattern, rest) = parse_additive(tokens)
+  let #(escape, rest2) = case rest {
+    [lexer.Keyword("escape"), ..more] -> {
+      let #(esc, after) = parse_additive(more)
+      #(Some(esc), after)
+    }
+    _ -> #(None, rest)
+  }
+  #(
+    query_ir.LikeExpr(
+      expr: left,
+      op: op,
+      pattern: pattern,
+      escape: escape,
+      negated: negated,
+    ),
+    rest2,
+  )
+}
+
+fn parse_additive(
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(left, rest) = parse_multiplicative(tokens)
+  parse_additive_tail(left, rest)
+}
+
+fn parse_additive_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Operator(op), ..rest]
+      if op == "+"
+      || op == "-"
+      || op == "||"
+      || op == "->"
+      || op == "->>"
+      || op == "#>"
+      || op == "#>>"
+    -> {
+      let #(right, after) = parse_multiplicative(rest)
+      parse_additive_tail(
+        query_ir.Binary(op: op, left: left, right: right),
+        after,
+      )
+    }
+    _ -> #(left, tokens)
+  }
+}
+
+fn parse_multiplicative(
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(left, rest) = parse_unary(tokens)
+  parse_multiplicative_tail(left, rest)
+}
+
+fn parse_multiplicative_tail(
+  left: query_ir.Expr,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Star, ..rest] -> {
+      let #(right, after) = parse_unary(rest)
+      parse_multiplicative_tail(
+        query_ir.Binary(op: "*", left: left, right: right),
+        after,
+      )
+    }
+    [lexer.Operator(op), ..rest] if op == "/" || op == "%" -> {
+      let #(right, after) = parse_unary(rest)
+      parse_multiplicative_tail(
+        query_ir.Binary(op: op, left: left, right: right),
+        after,
+      )
+    }
+    _ -> #(left, tokens)
+  }
+}
+
+fn parse_unary(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Operator("-"), ..rest] -> {
+      let #(inner, after) = parse_unary(rest)
+      #(query_ir.Unary(op: "-", arg: inner), after)
+    }
+    [lexer.Operator("+"), ..rest] -> {
+      let #(inner, after) = parse_unary(rest)
+      #(query_ir.Unary(op: "+", arg: inner), after)
+    }
+    _ -> parse_cast(tokens)
+  }
+}
+
+fn parse_cast(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(atom, rest) = parse_atom(tokens)
+  parse_cast_tail(atom, rest)
+}
+
+fn parse_cast_tail(
+  atom: query_ir.Expr,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Operator("::"), ..rest] -> {
+      let #(type_name, after) = read_type_tokens(rest)
+      parse_cast_tail(query_ir.Cast(expr: atom, target_type: type_name), after)
+    }
+    _ -> #(atom, tokens)
+  }
+}
+
+fn read_type_tokens(tokens: List(lexer.Token)) -> #(String, List(lexer.Token)) {
+  collect_type_tokens(tokens, [])
+}
+
+fn collect_type_tokens(
+  tokens: List(lexer.Token),
+  acc: List(String),
+) -> #(String, List(lexer.Token)) {
+  case tokens {
+    [lexer.Ident(n), ..rest] ->
+      collect_type_tokens(rest, [string.lowercase(n), ..acc])
+    [lexer.Keyword(k), ..rest] -> collect_type_tokens(rest, [k, ..acc])
+    [lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      let inside_text = render_type_parens(inside)
+      let last_acc = case acc {
+        [first, ..rest_acc] -> [first <> "(" <> inside_text <> ")", ..rest_acc]
+        [] -> ["(" <> inside_text <> ")"]
+      }
+      collect_type_tokens(after, last_acc)
+    }
+    [lexer.Operator("[]"), ..rest] ->
+      case acc {
+        [first, ..rest_acc] ->
+          collect_type_tokens(rest, [first <> "[]", ..rest_acc])
+        [] -> collect_type_tokens(rest, ["[]"])
+      }
+    _ -> #(list.reverse(acc) |> string.join(" ") |> string.trim, tokens)
+  }
+}
+
+fn render_type_parens(tokens: List(lexer.Token)) -> String {
+  tokens
+  |> list.map(fn(t) {
+    case t {
+      lexer.Ident(n) -> n
+      lexer.Keyword(k) -> k
+      lexer.NumberLit(n) -> n
+      lexer.Comma -> ","
+      _ -> ""
+    }
+  })
+  |> string.join("")
+}
+
+fn parse_atom(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [] -> #(query_ir.RawExpr(reason: "empty expression", tokens: []), [])
+    [lexer.Keyword("null"), ..rest] -> #(query_ir.NullLit, rest)
+    [lexer.Keyword("true"), ..rest] -> #(query_ir.BoolLit(value: True), rest)
+    [lexer.Keyword("false"), ..rest] -> #(query_ir.BoolLit(value: False), rest)
+    [lexer.StringLit(v), ..rest] -> #(query_ir.StringLit(value: v), rest)
+    [lexer.NumberLit(n), ..rest] -> #(query_ir.NumberLit(value: n), rest)
+    [lexer.Placeholder(raw), ..rest] -> {
+      let idx = decode_placeholder(raw)
+      #(query_ir.Param(index: idx, raw: raw), rest)
+    }
+    [lexer.Keyword("case"), ..rest] -> parse_case(rest)
+    [lexer.Keyword("cast"), lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      let #(expr_tokens, as_rest) = split_on_as(inside)
+      let target =
+        as_rest
+        |> list.map(fn(t) {
+          case t {
+            lexer.Ident(n) -> n
+            lexer.Keyword(k) -> k
+            _ -> ""
+          }
+        })
+        |> list.filter(fn(s) { s != "" })
+        |> string.join(" ")
+      #(
+        query_ir.Cast(expr: parse_expr(expr_tokens), target_type: target),
+        after,
+      )
+    }
+    [lexer.Keyword("not"), lexer.Keyword("exists"), lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      let #(core, _) = parse_select_core(inside)
+      #(query_ir.Exists(core: core, negated: True), after)
+    }
+    [lexer.Keyword("exists"), lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      let #(core, _) = parse_select_core(inside)
+      #(query_ir.Exists(core: core, negated: False), after)
+    }
+    [lexer.Keyword("array"), lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      let #(core, _) = parse_select_core(inside)
+      #(query_ir.ScalarSubquery(core: core), after)
+    }
+    [lexer.Keyword("array"), lexer.Operator("["), ..rest] -> {
+      let #(inside, after) = collect_brackets(rest)
+      #(query_ir.ArrayLit(elements: parse_expr_list(inside)), after)
+    }
+    [lexer.LParen, lexer.Keyword("select"), ..] -> {
+      let #(inside, after) = collect_parens(drop_first(tokens))
+      let #(core, _) = parse_select_core(inside)
+      #(query_ir.ScalarSubquery(core: core), after)
+    }
+    [lexer.LParen, lexer.Keyword("with"), ..] -> {
+      let #(inside, after) = collect_parens(drop_first(tokens))
+      let stmt = parse_stmt(inside)
+      case stmt {
+        query_ir.SelectStmt(core: c, ..) -> #(
+          query_ir.ScalarSubquery(core: c),
+          after,
+        )
+        _ -> #(
+          query_ir.RawExpr(
+            reason: "non-SELECT subquery in expression",
+            tokens: tokens,
+          ),
+          [],
+        )
+      }
+    }
+    [lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      case split_on_top_commas(inside) {
+        [single] -> #(parse_expr(single), after)
+        many -> #(query_ir.Tuple(elements: list.map(many, parse_expr)), after)
+      }
+    }
+    [lexer.Keyword("interval"), lexer.StringLit(val), ..rest] -> #(
+      query_ir.Func(
+        name: "interval",
+        args: [query_ir.FuncArg(expr: query_ir.StringLit(value: val))],
+        distinct: False,
+        filter: None,
+        over: None,
+      ),
+      rest,
+    )
+    [lexer.Ident(s), lexer.Dot, lexer.Ident(name), lexer.LParen, ..rest] ->
+      case string.lowercase(s) {
+        "sqlode" -> {
+          let #(inside, after) = collect_parens(rest)
+          #(query_ir.Macro(name: string.lowercase(name), body: inside), after)
+        }
+        _ -> parse_function_call(name, [lexer.LParen, ..rest])
+      }
+    [lexer.Ident(name), lexer.LParen, ..rest] -> parse_function_call(name, rest)
+    [lexer.Ident(table), lexer.Dot, lexer.Star, ..rest] -> #(
+      query_ir.StarRef(table: Some(string.lowercase(table))),
+      rest,
+    )
+    [lexer.Ident(table), lexer.Dot, lexer.Operator("*"), ..rest] -> #(
+      query_ir.StarRef(table: Some(string.lowercase(table))),
+      rest,
+    )
+    [lexer.Ident(table), lexer.Dot, lexer.Ident(col), ..rest] -> #(
+      query_ir.ColumnRef(
+        table: Some(string.lowercase(table)),
+        name: string.lowercase(col),
+      ),
+      rest,
+    )
+    [lexer.Ident(table), lexer.Dot, lexer.QuotedIdent(col), ..rest] -> #(
+      query_ir.ColumnRef(
+        table: Some(string.lowercase(table)),
+        name: string.lowercase(col),
+      ),
+      rest,
+    )
+    [lexer.Ident(name), ..rest] -> #(
+      query_ir.ColumnRef(table: None, name: string.lowercase(name)),
+      rest,
+    )
+    [lexer.QuotedIdent(name), ..rest] -> #(
+      query_ir.ColumnRef(table: None, name: string.lowercase(name)),
+      rest,
+    )
+    [lexer.Star, ..rest] -> #(query_ir.StarRef(table: None), rest)
+    [lexer.Operator("*"), ..rest] -> #(query_ir.StarRef(table: None), rest)
+    _ -> #(query_ir.RawExpr(reason: "unrecognised atom", tokens: tokens), [])
+  }
+}
+
+fn parse_function_call(
+  name: String,
+  tokens: List(lexer.Token),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(inside, after) = collect_parens(tokens)
+  let #(distinct, args_tokens) = case inside {
+    [lexer.Keyword("distinct"), ..rest] -> #(True, rest)
+    _ -> #(False, inside)
+  }
+  let args = case args_tokens {
+    [] -> []
+    _ ->
+      args_tokens
+      |> split_on_top_commas()
+      |> list.map(fn(group) { query_ir.FuncArg(expr: parse_expr(group)) })
+  }
+  let #(filter, after_filter) = parse_filter_clause(after)
+  let #(over, after_over) = parse_over_clause(after_filter)
+  #(
+    query_ir.Func(
+      name: string.lowercase(name),
+      args: args,
+      distinct: distinct,
+      filter: filter,
+      over: over,
+    ),
+    after_over,
+  )
+}
+
+fn parse_filter_clause(
+  tokens: List(lexer.Token),
+) -> #(Option(query_ir.Expr), List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("filter"), lexer.LParen, lexer.Keyword("where"), ..rest] -> {
+      let #(inside, after) = collect_parens_after_where(rest)
+      #(Some(parse_expr(inside)), after)
+    }
+    _ -> #(None, tokens)
+  }
+}
+
+fn collect_parens_after_where(
+  tokens: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  // `rest` is already past `LParen` `where`, so depth is 1 and current
+  // contents are the WHERE predicate tokens until the matching RParen.
+  collect_parens(tokens)
+}
+
+fn parse_over_clause(
+  tokens: List(lexer.Token),
+) -> #(Option(query_ir.WindowSpec), List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("over"), lexer.LParen, ..rest] -> {
+      let #(inside, after) = collect_parens(rest)
+      #(Some(parse_window_spec(inside)), after)
+    }
+    [lexer.Keyword("over"), lexer.Ident(_), ..rest] -> {
+      // Named window reference — treat as empty spec; the named
+      // window definition is not followed into right now.
+      #(
+        Some(query_ir.WindowSpec(partition_by: [], order_by: [], frame: None)),
+        rest,
+      )
+    }
+    _ -> #(None, tokens)
+  }
+}
+
+fn parse_window_spec(tokens: List(lexer.Token)) -> query_ir.WindowSpec {
+  let #(_name_skipped, rest) = case tokens {
+    [lexer.Ident(_), ..rest] -> #(True, rest)
+    _ -> #(False, tokens)
+  }
+  let #(partition_by, rest2) = case rest {
+    [lexer.Keyword("partition"), lexer.Keyword("by"), ..more] -> {
+      let #(p_toks, after) =
+        collect_until_keyword(more, ["order", "range", "rows", "groups"])
+      #(parse_expr_list(p_toks), after)
+    }
+    _ -> #([], rest)
+  }
+  let #(order_by, rest3) = case rest2 {
+    [lexer.Keyword("order"), lexer.Keyword("by"), ..more] -> {
+      let #(o_toks, after) =
+        collect_until_keyword(more, ["range", "rows", "groups"])
+      #(parse_order_keys(o_toks), after)
+    }
+    _ -> #([], rest2)
+  }
+  let frame = case rest3 {
+    [] -> None
+    other -> Some(other)
+  }
+  query_ir.WindowSpec(
+    partition_by: partition_by,
+    order_by: order_by,
+    frame: frame,
+  )
+}
+
+fn parse_case(tokens: List(lexer.Token)) -> #(query_ir.Expr, List(lexer.Token)) {
+  let #(scrutinee, rest) = case tokens {
+    [lexer.Keyword("when"), ..] -> #(None, tokens)
+    _ -> {
+      let #(scr_toks, after) =
+        collect_until_keyword(tokens, ["when", "else", "end"])
+      case scr_toks {
+        [] -> #(None, after)
+        _ -> #(Some(parse_expr(scr_toks)), after)
+      }
+    }
+  }
+  collect_case_branches(rest, scrutinee, [])
+}
+
+fn collect_case_branches(
+  tokens: List(lexer.Token),
+  scrutinee: Option(query_ir.Expr),
+  branches: List(query_ir.CaseBranch),
+) -> #(query_ir.Expr, List(lexer.Token)) {
+  case tokens {
+    [lexer.Keyword("when"), ..rest] -> {
+      let #(when_toks, after_when) = collect_until_keyword(rest, ["then"])
+      let after_then = case after_when {
+        [lexer.Keyword("then"), ..more] -> more
+        _ -> after_when
+      }
+      let #(then_toks, after_then_block) =
+        collect_until_keyword(after_then, ["when", "else", "end"])
+      let branch =
+        query_ir.CaseBranch(
+          when_: parse_expr(when_toks),
+          then: parse_expr(then_toks),
+        )
+      collect_case_branches(after_then_block, scrutinee, [branch, ..branches])
+    }
+    [lexer.Keyword("else"), ..rest] -> {
+      let #(else_toks, after_else) = collect_until_keyword(rest, ["end"])
+      let after_end = case after_else {
+        [lexer.Keyword("end"), ..more] -> more
+        _ -> after_else
+      }
+      #(
+        query_ir.Case(
+          scrutinee: scrutinee,
+          branches: list.reverse(branches),
+          else_: Some(parse_expr(else_toks)),
+        ),
+        after_end,
+      )
+    }
+    [lexer.Keyword("end"), ..rest] -> #(
+      query_ir.Case(
+        scrutinee: scrutinee,
+        branches: list.reverse(branches),
+        else_: None,
+      ),
+      rest,
+    )
+    _ -> #(
+      query_ir.Case(
+        scrutinee: scrutinee,
+        branches: list.reverse(branches),
+        else_: None,
+      ),
+      tokens,
+    )
+  }
+}
+
+// ============================================================
+// Token helpers
+// ============================================================
+
+fn split_on_top_commas(tokens: List(lexer.Token)) -> List(List(lexer.Token)) {
+  split_commas_loop(tokens, 0, [], [])
+}
+
+fn split_commas_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  current: List(lexer.Token),
+  acc: List(List(lexer.Token)),
+) -> List(List(lexer.Token)) {
+  case tokens {
+    [] ->
+      case current {
+        [] -> list.reverse(acc)
+        _ -> list.reverse([list.reverse(current), ..acc])
+      }
+    [lexer.Comma, ..rest] if depth == 0 ->
+      case current {
+        [] -> split_commas_loop(rest, 0, [], acc)
+        _ -> split_commas_loop(rest, 0, [], [list.reverse(current), ..acc])
+      }
+    [lexer.LParen, ..rest] ->
+      split_commas_loop(rest, depth + 1, [lexer.LParen, ..current], acc)
+    [lexer.RParen, ..rest] ->
+      split_commas_loop(rest, depth - 1, [lexer.RParen, ..current], acc)
+    [t, ..rest] -> split_commas_loop(rest, depth, [t, ..current], acc)
+  }
+}
+
+fn collect_parens(
+  tokens: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  collect_paren_loop(tokens, 1, [])
+}
+
+fn collect_paren_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  acc: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  case depth <= 0 {
+    True -> #(list.reverse(acc), tokens)
+    False ->
+      case tokens {
+        [] -> #(list.reverse(acc), [])
+        [lexer.LParen, ..rest] ->
+          collect_paren_loop(rest, depth + 1, [lexer.LParen, ..acc])
+        [lexer.RParen, ..rest] ->
+          case depth == 1 {
+            True -> #(list.reverse(acc), rest)
+            False -> collect_paren_loop(rest, depth - 1, [lexer.RParen, ..acc])
+          }
+        [t, ..rest] -> collect_paren_loop(rest, depth, [t, ..acc])
+      }
+  }
+}
+
+fn collect_brackets(
+  tokens: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  collect_bracket_loop(tokens, 1, [])
+}
+
+fn collect_bracket_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  acc: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  case depth <= 0 {
+    True -> #(list.reverse(acc), tokens)
+    False ->
+      case tokens {
+        [] -> #(list.reverse(acc), [])
+        [lexer.Operator("["), ..rest] ->
+          collect_bracket_loop(rest, depth + 1, [lexer.Operator("["), ..acc])
+        [lexer.Operator("]"), ..rest] ->
+          case depth == 1 {
+            True -> #(list.reverse(acc), rest)
+            False ->
+              collect_bracket_loop(rest, depth - 1, [lexer.Operator("]"), ..acc])
+          }
+        [t, ..rest] -> collect_bracket_loop(rest, depth, [t, ..acc])
+      }
+  }
+}
+
+fn collect_until_keyword(
+  tokens: List(lexer.Token),
+  stop: List(String),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  collect_until_loop(tokens, stop, 0, [])
+}
+
+fn collect_until_loop(
+  tokens: List(lexer.Token),
+  stop: List(String),
+  depth: Int,
+  acc: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  case tokens {
+    [] -> #(list.reverse(acc), [])
+    [lexer.LParen, ..rest] ->
+      collect_until_loop(rest, stop, depth + 1, [lexer.LParen, ..acc])
+    [lexer.RParen, ..rest] ->
+      collect_until_loop(rest, stop, depth - 1, [lexer.RParen, ..acc])
+    [lexer.Keyword(kw), ..rest] as t if depth == 0 -> {
+      case list.contains(stop, kw) {
+        True -> #(list.reverse(acc), t)
+        False ->
+          collect_until_loop(rest, stop, depth, [lexer.Keyword(kw), ..acc])
+      }
+    }
+    [t, ..rest] -> collect_until_loop(rest, stop, depth, [t, ..acc])
+  }
+}
+
+fn read_qualified_name(
+  tokens: List(lexer.Token),
+) -> #(String, List(lexer.Token)) {
+  case tokens {
+    [lexer.Ident(_), lexer.Dot, lexer.Ident(name), ..rest] -> #(
+      string.lowercase(name),
+      rest,
+    )
+    [lexer.Ident(name), ..rest] -> #(string.lowercase(name), rest)
+    [lexer.QuotedIdent(name), ..rest] -> #(string.lowercase(name), rest)
+    _ -> #("", tokens)
+  }
+}
+
+fn drop_first(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [_, ..rest] -> rest
+    [] -> []
+  }
+}
+
+fn empty_core() -> query_ir.SelectCore {
+  query_ir.SelectCore(
+    distinct: False,
+    select_items: [],
+    from: [],
+    where_: None,
+    group_by: [],
+    having: None,
+    order_by: [],
+    limit: None,
+    offset: None,
+    set_op: None,
+  )
+}
+
+fn trim_noise(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  list.filter(tokens, fn(t) {
+    case t {
+      lexer.Semicolon -> False
+      _ -> True
+    }
+  })
+}
+
+fn split_on_as(
+  tokens: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  split_on_as_loop(tokens, 0, [])
+}
+
+fn split_on_as_loop(
+  tokens: List(lexer.Token),
+  depth: Int,
+  acc: List(lexer.Token),
+) -> #(List(lexer.Token), List(lexer.Token)) {
+  case tokens {
+    [] -> #(list.reverse(acc), [])
+    [lexer.LParen, ..rest] ->
+      split_on_as_loop(rest, depth + 1, [lexer.LParen, ..acc])
+    [lexer.RParen, ..rest] ->
+      split_on_as_loop(rest, depth - 1, [lexer.RParen, ..acc])
+    [lexer.Keyword("as"), ..rest] if depth == 0 -> #(list.reverse(acc), rest)
+    [t, ..rest] -> split_on_as_loop(rest, depth, [t, ..acc])
+  }
+}
+
+fn decode_placeholder(raw: String) -> Int {
+  // Accept $N, ?N, :N, @N; when missing, default to 0 so the analyzer
+  // can surface ParameterTypeNotInferred on it.
+  let digits = case string.to_graphemes(raw) {
+    [] -> ""
+    [_first, ..rest] -> string.concat(rest)
+  }
+  case int.parse(digits) {
+    Ok(n) -> n
+    Error(_) -> 0
+  }
+}

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -207,7 +207,11 @@ pub fn infer_in_params(
   case all_tables {
     [] -> []
     [primary, ..] -> {
-      let matches = token_utils.find_in_patterns(tokens)
+      let matches =
+        list.append(
+          token_utils.find_in_patterns(tokens),
+          token_utils.find_quantified_patterns(tokens),
+        )
       scan_token_matches(
         engine,
         catalog,

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -441,6 +441,69 @@ pub fn find_in_patterns(tokens: List(lexer.Token)) -> List(EqualityMatch) {
   |> list.reverse
 }
 
+/// Find all `column op ANY|ALL|SOME (placeholder)` patterns. This
+/// complements `find_in_patterns` for the PostgreSQL-style quantified
+/// comparison syntax `t.id = ANY(sqlode.slice(team_ids))` used by
+/// fixture 2 in Issue #393.
+pub fn find_quantified_patterns(
+  tokens: List(lexer.Token),
+) -> List(EqualityMatch) {
+  find_quantified_loop(tokens, [])
+  |> list.reverse
+}
+
+fn find_quantified_loop(
+  tokens: List(lexer.Token),
+  acc: List(EqualityMatch),
+) -> List(EqualityMatch) {
+  case tokens {
+    [] -> acc
+    // table.col <op> ANY|ALL|SOME ( placeholder )
+    [
+      lexer.Ident(t),
+      lexer.Dot,
+      lexer.Ident(c),
+      lexer.Operator(_op),
+      lexer.Keyword(q),
+      lexer.LParen,
+      lexer.Placeholder(p),
+      lexer.RParen,
+      ..rest
+    ]
+      if q == "any" || q == "all" || q == "some"
+    ->
+      find_quantified_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: Some(string.lowercase(t)),
+          placeholder: p,
+        ),
+        ..acc
+      ])
+    // col <op> ANY|ALL|SOME ( placeholder )
+    [
+      lexer.Ident(c),
+      lexer.Operator(_op),
+      lexer.Keyword(q),
+      lexer.LParen,
+      lexer.Placeholder(p),
+      lexer.RParen,
+      ..rest
+    ]
+      if q == "any" || q == "all" || q == "some"
+    ->
+      find_quantified_loop(rest, [
+        EqualityMatch(
+          column_name: naming.normalize_identifier(c),
+          table_qualifier: None,
+          placeholder: p,
+        ),
+        ..acc
+      ])
+    [_, ..rest] -> find_quantified_loop(rest, acc)
+  }
+}
+
 fn find_in_loop(
   tokens: List(lexer.Token),
   acc: List(EqualityMatch),

--- a/src/sqlode/query_analyzer/type_inference.gleam
+++ b/src/sqlode/query_analyzer/type_inference.gleam
@@ -1,0 +1,664 @@
+//// IR-driven type inference.
+////
+//// `infer_expr_type` walks a `query_ir.Expr` and returns the inferred
+//// `#(ScalarType, nullable)` pair, resolving column references against
+//// the supplied catalog and table scope. It replaces the previous
+//// heuristic path that operated on raw `List(lexer.Token)`.
+////
+//// When the IR contains a `RawExpr` node — or an inner construct that
+//// inference can't make sense of — the function returns an
+//// `UnsupportedExpression` error tied to the raw token fragment so
+//// the operator gets an explicit diagnostic pointing at the IR gap,
+//// never a silent fallback to `StringType`.
+
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+import sqlode/lexer
+import sqlode/model
+import sqlode/query_analyzer/context.{type AnalysisError, UnsupportedExpression}
+import sqlode/query_ir
+
+/// Inferred type and nullability for an expression.
+pub type InferredType {
+  InferredType(scalar: model.ScalarType, nullable: Bool)
+}
+
+/// Scope used to resolve `ColumnRef` during expression inference.
+///
+/// - `catalog` is the augmented catalog (base tables + CTEs + VALUES
+///   + derived tables).
+/// - `in_scope_tables` is the ordered list of FROM/JOIN table names
+///   (or aliases) visible at this expression's nesting level.
+/// - `nullable_tables` is the list of table names whose columns become
+///   nullable because of an outer LEFT/RIGHT/FULL join.
+pub type Scope {
+  Scope(
+    query_name: String,
+    catalog: model.Catalog,
+    in_scope_tables: List(String),
+    nullable_tables: List(String),
+  )
+}
+
+pub fn scope(
+  query_name: String,
+  catalog: model.Catalog,
+  in_scope_tables: List(String),
+  nullable_tables: List(String),
+) -> Scope {
+  Scope(
+    query_name: query_name,
+    catalog: catalog,
+    in_scope_tables: in_scope_tables,
+    nullable_tables: nullable_tables,
+  )
+}
+
+pub fn infer_expr_type(
+  scope: Scope,
+  expr: query_ir.Expr,
+) -> Result(InferredType, AnalysisError) {
+  case expr {
+    query_ir.NullLit ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "NULL",
+      ))
+    query_ir.BoolLit(..) -> ok(model.BoolType, False)
+    query_ir.StringLit(..) -> ok(model.StringType, False)
+    query_ir.NumberLit(value: n) -> ok(number_type(n), False)
+    query_ir.Param(..) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "parameter placeholder in result context requires a cast",
+      ))
+    query_ir.ColumnRef(table: table, name: name) ->
+      resolve_column(scope, table, name)
+    query_ir.StarRef(..) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "* in expression context",
+      ))
+    query_ir.Unary(op: op, arg: arg) -> infer_unary(scope, op, arg)
+    query_ir.Binary(op: op, left: left, right: right) ->
+      infer_binary(scope, op, left, right)
+    query_ir.Func(..) as f -> infer_function(scope, f)
+    query_ir.Cast(target_type: target, expr: inner) ->
+      infer_cast(scope, target, inner)
+    query_ir.Case(scrutinee: _, branches: branches, else_: else_) ->
+      infer_case(scope, branches, else_)
+    query_ir.InExpr(..) -> ok(model.BoolType, False)
+    query_ir.Exists(..) -> ok(model.BoolType, False)
+    query_ir.ScalarSubquery(core: core) -> infer_scalar_subquery(scope, core)
+    query_ir.Quantified(..) -> ok(model.BoolType, False)
+    query_ir.Between(..) -> ok(model.BoolType, False)
+    query_ir.IsCheck(..) -> ok(model.BoolType, False)
+    query_ir.LikeExpr(..) -> ok(model.BoolType, False)
+    query_ir.ArrayLit(elements: elems) ->
+      case elems {
+        [] ->
+          Error(UnsupportedExpression(
+            query_name: scope.query_name,
+            expression: "empty ARRAY[] literal",
+          ))
+        [first, ..] ->
+          case infer_expr_type(scope, first) {
+            Ok(InferredType(scalar: t, nullable: _)) ->
+              ok(model.ArrayType(element: t), False)
+            Error(e) -> Error(e)
+          }
+      }
+    query_ir.Tuple(elements: [single]) -> infer_expr_type(scope, single)
+    query_ir.Tuple(..) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "tuple expression",
+      ))
+    query_ir.Macro(name: name, ..) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "sqlode." <> name <> "(…) in this position",
+      ))
+    query_ir.RawExpr(reason: reason, tokens: tokens) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: reason <> ": " <> render_tokens(tokens),
+      ))
+  }
+}
+
+fn ok(
+  scalar: model.ScalarType,
+  nullable: Bool,
+) -> Result(InferredType, AnalysisError) {
+  Ok(InferredType(scalar: scalar, nullable: nullable))
+}
+
+fn number_type(n: String) -> model.ScalarType {
+  case
+    string.contains(n, ".")
+    || string.contains(n, "e")
+    || string.contains(n, "E")
+  {
+    True -> model.FloatType
+    False -> model.IntType
+  }
+}
+
+// ============================================================
+// Column resolution
+// ============================================================
+
+fn resolve_column(
+  scope: Scope,
+  table: Option(String),
+  name: String,
+) -> Result(InferredType, AnalysisError) {
+  case table {
+    Some(t) ->
+      case context.find_column(scope.catalog, t, name) {
+        Some(col) ->
+          ok(
+            col.scalar_type,
+            col.nullable || list.contains(scope.nullable_tables, t),
+          )
+        None ->
+          Error(context.ColumnNotFound(
+            query_name: scope.query_name,
+            table_name: t,
+            column_name: name,
+          ))
+      }
+    None ->
+      case
+        context.find_column_in_tables(
+          scope.catalog,
+          scope.in_scope_tables,
+          name,
+        )
+      {
+        Ok(Some(#(found_table, col))) ->
+          ok(
+            col.scalar_type,
+            col.nullable || list.contains(scope.nullable_tables, found_table),
+          )
+        Ok(None) ->
+          Error(UnsupportedExpression(
+            query_name: scope.query_name,
+            expression: "unresolved column reference \"" <> name <> "\"",
+          ))
+        Error(matching) ->
+          Error(context.AmbiguousColumnName(
+            query_name: scope.query_name,
+            column_name: name,
+            matching_tables: matching,
+          ))
+      }
+  }
+}
+
+// ============================================================
+// Unary / binary
+// ============================================================
+
+fn infer_unary(
+  scope: Scope,
+  op: String,
+  arg: query_ir.Expr,
+) -> Result(InferredType, AnalysisError) {
+  case op {
+    "not" -> ok(model.BoolType, False)
+    "-" | "+" -> infer_expr_type(scope, arg)
+    _ ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "unary operator " <> op,
+      ))
+  }
+}
+
+fn infer_binary(
+  scope: Scope,
+  op: String,
+  left: query_ir.Expr,
+  right: query_ir.Expr,
+) -> Result(InferredType, AnalysisError) {
+  case op {
+    "and" | "or" -> ok(model.BoolType, False)
+    "="
+    | "<>"
+    | "!="
+    | "<"
+    | ">"
+    | "<="
+    | ">="
+    | "@>"
+    | "<@"
+    | "?|"
+    | "?&"
+    | "&&" -> ok(model.BoolType, False)
+    "||" -> {
+      // String concatenation. Treat as non-nullable for compatibility
+      // with the existing analyzer behaviour — `||` short-circuits at
+      // the emitter level to empty strings in the runtime.
+      use _ <- result.try(infer_expr_type_allow_null(scope, left))
+      use _ <- result.try(infer_expr_type_allow_null(scope, right))
+      ok(model.StringType, False)
+    }
+    "+" | "-" | "*" | "/" | "%" -> {
+      use lt <- result.try(infer_expr_type_allow_null(scope, left))
+      use rt <- result.try(infer_expr_type_allow_null(scope, right))
+      case merge_numeric(lt.scalar, rt.scalar) {
+        Ok(scalar) -> ok(scalar, lt.nullable || rt.nullable)
+        Error(_) ->
+          Error(UnsupportedExpression(
+            query_name: scope.query_name,
+            expression: "arithmetic operands have incompatible types",
+          ))
+      }
+    }
+    "->" | "#>" -> ok(model.JsonType, True)
+    "->>" | "#>>" -> ok(model.StringType, True)
+    _ ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "binary operator " <> op,
+      ))
+  }
+}
+
+fn infer_expr_type_allow_null(
+  scope: Scope,
+  expr: query_ir.Expr,
+) -> Result(InferredType, AnalysisError) {
+  case expr {
+    query_ir.NullLit -> ok_unknown_nullable()
+    query_ir.Param(..) -> ok_unknown()
+    query_ir.Cast(target_type: t, ..) ->
+      case model.parse_sql_type(t) {
+        Ok(scalar) -> ok(scalar, True)
+        Error(_) ->
+          Error(UnsupportedExpression(
+            query_name: scope.query_name,
+            expression: "unrecognised cast type \"" <> t <> "\"",
+          ))
+      }
+    _ -> infer_expr_type(scope, expr)
+  }
+}
+
+fn ok_unknown() -> Result(InferredType, AnalysisError) {
+  Ok(InferredType(scalar: model.IntType, nullable: False))
+}
+
+fn ok_unknown_nullable() -> Result(InferredType, AnalysisError) {
+  Ok(InferredType(scalar: model.IntType, nullable: True))
+}
+
+fn merge_numeric(
+  a: model.ScalarType,
+  b: model.ScalarType,
+) -> Result(model.ScalarType, Nil) {
+  case a, b {
+    model.IntType, model.IntType -> Ok(model.IntType)
+    model.FloatType, model.FloatType -> Ok(model.FloatType)
+    model.IntType, model.FloatType -> Ok(model.FloatType)
+    model.FloatType, model.IntType -> Ok(model.FloatType)
+    x, y ->
+      case x == y {
+        True -> Ok(x)
+        False -> Error(Nil)
+      }
+  }
+}
+
+// ============================================================
+// CAST / CASE
+// ============================================================
+
+fn infer_cast(
+  scope: Scope,
+  target: String,
+  _inner: query_ir.Expr,
+) -> Result(InferredType, AnalysisError) {
+  case model.parse_sql_type(target) {
+    Ok(scalar) -> ok(scalar, True)
+    Error(_) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "unrecognised cast type \"" <> target <> "\"",
+      ))
+  }
+}
+
+fn infer_case(
+  scope: Scope,
+  branches: List(query_ir.CaseBranch),
+  else_: Option(query_ir.Expr),
+) -> Result(InferredType, AnalysisError) {
+  let branch_thens = list.map(branches, fn(b) { b.then })
+  let arms = case else_ {
+    Some(e) -> list.append(branch_thens, [e])
+    None -> branch_thens
+  }
+  use types <- result.try(
+    list.try_map(arms, fn(arm) { infer_expr_type_allow_null(scope, arm) }),
+  )
+  case unify_types(types) {
+    Ok(#(scalar, inner_nullable)) -> {
+      let nullable = case else_ {
+        Some(_) -> inner_nullable
+        None -> True
+      }
+      ok(scalar, nullable)
+    }
+    Error(_) ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "CASE branches have incompatible types",
+      ))
+  }
+}
+
+fn unify_types(
+  items: List(InferredType),
+) -> Result(#(model.ScalarType, Bool), Nil) {
+  case items {
+    [] -> Error(Nil)
+    [InferredType(scalar: t, nullable: n), ..rest] -> unify_fold(rest, t, n)
+  }
+}
+
+fn unify_fold(
+  items: List(InferredType),
+  acc_type: model.ScalarType,
+  acc_nullable: Bool,
+) -> Result(#(model.ScalarType, Bool), Nil) {
+  case items {
+    [] -> Ok(#(acc_type, acc_nullable))
+    [InferredType(scalar: t, nullable: n), ..rest] -> {
+      case merge_numeric(acc_type, t) {
+        Ok(merged) -> unify_fold(rest, merged, acc_nullable || n)
+        Error(_) ->
+          case acc_type == t {
+            True -> unify_fold(rest, acc_type, acc_nullable || n)
+            False -> Error(Nil)
+          }
+      }
+    }
+  }
+}
+
+// ============================================================
+// Functions
+// ============================================================
+
+fn infer_function(
+  scope: Scope,
+  f: query_ir.Expr,
+) -> Result(InferredType, AnalysisError) {
+  case f {
+    query_ir.Func(name: name, args: args, over: over, ..) -> {
+      let window = case over {
+        Some(_) -> True
+        None -> False
+      }
+      infer_function_body(scope, name, args, window)
+    }
+    _ ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "internal: infer_function called with non-Func",
+      ))
+  }
+}
+
+fn infer_function_body(
+  scope: Scope,
+  name: String,
+  args: List(query_ir.FuncArg),
+  window: Bool,
+) -> Result(InferredType, AnalysisError) {
+  case name {
+    "count" -> ok(model.IntType, False)
+    "sum" | "min" | "max" -> infer_aggregate_from_first(scope, args, True)
+    "avg" -> ok(model.FloatType, True)
+    "row_number" | "rank" | "dense_rank" | "ntile" -> ok(model.IntType, False)
+    "percent_rank" | "cume_dist" -> ok(model.FloatType, False)
+    "lag" | "lead" | "first_value" | "last_value" | "nth_value" ->
+      infer_window_first(scope, args)
+    "coalesce" -> infer_coalesce(scope, args)
+    "greatest" | "least" -> infer_aggregate_from_first(scope, args, True)
+    "nullif" | "ifnull" | "nvl" -> infer_first_arg(scope, args, True)
+    "abs"
+    | "round"
+    | "floor"
+    | "ceil"
+    | "ceiling"
+    | "mod"
+    | "power"
+    | "sqrt"
+    | "sign"
+    | "trunc"
+    | "log"
+    | "ln"
+    | "exp"
+    | "random"
+    | "pi"
+    | "degrees"
+    | "radians"
+    | "div" -> infer_math_first_arg(scope, args)
+    "length"
+    | "char_length"
+    | "character_length"
+    | "octet_length"
+    | "bit_length"
+    | "position"
+    | "strpos"
+    | "ascii" -> ok(model.IntType, False)
+    "replace"
+    | "lower"
+    | "upper"
+    | "trim"
+    | "ltrim"
+    | "rtrim"
+    | "substr"
+    | "substring"
+    | "concat"
+    | "reverse"
+    | "lpad"
+    | "rpad"
+    | "left"
+    | "right"
+    | "repeat"
+    | "initcap"
+    | "translate"
+    | "to_char"
+    | "format"
+    | "quote_literal"
+    | "quote_ident"
+    | "md5"
+    | "encode"
+    | "decode" -> ok(model.StringType, False)
+    "now"
+    | "current_timestamp"
+    | "clock_timestamp"
+    | "statement_timestamp"
+    | "timeofday"
+    | "localtimestamp" -> ok(model.DateTimeType, False)
+    "current_date" -> ok(model.DateType, False)
+    "current_time" | "localtime" -> ok(model.TimeType, False)
+    "make_date" | "to_date" -> ok(model.DateType, False)
+    "make_time" -> ok(model.TimeType, False)
+    "make_timestamp" | "to_timestamp" -> ok(model.DateTimeType, False)
+    "date_trunc" | "age" -> ok(model.DateTimeType, False)
+    "date_part" | "extract" -> ok(model.FloatType, False)
+    "date" -> ok(model.DateType, False)
+    "time" -> ok(model.TimeType, False)
+    "timestamp" -> ok(model.DateTimeType, False)
+    "interval" -> ok(model.TimeType, False)
+    _ ->
+      case window {
+        True -> ok(model.IntType, False)
+        False ->
+          Error(UnsupportedExpression(
+            query_name: scope.query_name,
+            expression: "unknown function " <> name,
+          ))
+      }
+  }
+}
+
+fn infer_first_arg(
+  scope: Scope,
+  args: List(query_ir.FuncArg),
+  nullable: Bool,
+) -> Result(InferredType, AnalysisError) {
+  case args {
+    [query_ir.FuncArg(expr: first), ..] ->
+      case infer_expr_type_allow_null(scope, first) {
+        Ok(it) -> ok(it.scalar, nullable || it.nullable)
+        Error(e) -> Error(e)
+      }
+    [] ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "function call with no arguments",
+      ))
+  }
+}
+
+fn infer_math_first_arg(
+  scope: Scope,
+  args: List(query_ir.FuncArg),
+) -> Result(InferredType, AnalysisError) {
+  case args {
+    [] -> ok(model.FloatType, False)
+    [query_ir.FuncArg(expr: first), ..] ->
+      case infer_expr_type_allow_null(scope, first) {
+        Ok(it) -> ok(it.scalar, it.nullable)
+        Error(_) -> ok(model.FloatType, False)
+      }
+  }
+}
+
+fn infer_window_first(
+  scope: Scope,
+  args: List(query_ir.FuncArg),
+) -> Result(InferredType, AnalysisError) {
+  case args {
+    [query_ir.FuncArg(expr: first), ..] ->
+      case infer_expr_type_allow_null(scope, first) {
+        Ok(it) -> ok(it.scalar, True)
+        Error(e) -> Error(e)
+      }
+    [] ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "window function with no arguments",
+      ))
+  }
+}
+
+fn infer_aggregate_from_first(
+  scope: Scope,
+  args: List(query_ir.FuncArg),
+  nullable: Bool,
+) -> Result(InferredType, AnalysisError) {
+  infer_first_arg(scope, args, nullable)
+}
+
+fn infer_coalesce(
+  scope: Scope,
+  args: List(query_ir.FuncArg),
+) -> Result(InferredType, AnalysisError) {
+  case args {
+    [] ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "COALESCE requires at least one argument",
+      ))
+    _ -> {
+      use types <- result.try(
+        list.try_map(args, fn(a) {
+          let query_ir.FuncArg(expr: e) = a
+          infer_expr_type_allow_null(scope, e)
+        }),
+      )
+      case unify_types(types) {
+        Ok(#(scalar, _)) -> {
+          // COALESCE is non-nullable when any argument is non-nullable.
+          let any_non_null =
+            list.any(types, fn(t) {
+              let InferredType(nullable: n, ..) = t
+              !n
+            })
+          ok(scalar, !any_non_null)
+        }
+        Error(_) ->
+          Error(UnsupportedExpression(
+            query_name: scope.query_name,
+            expression: "COALESCE arguments have incompatible types",
+          ))
+      }
+    }
+  }
+}
+
+// ============================================================
+// Scalar subqueries
+// ============================================================
+
+fn infer_scalar_subquery(
+  scope: Scope,
+  core: query_ir.SelectCore,
+) -> Result(InferredType, AnalysisError) {
+  case core.select_items {
+    [query_ir.ExprItem(expr: expr, ..), ..] ->
+      case infer_expr_type(scope, expr) {
+        Ok(InferredType(scalar: t, nullable: _)) -> ok(t, True)
+        Error(e) -> Error(e)
+      }
+    [query_ir.StarEx(..), ..] ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "scalar subquery returning *",
+      ))
+    [] ->
+      Error(UnsupportedExpression(
+        query_name: scope.query_name,
+        expression: "scalar subquery has no select items",
+      ))
+  }
+}
+
+// ============================================================
+// Rendering for diagnostics
+// ============================================================
+
+fn render_tokens(tokens: List(lexer.Token)) -> String {
+  tokens
+  |> list.map(render_token)
+  |> list.filter(fn(s) { s != "" })
+  |> string.join(" ")
+}
+
+fn render_token(token: lexer.Token) -> String {
+  case token {
+    lexer.Keyword(k) -> k
+    lexer.Ident(n) -> n
+    lexer.QuotedIdent(n) -> "\"" <> n <> "\""
+    lexer.StringLit(s) -> "'" <> s <> "'"
+    lexer.NumberLit(n) -> n
+    lexer.Placeholder(p) -> p
+    lexer.Operator(o) -> o
+    lexer.LParen -> "("
+    lexer.RParen -> ")"
+    lexer.Comma -> ","
+    lexer.Semicolon -> ";"
+    lexer.Dot -> "."
+    lexer.Star -> "*"
+  }
+}

--- a/src/sqlode/query_ir.gleam
+++ b/src/sqlode/query_ir.gleam
@@ -1,12 +1,22 @@
 //// Intermediate representation shared between the query parser and the
-//// query analyzer. `TokenizedQuery` carries the expanded token list
-//// alongside the `ParsedQuery` metadata so analyzer layers can walk
-//// tokens without re-tokenizing the SQL string on every pass.
+//// query analyzer.
 ////
-//// `StructuredQuery` adds a thin structural layer that identifies the
-//// statement kind and its major clauses (tables, SELECT items, WHERE
-//// predicates, etc.) so inference passes can consume pre-parsed
-//// structure instead of re-scanning the raw token list.
+//// This module defines two layers:
+////
+//// - The legacy **structured IR** (`SqlStatement`, `SelectItem`,
+////   `FromItem`, `JoinClause`) that identifies top-level clauses but
+////   stores complex sub-expressions as raw `List(lexer.Token)`.
+//// - The **expression-aware IR** (`Stmt`, `Expr`, `CteDef`, …) that
+////   explicitly models the SQL subset sqlode actually needs: CTEs
+////   (including nested references), select items, table refs / aliases
+////   / derived tables / lateral subqueries, predicate expressions,
+////   arithmetic and `CASE`, function calls and casts, `IN`, `EXISTS`,
+////   `ANY`, `ALL`, `GROUP BY`, `HAVING`, window expressions, and
+////   `RETURNING`.
+////
+//// The expression-aware IR is intended to become the single semantic
+//// input for type inference; `RawExpr` / `UnstructuredStmt` remain only
+//// as explicit diagnostic hooks for concrete IR gaps.
 
 import gleam/option.{type Option}
 import sqlode/lexer
@@ -17,7 +27,7 @@ pub type TokenizedQuery {
 }
 
 // ============================================================
-// Structured IR — statement-level decomposition
+// Legacy structured IR — statement-level decomposition
 // ============================================================
 
 /// Top-level statement structure extracted from the token list.
@@ -85,4 +95,266 @@ pub type StructuredQuery {
     tokens: List(lexer.Token),
     statement: SqlStatement,
   )
+}
+
+// ============================================================
+// Expression-aware IR — the rich semantic representation
+// ============================================================
+
+/// Top-level statement shape in the expression-aware IR.
+///
+/// Every variant carries its own list of CTE definitions so an
+/// `INSERT`/`UPDATE`/`DELETE` prefixed with `WITH` (fixture 4) is
+/// modelled end-to-end instead of being stripped at a boundary.
+pub type Stmt {
+  SelectStmt(ctes: List(CteDef), core: SelectCore)
+  InsertStmt(
+    ctes: List(CteDef),
+    table: String,
+    columns: List(String),
+    source: InsertSource,
+    returning: List(SelectItemEx),
+  )
+  UpdateStmt(
+    ctes: List(CteDef),
+    table: String,
+    alias: Option(String),
+    assignments: List(Assignment),
+    from: List(FromItemEx),
+    where_: Option(Expr),
+    returning: List(SelectItemEx),
+  )
+  DeleteStmt(
+    ctes: List(CteDef),
+    table: String,
+    alias: Option(String),
+    using: List(FromItemEx),
+    where_: Option(Expr),
+    returning: List(SelectItemEx),
+  )
+  /// Explicit fallback. The `reason` string is surfaced in analyzer
+  /// diagnostics so the operator can see which IR gap was hit; the
+  /// raw token list is preserved so legacy token-based passes can
+  /// still work on it.
+  UnstructuredStmt(reason: String, tokens: List(lexer.Token))
+}
+
+/// The body of a `SELECT`. Reused for subqueries (scalar, `IN`,
+/// `EXISTS`) and for INSERT..SELECT.
+pub type SelectCore {
+  SelectCore(
+    distinct: Bool,
+    select_items: List(SelectItemEx),
+    from: List(FromItemEx),
+    where_: Option(Expr),
+    group_by: List(Expr),
+    having: Option(Expr),
+    order_by: List(OrderKey),
+    limit: Option(Expr),
+    offset: Option(Expr),
+    set_op: Option(SetOp),
+  )
+}
+
+pub type SetOp {
+  SetOp(kind: SetOpKind, all: Bool, right: SelectCore)
+}
+
+pub type SetOpKind {
+  Union
+  Intersect
+  Except
+}
+
+pub type OrderKey {
+  OrderKey(expr: Expr, descending: Bool, nulls: Option(NullsOrder))
+}
+
+pub type NullsOrder {
+  NullsFirst
+  NullsLast
+}
+
+/// A CTE definition. `columns` is the explicit column list when
+/// present (`name(c1, c2) AS (…)`). `body` is the nested statement.
+pub type CteDef {
+  CteDef(name: String, columns: List(String), body: Stmt, recursive: Bool)
+}
+
+/// A select item in the expression-aware IR.
+pub type SelectItemEx {
+  /// `*`, `table.*`
+  StarEx(table_prefix: Option(String))
+  /// An expression, possibly aliased. `origin` records the source
+  /// table when the expression is a simple qualified column, so
+  /// result-column resolution can skip the token rescan.
+  ExprItem(expr: Expr, alias: Option(String))
+}
+
+/// Items in a FROM clause.
+pub type FromItemEx {
+  FromTable(name: String, alias: Option(String))
+  FromSubquery(core: SelectCore, alias: String, column_aliases: List(String))
+  FromValues(
+    rows: List(List(Expr)),
+    alias: String,
+    column_aliases: List(String),
+  )
+  FromJoin(
+    left: FromItemEx,
+    right: FromItemEx,
+    kind: JoinKind,
+    on: JoinOn,
+    lateral: Bool,
+  )
+}
+
+pub type JoinKind {
+  InnerJoin
+  LeftJoin
+  RightJoin
+  FullJoin
+  CrossJoin
+}
+
+pub type JoinOn {
+  JoinOnExpr(expr: Expr)
+  JoinUsing(columns: List(String))
+  JoinNoCondition
+}
+
+pub type Assignment {
+  Assignment(column: String, value: Expr)
+}
+
+pub type InsertSource {
+  InsertValues(rows: List(List(Expr)))
+  InsertSelect(core: SelectCore)
+  InsertDefaultValues
+}
+
+// ------------------------------------------------------------
+// Expression AST
+// ------------------------------------------------------------
+
+/// The expression AST. Designed to cover the subset of SQL that
+/// sqlode needs to infer parameter and result-column types for the
+/// complex fixtures (CTE + window + CASE, LATERAL + COALESCE, EXISTS
+/// + nested CASE, INSERT..SELECT..RETURNING).
+pub type Expr {
+  /// `NULL`
+  NullLit
+  /// `TRUE`, `FALSE`
+  BoolLit(value: Bool)
+  /// String literal
+  StringLit(value: String)
+  /// Numeric literal; string form preserves precision for downstream
+  /// callers and lets us decide int vs float without reparsing.
+  NumberLit(value: String)
+  /// Parameter placeholder: `$1`, `?`, `?1`, `:name`, etc. `index`
+  /// is the 1-based index sqlode assigns to the placeholder.
+  Param(index: Int, raw: String)
+  /// Column reference (`col` or `table.col`).
+  ColumnRef(table: Option(String), name: String)
+  /// `t.*` or `*` — only valid inside COUNT(*), really.
+  StarRef(table: Option(String))
+  /// Unary prefix operator.
+  Unary(op: String, arg: Expr)
+  /// Binary operator (arithmetic, comparison, logical, string, JSON).
+  Binary(op: String, left: Expr, right: Expr)
+  /// Function call. `distinct` covers `COUNT(DISTINCT x)`. `filter`
+  /// and `over` carry the optional tail clauses.
+  Func(
+    name: String,
+    args: List(FuncArg),
+    distinct: Bool,
+    filter: Option(Expr),
+    over: Option(WindowSpec),
+  )
+  /// `CAST(expr AS type)` or the shorthand `expr::type`.
+  Cast(expr: Expr, target_type: String)
+  /// `CASE [scrutinee] WHEN … THEN … ELSE … END`.
+  Case(scrutinee: Option(Expr), branches: List(CaseBranch), else_: Option(Expr))
+  /// `expr [NOT] IN …`
+  InExpr(expr: Expr, source: InSource, negated: Bool)
+  /// `[NOT] EXISTS (subquery)`
+  Exists(core: SelectCore, negated: Bool)
+  /// Correlated scalar subquery.
+  ScalarSubquery(core: SelectCore)
+  /// `left op ANY|ALL (right)` — `right` may be a subquery or array.
+  Quantified(op: String, left: Expr, quantifier: Quantifier, right: Expr)
+  /// `expr BETWEEN low AND high`.
+  Between(expr: Expr, low: Expr, high: Expr, negated: Bool)
+  /// `expr IS [NOT] NULL` / `IS [NOT] TRUE|FALSE|UNKNOWN`.
+  IsCheck(expr: Expr, predicate: IsPredicate, negated: Bool)
+  /// `[NOT] LIKE` / `[NOT] ILIKE` / `[NOT] SIMILAR TO`.
+  LikeExpr(
+    expr: Expr,
+    op: LikeOp,
+    pattern: Expr,
+    escape: Option(Expr),
+    negated: Bool,
+  )
+  /// `ARRAY[a, b, c]`.
+  ArrayLit(elements: List(Expr))
+  /// Tuple / row constructor `(a, b, c)`.
+  Tuple(elements: List(Expr))
+  /// `sqlode.arg(name)` / `sqlode.narg(name)` / `sqlode.slice(name)` /
+  /// `sqlode.embed(table)` — sqlode-specific macros.
+  Macro(name: String, body: List(lexer.Token))
+  /// Explicit unsupported-expression marker. Analyzer passes surface
+  /// `UnsupportedExpression` when inference hits this node.
+  RawExpr(reason: String, tokens: List(lexer.Token))
+}
+
+pub type FuncArg {
+  FuncArg(expr: Expr)
+}
+
+pub type CaseBranch {
+  CaseBranch(when_: Expr, then: Expr)
+}
+
+pub type Quantifier {
+  QAny
+  QAll
+  QSome
+}
+
+pub type IsPredicate {
+  IsNull
+  IsTrue
+  IsFalse
+  IsUnknown
+  IsDistinctFrom(target: Expr)
+}
+
+pub type LikeOp {
+  Like
+  Ilike
+  SimilarTo
+}
+
+pub type InSource {
+  InList(values: List(Expr))
+  InSubquery(core: SelectCore)
+  /// `IN <sqlode.slice(name)>` — a sqlode-specific variadic list.
+  InSliceMacro(name: String)
+}
+
+pub type WindowSpec {
+  WindowSpec(
+    partition_by: List(Expr),
+    order_by: List(OrderKey),
+    frame: Option(List(lexer.Token)),
+  )
+}
+
+// ------------------------------------------------------------
+// Rich-IR wrapper mirroring `StructuredQuery` for callers that
+// want the rich representation alongside the tokens.
+// ------------------------------------------------------------
+
+pub type RichQuery {
+  RichQuery(base: model.ParsedQuery, tokens: List(lexer.Token), stmt: Stmt)
 }

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -1140,6 +1140,52 @@ fn split_tokens_by_comma_loop(
   }
 }
 
+fn parse_named_column(
+  path: String,
+  table_name: String,
+  raw_name: String,
+  all_tokens: List(lexer.Token),
+  rest: List(lexer.Token),
+  enums: List(model.EnumDef),
+) -> Result(Option(model.Column), ParseError) {
+  let name = naming.normalize_identifier(raw_name)
+  let type_toks = take_type_tokens_from_lexer(rest, [])
+  case type_toks {
+    [] ->
+      Error(InvalidColumn(
+        path: path,
+        table: table_name,
+        detail: "missing type for column " <> name,
+      ))
+    _ -> {
+      let type_text = render_type_tokens(type_toks)
+      let nullable = case
+        tokens_contain_not_null(all_tokens)
+        || tokens_contain_keyword(all_tokens, "primary")
+        || string.contains(type_text, "serial")
+      {
+        True -> False
+        False -> True
+      }
+      use scalar_type <- result.try(case find_enum(type_text, enums) {
+        Some(enum_name) -> Ok(model.EnumType(enum_name))
+        None ->
+          infer_scalar_type(type_text)
+          |> result.map_error(fn(detail) {
+            InvalidColumn(path: path, table: table_name, detail: detail)
+          })
+      })
+      Ok(
+        Some(model.Column(
+          name: name,
+          scalar_type: scalar_type,
+          nullable: nullable,
+        )),
+      )
+    }
+  }
+}
+
 fn parse_column_tokens(
   path: String,
   table_name: String,
@@ -1155,6 +1201,11 @@ fn parse_column_tokens(
         | lexer.Keyword("unique")
         | lexer.Keyword("constraint")
         | lexer.Keyword("check") -> Ok(None)
+        // Non-reserved SQL keywords like `action`, `name`, `order`
+        // are frequently used as column identifiers in user schemas.
+        // Accept them here the same way Ident/QuotedIdent are handled.
+        lexer.Keyword(n) ->
+          parse_named_column(path, table_name, n, tokens, rest, enums)
         lexer.Ident(n) | lexer.QuotedIdent(n) -> {
           let name = naming.normalize_identifier(n)
           let type_toks = take_type_tokens_from_lexer(rest, [])

--- a/test/complex_sql_test.gleam
+++ b/test/complex_sql_test.gleam
@@ -1,0 +1,276 @@
+//// Tests for the four complex SQL fixtures added for Issue #393.
+//// These fixtures exercise the expression-aware IR on constructs
+//// that were previously handled by token-rescan heuristics: CTEs
+//// (including nested CTE references), window expressions, LATERAL
+//// subqueries, correlated EXISTS, nested CASE with nullable
+//// branches, and INSERT..SELECT..RETURNING with a CTE input.
+////
+//// Each fixture is checked at two layers:
+////
+//// 1. **Analyzer** — the `query_analyzer` pipeline must accept the
+////    statement, infer the expected parameter types and produce the
+////    documented result-column shape. The fixtures stress arithmetic
+////    with casts, function-return inference, CASE branch unification
+////    and LATERAL alias propagation.
+////
+//// 2. **Codegen** — the `codegen/queries`, `codegen/params` and
+////    `codegen/models` modules must successfully render Gleam code
+////    for the analyzed queries, and the generated output must
+////    reference the expected top-level artefacts (param type name,
+////    function name, command kind). This guards against the scenario
+////    where analysis succeeds but codegen later drops columns or
+////    emits placeholder output.
+
+import gleam/dict
+import gleam/list
+import gleam/option.{None}
+import gleam/string
+import gleeunit
+import gleeunit/should
+import simplifile
+import sqlode/codegen/params
+import sqlode/codegen/queries
+import sqlode/model
+import sqlode/naming
+import sqlode/query_analyzer
+import sqlode/query_parser
+import sqlode/runtime
+import sqlode/schema_parser
+
+pub fn main() {
+  gleeunit.main()
+}
+
+const schema_path = "test/fixtures/complex_sql_schema.sql"
+
+fn catalog() -> model.Catalog {
+  let assert Ok(content) = simplifile.read(schema_path)
+  let assert Ok(#(cat, _)) =
+    schema_parser.parse_files([#(schema_path, content)])
+  cat
+}
+
+fn analyze(path: String) -> List(model.AnalyzedQuery) {
+  let naming_ctx = naming.new()
+  let cat = catalog()
+  let assert Ok(content) = simplifile.read(path)
+  let assert Ok(parsed) =
+    query_parser.parse_file(path, model.PostgreSQL, naming_ctx, content)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.PostgreSQL, cat, naming_ctx, parsed)
+  analyzed
+}
+
+fn test_block(queries_path: String) -> model.SqlBlock {
+  model.SqlBlock(
+    name: None,
+    engine: model.PostgreSQL,
+    schema: [schema_path],
+    queries: [queries_path],
+    gleam: model.GleamOutput(
+      out: "src/db",
+      runtime: model.Raw,
+      type_mapping: model.StringMapping,
+      emit_sql_as_comment: False,
+      emit_exact_table_names: False,
+      omit_unused_models: False,
+      vendor_runtime: False,
+      strict_views: False,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+fn param_types(
+  p: List(model.QueryParam),
+) -> List(#(Int, model.ScalarType, Bool, Bool)) {
+  list.map(p, fn(q) { #(q.index, q.scalar_type, q.nullable, q.is_list) })
+}
+
+fn result_columns(
+  cols: List(model.ResultItem),
+) -> List(#(String, model.ScalarType, Bool)) {
+  list.filter_map(cols, fn(item) {
+    case item {
+      model.ScalarResult(rc) -> Ok(#(rc.name, rc.scalar_type, rc.nullable))
+      model.EmbeddedResult(_) -> Error(Nil)
+    }
+  })
+}
+
+// ============================================================
+// Fixture 1 — CTE + window + CASE + arithmetic
+// ============================================================
+
+pub fn cte_window_case_analyzer_test() {
+  let analyzed = analyze("test/fixtures/complex_sql_cte_window_case.sql")
+  let assert [query] = analyzed
+
+  query.base.name |> should.equal("ListRankedUsers")
+  query.base.command |> should.equal(runtime.QueryMany)
+
+  // $1 is a cast timestamp (used in `p.created_at >= $1::timestamp`).
+  // $2 is the cast int inside the scored_users arithmetic.
+  // $3 is the outer WHERE filter against the CTE-derived `score`.
+  param_types(query.params)
+  |> should.equal([
+    #(1, model.DateTimeType, False, False),
+    #(2, model.IntType, False, False),
+    #(3, model.IntType, False, False),
+  ])
+
+  // Result columns come from the outer SELECT over `scored_users`.
+  // `id`/`email` flow through the CTE unchanged from `users`; `tier`
+  // is the unified CASE result (all string literal branches); `score`
+  // is the integer arithmetic. `score` is nullable because it mixes
+  // a non-null aggregate with a casted parameter, and sqlode treats
+  // casts as nullable in expression context so the caller is free to
+  // pass a nullable parameter behind the cast.
+  result_columns(query.result_columns)
+  |> should.equal([
+    #("id", model.IntType, False),
+    #("email", model.StringType, False),
+    #("tier", model.StringType, False),
+    #("score", model.IntType, True),
+  ])
+}
+
+pub fn cte_window_case_codegen_test() {
+  let naming_ctx = naming.new()
+  let block = test_block("test/fixtures/complex_sql_cte_window_case.sql")
+  let analyzed = analyze("test/fixtures/complex_sql_cte_window_case.sql")
+
+  let rendered_queries =
+    queries.render(naming_ctx, block, analyzed, dict.new(), False)
+  string.contains(rendered_queries, "pub fn list_ranked_users(")
+  |> should.be_true()
+  string.contains(rendered_queries, "command: runtime.QueryMany")
+  |> should.be_true()
+
+  let rendered_params =
+    params.render(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+      "sqlode/runtime",
+    )
+  string.contains(rendered_params, "pub type ListRankedUsersParams {")
+  |> should.be_true()
+}
+
+// ============================================================
+// Fixture 2 — LATERAL subquery + aggregate projection
+// ============================================================
+
+pub fn lateral_aggregate_analyzer_test() {
+  let analyzed = analyze("test/fixtures/complex_sql_lateral_aggregate.sql")
+  let assert [query] = analyzed
+
+  query.base.name |> should.equal("ListTeamsWithLatestPost")
+  query.base.command |> should.equal(runtime.QueryMany)
+
+  // The query uses a single sqlode.slice(team_ids) param against
+  // `t.id`. The slice macro keeps the parameter's list-ness at `True`.
+  let assert [single_param] = query.params
+  single_param.index |> should.equal(1)
+  single_param.scalar_type |> should.equal(model.IntType)
+  single_param.is_list |> should.equal(True)
+
+  // LATERAL alias `latest_post` projects `created_at` from posts
+  // (timestamp). COALESCE's default makes `member_count` non-nullable.
+  result_columns(query.result_columns)
+  |> should.equal([
+    #("id", model.IntType, False),
+    #("name", model.StringType, False),
+    #("latest_post_at", model.DateTimeType, True),
+    #("member_count", model.IntType, False),
+  ])
+}
+
+pub fn lateral_aggregate_codegen_test() {
+  let naming_ctx = naming.new()
+  let block = test_block("test/fixtures/complex_sql_lateral_aggregate.sql")
+  let analyzed = analyze("test/fixtures/complex_sql_lateral_aggregate.sql")
+
+  let rendered_queries =
+    queries.render(naming_ctx, block, analyzed, dict.new(), False)
+  string.contains(rendered_queries, "pub fn list_teams_with_latest_post(")
+  |> should.be_true()
+}
+
+// ============================================================
+// Fixture 3 — correlated EXISTS + nested CASE + nullable branches
+// ============================================================
+
+pub fn exists_case_analyzer_test() {
+  let analyzed = analyze("test/fixtures/complex_sql_exists_case.sql")
+  let assert [query] = analyzed
+
+  query.base.name |> should.equal("ListReviewablePosts")
+  query.base.command |> should.equal(runtime.QueryMany)
+
+  // $1 and $2 are int casts inside `(p.score + $1::int) > $2::int`.
+  param_types(query.params)
+  |> should.equal([
+    #(1, model.IntType, False, False),
+    #(2, model.IntType, False, False),
+  ])
+
+  // `moderation_state` is a CASE with a string ELSE, so not nullable.
+  // `review_timestamp` branches are `reviewed_at` (nullable) and NULL,
+  // so the unified type is DateTime with nullable=True.
+  result_columns(query.result_columns)
+  |> should.equal([
+    #("id", model.IntType, False),
+    #("moderation_state", model.StringType, False),
+    #("review_timestamp", model.DateTimeType, True),
+  ])
+}
+
+pub fn exists_case_codegen_test() {
+  let naming_ctx = naming.new()
+  let block = test_block("test/fixtures/complex_sql_exists_case.sql")
+  let analyzed = analyze("test/fixtures/complex_sql_exists_case.sql")
+
+  let rendered_queries =
+    queries.render(naming_ctx, block, analyzed, dict.new(), False)
+  string.contains(rendered_queries, "pub fn list_reviewable_posts(")
+  |> should.be_true()
+}
+
+// ============================================================
+// Fixture 4 — INSERT .. SELECT with CTE + RETURNING
+// ============================================================
+
+pub fn insert_select_analyzer_test() {
+  let analyzed = analyze("test/fixtures/complex_sql_insert_select.sql")
+  let assert [query] = analyzed
+
+  query.base.name |> should.equal("CreateAuditRows")
+  query.base.command |> should.equal(runtime.QueryMany)
+
+  // Only one placeholder ($1) — the updated_at cutoff inside the CTE.
+  param_types(query.params)
+  |> should.equal([#(1, model.DateTimeType, False, False)])
+
+  // RETURNING columns map back to audit_log (the INSERT target).
+  result_columns(query.result_columns)
+  |> should.equal([
+    #("id", model.IntType, False),
+    #("post_id", model.IntType, False),
+    #("actor_id", model.IntType, False),
+    #("action", model.StringType, False),
+  ])
+}
+
+pub fn insert_select_codegen_test() {
+  let naming_ctx = naming.new()
+  let block = test_block("test/fixtures/complex_sql_insert_select.sql")
+  let analyzed = analyze("test/fixtures/complex_sql_insert_select.sql")
+
+  let rendered_queries =
+    queries.render(naming_ctx, block, analyzed, dict.new(), False)
+  string.contains(rendered_queries, "pub fn create_audit_rows(")
+  |> should.be_true()
+}

--- a/test/fixtures/complex_sql_cte_window_case.sql
+++ b/test/fixtures/complex_sql_cte_window_case.sql
@@ -1,0 +1,35 @@
+-- Fixture 1 for Issue #393: CTE + window + CASE + arithmetic.
+-- Exercises the expression-aware IR on nested CTE references,
+-- window expressions, CASE branches and arithmetic with casts.
+
+-- name: ListRankedUsers :many
+WITH ranked_posts AS (
+  SELECT
+    p.user_id,
+    COUNT(*) AS post_count,
+    ROW_NUMBER() OVER (
+      PARTITION BY p.user_id
+      ORDER BY MAX(p.created_at) DESC
+    ) AS post_rank
+  FROM posts AS p
+  WHERE p.created_at >= $1::timestamp
+  GROUP BY p.user_id
+),
+scored_users AS (
+  SELECT
+    u.id,
+    u.email,
+    rp.post_count,
+    CASE
+      WHEN rp.post_count >= 100 THEN 'power'
+      WHEN rp.post_count >= 10 THEN 'active'
+      ELSE 'casual'
+    END AS tier,
+    (rp.post_count * 2) + $2::int AS score
+  FROM users AS u
+  JOIN ranked_posts AS rp ON rp.user_id = u.id
+)
+SELECT id, email, tier, score
+FROM scored_users
+WHERE score > $3::int
+ORDER BY score DESC;

--- a/test/fixtures/complex_sql_exists_case.sql
+++ b/test/fixtures/complex_sql_exists_case.sql
@@ -1,0 +1,23 @@
+-- Fixture 3 for Issue #393: correlated EXISTS + nested CASE +
+-- nullable branches. Exercises EXISTS as a boolean predicate inside
+-- a WHEN branch, a CASE that can project NULL, and arithmetic that
+-- mixes a non-nullable column with a casted parameter.
+
+-- name: ListReviewablePosts :many
+SELECT
+  p.id,
+  CASE
+    WHEN EXISTS (
+      SELECT 1
+      FROM comments AS c
+      WHERE c.post_id = p.id AND c.flagged = TRUE
+    ) THEN 'flagged'
+    WHEN p.deleted_at IS NOT NULL THEN 'deleted'
+    ELSE 'clean'
+  END AS moderation_state,
+  CASE
+    WHEN p.reviewed_at IS NOT NULL THEN p.reviewed_at
+    ELSE NULL
+  END AS review_timestamp
+FROM posts AS p
+WHERE (p.score + $1::int) > $2::int;

--- a/test/fixtures/complex_sql_insert_select.sql
+++ b/test/fixtures/complex_sql_insert_select.sql
@@ -1,0 +1,15 @@
+-- Fixture 4 for Issue #393: INSERT ... SELECT with a CTE input and
+-- RETURNING. Exercises the expression-aware IR on prefixed CTEs for
+-- non-SELECT statements, INSERT .. SELECT as an insert source, and
+-- RETURNING column inference against the INSERT target.
+
+-- name: CreateAuditRows :many
+WITH changed_posts AS (
+  SELECT p.id, p.user_id
+  FROM posts AS p
+  WHERE p.updated_at >= $1::timestamp
+)
+INSERT INTO audit_log (post_id, actor_id, action)
+SELECT cp.id, cp.user_id, 'refresh'
+FROM changed_posts AS cp
+RETURNING id, post_id, actor_id, action;

--- a/test/fixtures/complex_sql_lateral_aggregate.sql
+++ b/test/fixtures/complex_sql_lateral_aggregate.sql
@@ -1,0 +1,25 @@
+-- Fixture 2 for Issue #393: LATERAL subquery + aggregate projection.
+-- Exercises the expression-aware IR on LATERAL joins, correlated
+-- access to outer columns (`p.team_id = t.id`), COALESCE and the
+-- `sqlode.slice` macro used inside an ANY(...) comparison.
+
+-- name: ListTeamsWithLatestPost :many
+SELECT
+  t.id,
+  t.name,
+  latest_post.created_at AS latest_post_at,
+  COALESCE(stats.member_count, 0) AS member_count
+FROM teams AS t
+LEFT JOIN LATERAL (
+  SELECT p.created_at
+  FROM posts AS p
+  WHERE p.team_id = t.id
+  ORDER BY p.created_at DESC
+  LIMIT 1
+) AS latest_post ON TRUE
+LEFT JOIN (
+  SELECT m.team_id, COUNT(*) AS member_count
+  FROM memberships AS m
+  GROUP BY m.team_id
+) AS stats ON stats.team_id = t.id
+WHERE t.id = ANY(sqlode.slice(team_ids));

--- a/test/fixtures/complex_sql_schema.sql
+++ b/test/fixtures/complex_sql_schema.sql
@@ -1,0 +1,43 @@
+-- Schema backing the four complex SQL fixtures for Issue #393.
+-- Each column is annotated so the analyzer can distinguish nullable
+-- from NOT NULL references, which in turn shapes the inferred
+-- `nullable` flag on the generated result columns.
+
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY NOT NULL,
+  email TEXT NOT NULL
+);
+
+CREATE TABLE posts (
+  id BIGINT PRIMARY KEY NOT NULL,
+  user_id BIGINT NOT NULL,
+  team_id BIGINT NOT NULL,
+  score INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  reviewed_at TIMESTAMP,
+  deleted_at TIMESTAMP
+);
+
+CREATE TABLE teams (
+  id BIGINT PRIMARY KEY NOT NULL,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE memberships (
+  team_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL
+);
+
+CREATE TABLE comments (
+  id BIGINT PRIMARY KEY NOT NULL,
+  post_id BIGINT NOT NULL,
+  flagged BOOLEAN NOT NULL
+);
+
+CREATE TABLE audit_log (
+  id BIGINT PRIMARY KEY NOT NULL,
+  post_id BIGINT NOT NULL,
+  actor_id BIGINT NOT NULL,
+  action TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- Introduce an expression-aware SQL IR (`Stmt`, `SelectCore`, `CteDef`, `Expr`) that explicitly models CTEs, LATERAL subqueries, select items, predicates, arithmetic, `CASE`, function calls, casts, `IN`, `EXISTS`, `ANY`/`ALL`, window specs, and `RETURNING`.
- Replace the heuristic token-scan paths for arithmetic / `CASE` / function-call return types with IR-driven inference. When inference can't progress, an `UnsupportedExpression` diagnostic is surfaced instead of silently defaulting to `StringType`.
- Add four executable fixtures under `test/fixtures/complex_sql_*.sql` covering the acceptance scenarios from Issue #393 (CTE + window + `CASE`, LATERAL + aggregate, correlated `EXISTS` + nested `CASE` with nullable branches, `INSERT .. SELECT .. RETURNING` with a CTE input) and wire them through the analyzer and codegen test layers.

## Changes
- **IR** — `src/sqlode/query_ir.gleam` now also exposes the new `Stmt` / `Expr` / `CteDef` / `FromItemEx` / `SelectItemEx` types alongside the legacy structured IR.
- **Parsing** — new `src/sqlode/query_analyzer/expr_parser.gleam` is a precedence-aware recursive-descent parser producing the new IR from tokens.
- **Inference** — new `src/sqlode/query_analyzer/type_inference.gleam` walks the expression AST against the augmented catalog and returns `(ScalarType, nullable)` or an explicit diagnostic. `column_inferencer.infer_expression_type_from_tokens` now routes through the IR first.
- **Alias resolution** — `column_inferencer.extract_table_aliases` registers each `FROM/JOIN table AS alias` as a virtual catalog entry so qualified refs resolve uniformly at every nesting level.
- **RETURNING scoping** — `detect_dml_target` restricts `RETURNING` resolution to the INSERT / UPDATE / DELETE target so `INSERT .. SELECT .. RETURNING` doesn't see the SELECT source tables as ambiguous candidates.
- **LATERAL nullability** — `LEFT [OUTER] JOIN LATERAL (…) AS alias` is now recognised when walking nullable tables.
- **ANY / ALL / SOME** — `token_utils.find_quantified_patterns` feeds `param_inferencer.infer_in_params` so `col = ANY(placeholder)` (and the `sqlode.slice` macro form) participates in parameter inference alongside `IN`.
- **Schema parser** — accepts non-reserved keywords (`action`, `name`, `order`, …) as column identifiers.

## Design decisions
- The legacy structured IR is retained for backward compatibility; the new IR coexists with it and gradually takes over the analyzer's expression paths. This keeps the blast radius contained while the richer representation grows.
- `RawExpr` / `UnstructuredStmt` are kept as explicit fallback nodes carrying a human-readable reason string, so any future IR gap is traceable to a concrete expression instead of silently degrading to `StringType`.
- Casts (`expr::type` / `CAST(expr AS type)`) intentionally mark their result as nullable in expression context, matching the legacy analyzer behaviour (the caller is free to bind a nullable parameter behind a cast).

## Test plan
- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam test` (858 passed, 0 failures)
- [x] `shellspec` (20 examples, 0 failures)
- [x] Each complex-SQL fixture is asserted on inferred parameter types, inferred result columns, and successful codegen of the generated Gleam module

Closes #393