### PR TITLE
fix: reject ambiguous unqualified parameter columns (#390)

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -139,17 +139,24 @@ fn build_params(
   catalog: model.Catalog,
   occurrences: List(placeholder.PlaceholderOccurrence),
 ) -> Result(List(model.QueryParam), context.AnalysisError) {
+  use equality <- result.try(param_inferencer.infer_equality_params(
+    ctx,
+    engine,
+    query.name,
+    tokens,
+    catalog,
+  ))
+  use in_params <- result.try(param_inferencer.infer_in_params(
+    ctx,
+    engine,
+    query.name,
+    tokens,
+    catalog,
+  ))
   let inferences =
-    list.append(
-      param_inferencer.infer_insert_params_from_ir(engine, statement, catalog),
-      param_inferencer.infer_equality_params(ctx, engine, tokens, catalog),
-    )
-    |> list.append(param_inferencer.infer_in_params(
-      ctx,
-      engine,
-      tokens,
-      catalog,
-    ))
+    param_inferencer.infer_insert_params_from_ir(engine, statement, catalog)
+    |> list.append(equality)
+    |> list.append(in_params)
 
   use cast_dict <- result.try(
     param_inferencer.extract_type_casts(ctx, engine, tokens)

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -2,10 +2,13 @@ import gleam/dict
 import gleam/int
 import gleam/list
 import gleam/option.{None, Some}
+import gleam/result
 import gleam/string
 import sqlode/lexer
 import sqlode/model
-import sqlode/query_analyzer/context.{type AnalyzerContext}
+import sqlode/query_analyzer/context.{
+  type AnalysisError, type AnalyzerContext, AmbiguousColumnName,
+}
 import sqlode/query_analyzer/placeholder
 import sqlode/query_analyzer/token_utils
 import sqlode/query_ir
@@ -110,88 +113,120 @@ fn map_insert_columns(
 pub fn infer_equality_params(
   _ctx: AnalyzerContext,
   engine: model.Engine,
+  query_name: String,
   tokens: List(lexer.Token),
   catalog: model.Catalog,
-) -> List(#(Int, model.Column)) {
-  let all_tables = token_utils.extract_table_names(tokens)
-
+) -> Result(List(#(Int, model.Column)), AnalysisError) {
+  // Only FROM/JOIN tables of the outermost statement are in scope for
+  // top-level predicates. Dropping the WITH prefix keeps CTE-internal
+  // tables (which each CTE resolves against its own scope) from
+  // leaking into the ambiguity check for the outer WHERE.
+  let main_tokens = token_utils.strip_leading_with(tokens)
+  let all_tables = token_utils.extract_table_names(main_tokens)
   case all_tables {
-    [] -> []
-    [primary, ..] -> {
-      let matches = token_utils.find_equality_patterns(tokens)
+    [] -> Ok([])
+    _ -> {
+      let matches = token_utils.find_equality_patterns(main_tokens)
       scan_token_matches(
         engine,
         catalog,
-        primary,
+        query_name,
         all_tables,
         matches,
         1,
         dict.new(),
         [],
       )
-      |> list.reverse
+      |> result.map(list.reverse)
     }
   }
 }
 
+/// Walk each `column <op> placeholder` / `column IN (placeholder)` /
+/// quantified pattern the token scanners found and bind a parameter
+/// type when the referenced column exists. Ambiguity (the column name
+/// exists in more than one in-scope table and is not qualified) is
+/// surfaced as `AmbiguousColumnName` so `sqlode generate` fails before
+/// emitting a wrong `Params` type — the result-column inferencer has
+/// raised the same diagnostic for select-list ambiguity; parameter
+/// inference now behaves symmetrically. A qualified column that can't
+/// be found, and an unqualified column not present in any visible
+/// table, simply skip inference for that placeholder — the outer
+/// analyzer still has type-cast / macro hooks to satisfy the param.
 fn scan_token_matches(
   engine: model.Engine,
   catalog: model.Catalog,
-  primary_table: String,
+  query_name: String,
   all_tables: List(String),
   matches: List(token_utils.EqualityMatch),
   occurrence: Int,
   seen: dict.Dict(String, Int),
   acc: List(#(Int, model.Column)),
-) -> List(#(Int, model.Column)) {
+) -> Result(List(#(Int, model.Column)), AnalysisError) {
   case matches {
-    [] -> acc
+    [] -> Ok(acc)
     [match, ..rest] -> {
       let #(maybe_index, next_occurrence, updated_seen) =
         placeholder.resolve_index(engine, match.placeholder, occurrence, seen)
 
-      let acc = case maybe_index {
+      case maybe_index {
+        None ->
+          scan_token_matches(
+            engine,
+            catalog,
+            query_name,
+            all_tables,
+            rest,
+            next_occurrence,
+            updated_seen,
+            acc,
+          )
         Some(index) -> {
-          let found = case match.table_qualifier {
+          let lookup = case match.table_qualifier {
             Some(table) ->
-              context.find_column(catalog, table, match.column_name)
+              Ok(
+                context.find_column(catalog, table, match.column_name)
+                |> option.map(fn(col) { #(table, col) }),
+              )
             None ->
-              case
-                context.find_column_in_tables(
-                  catalog,
-                  all_tables,
-                  match.column_name,
-                )
-              {
-                Ok(Some(pair)) -> Some(pair.1)
-                _ -> None
-              }
+              context.find_column_in_tables(
+                catalog,
+                all_tables,
+                match.column_name,
+              )
           }
-          case found {
-            Some(column) -> [#(index, column), ..acc]
-            None ->
-              // Fallback: try primary table
-              case
-                context.find_column(catalog, primary_table, match.column_name)
-              {
-                Some(column) -> [#(index, column), ..acc]
-                None -> acc
-              }
+          case lookup {
+            Error(matching_tables) ->
+              Error(AmbiguousColumnName(
+                query_name: query_name,
+                column_name: match.column_name,
+                matching_tables: matching_tables,
+              ))
+            Ok(Some(#(_table, column))) ->
+              scan_token_matches(
+                engine,
+                catalog,
+                query_name,
+                all_tables,
+                rest,
+                next_occurrence,
+                updated_seen,
+                [#(index, column), ..acc],
+              )
+            Ok(None) ->
+              scan_token_matches(
+                engine,
+                catalog,
+                query_name,
+                all_tables,
+                rest,
+                next_occurrence,
+                updated_seen,
+                acc,
+              )
           }
         }
-        None -> acc
       }
-
-      scan_token_matches(
-        engine,
-        catalog,
-        primary_table,
-        all_tables,
-        rest,
-        next_occurrence,
-        updated_seen,
-        acc,
-      )
     }
   }
 }
@@ -199,30 +234,31 @@ fn scan_token_matches(
 pub fn infer_in_params(
   _ctx: AnalyzerContext,
   engine: model.Engine,
+  query_name: String,
   tokens: List(lexer.Token),
   catalog: model.Catalog,
-) -> List(#(Int, model.Column)) {
-  let all_tables = token_utils.extract_table_names(tokens)
-
+) -> Result(List(#(Int, model.Column)), AnalysisError) {
+  let main_tokens = token_utils.strip_leading_with(tokens)
+  let all_tables = token_utils.extract_table_names(main_tokens)
   case all_tables {
-    [] -> []
-    [primary, ..] -> {
+    [] -> Ok([])
+    _ -> {
       let matches =
         list.append(
-          token_utils.find_in_patterns(tokens),
-          token_utils.find_quantified_patterns(tokens),
+          token_utils.find_in_patterns(main_tokens),
+          token_utils.find_quantified_patterns(main_tokens),
         )
       scan_token_matches(
         engine,
         catalog,
-        primary,
+        query_name,
         all_tables,
         matches,
         1,
         dict.new(),
         [],
       )
-      |> list.reverse
+      |> result.map(list.reverse)
     }
   }
 }

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -118,6 +118,39 @@ pub fn read_table_name(
   }
 }
 
+/// Strip a leading `WITH [RECURSIVE] cte_defs` clause so downstream
+/// passes see only the tokens of the main statement. Each CTE
+/// definition lives inside parentheses so we skip them along with
+/// the name / column-list preamble between commas. If the statement
+/// does not begin with WITH, the tokens are returned unchanged.
+///
+/// This is the same strip that the column inferencer uses for
+/// result-column scoping; exposing it here lets the parameter
+/// inferencer reuse the identical boundary when it decides which
+/// tables are visible to a top-level WHERE/ON predicate.
+pub fn strip_leading_with(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [lexer.Keyword("with"), lexer.Keyword("recursive"), ..rest] ->
+      skip_with_body(rest)
+    [lexer.Keyword("with"), ..rest] -> skip_with_body(rest)
+    _ -> tokens
+  }
+}
+
+fn skip_with_body(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [] -> []
+    [lexer.Keyword(kw), ..] as t
+      if kw == "select" || kw == "insert" || kw == "update" || kw == "delete"
+    -> t
+    [lexer.LParen, ..rest] -> {
+      let remaining = skip_parens(rest, 1)
+      skip_with_body(remaining)
+    }
+    [_, ..rest] -> skip_with_body(rest)
+  }
+}
+
 /// Skip tokens until all parentheses at the given depth are closed.
 pub fn skip_parens(tokens: List(lexer.Token), depth: Int) -> List(lexer.Token) {
   case depth <= 0 {

--- a/test/complex_sql_test.gleam
+++ b/test/complex_sql_test.gleam
@@ -111,12 +111,14 @@ pub fn cte_window_case_analyzer_test() {
 
   // $1 is a cast timestamp (used in `p.created_at >= $1::timestamp`).
   // $2 is the cast int inside the scored_users arithmetic.
-  // $3 is the outer WHERE filter against the CTE-derived `score`.
+  // $3 is the outer WHERE filter against the CTE-derived `score`,
+  // which is itself nullable (arithmetic with a casted parameter),
+  // so the inferred parameter type inherits the column's nullability.
   param_types(query.params)
   |> should.equal([
     #(1, model.DateTimeType, False, False),
     #(2, model.IntType, False, False),
-    #(3, model.IntType, False, False),
+    #(3, model.IntType, True, False),
   ])
 
   // Result columns come from the outer SELECT over `scored_users`.

--- a/test/fixtures/ambiguous_param_query.sql
+++ b/test/fixtures/ambiguous_param_query.sql
@@ -1,0 +1,16 @@
+-- Regression fixture for Issue #390. The unqualified `WHERE id = $1`
+-- appears after a CTE + join that exposes `id` on three tables:
+-- `memberships`, `active_users` (from the CTE), and `teams`.
+-- Parameter inference must refuse to pick one silently.
+
+-- name: GetMembership :one
+WITH active_users AS (
+  SELECT u.id, u.team_id
+  FROM users AS u
+  WHERE u.deleted_at IS NULL
+)
+SELECT m.id, t.owner_id
+FROM memberships AS m
+JOIN active_users AS au ON au.id = m.user_id
+JOIN teams AS t ON t.id = au.team_id
+WHERE id = $1;

--- a/test/fixtures/ambiguous_param_schema.sql
+++ b/test/fixtures/ambiguous_param_schema.sql
@@ -1,0 +1,21 @@
+-- Schema backing the ambiguous-parameter regression fixture for
+-- Issue #390. The shape mirrors the reproduction in the issue:
+-- three tables that all expose an `id` column so an unqualified
+-- `WHERE id = $1` predicate is ambiguous.
+
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY NOT NULL,
+  team_id BIGINT NOT NULL,
+  deleted_at TIMESTAMP
+);
+
+CREATE TABLE teams (
+  id BIGINT PRIMARY KEY NOT NULL,
+  owner_id BIGINT NOT NULL
+);
+
+CREATE TABLE memberships (
+  id BIGINT PRIMARY KEY NOT NULL,
+  user_id BIGINT NOT NULL,
+  team_id BIGINT NOT NULL
+);

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2426,3 +2426,49 @@ pub fn param_type_conflict_detection_test() {
     type_b: model.StringType,
   )) = result
 }
+
+pub fn ambiguous_unqualified_param_column_is_rejected_test() {
+  // Regression for Issue #390. A CTE-joined query with three `id`
+  // columns in scope (`memberships.id`, `active_users.id`,
+  // `teams.id`) must surface an AmbiguousColumnName error for
+  // `WHERE id = $1` instead of silently binding to the primary
+  // table's id column.
+  let naming_ctx = naming.new()
+  let assert Ok(schema_content) =
+    simplifile.read("test/fixtures/ambiguous_param_schema.sql")
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([
+      #("test/fixtures/ambiguous_param_schema.sql", schema_content),
+    ])
+
+  let assert Ok(sql) =
+    simplifile.read("test/fixtures/ambiguous_param_query.sql")
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "test/fixtures/ambiguous_param_query.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      sql,
+    )
+
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+
+  let assert Error(context.AmbiguousColumnName(
+    query_name: "GetMembership",
+    column_name: "id",
+    matching_tables: tables,
+  )) = result
+  // The matching list must contain every table that exposes `id` at
+  // the outermost FROM/JOIN scope. CTE-internal references do not
+  // leak here thanks to the WITH-prefix strip, so we assert on the
+  // three top-level tables.
+  list.contains(tables, "memberships") |> should.be_true()
+  list.contains(tables, "active_users") |> should.be_true()
+  list.contains(tables, "teams") |> should.be_true()
+}


### PR DESCRIPTION
## Summary
- Parameter inference now raises `AmbiguousColumnName` when an unqualified column in a WHERE / comparison / IN / ANY predicate matches more than one in-scope table, mirroring the existing diagnostic for result-column inference.
- The previous primary-table fallback — which silently bound the parameter to the first table and let a wrong \`Params\` type reach codegen — is removed.
- Top-level predicate scope is restricted to the outermost FROM/JOIN tables via a new `token_utils.strip_leading_with` helper, so CTE-internal references don't participate in the ambiguity check.

## Changes
- `src/sqlode/query_analyzer/param_inferencer.gleam`
  - `scan_token_matches` now returns `Result(List(#(Int, Column)), AnalysisError)`, propagating `AmbiguousColumnName` on multi-table hits and skipping inference (without falling back) when a qualified column is missing.
  - `infer_equality_params` / `infer_in_params` accept `query_name`, strip a leading `WITH` clause before running the token scan, and return the new `Result` shape.
- `src/sqlode/query_analyzer.gleam` — threads the new `Result` values through `build_params` via `result.try`.
- `src/sqlode/query_analyzer/token_utils.gleam` — adds `strip_leading_with` (shared with the result-column inferencer's semantics).
- `test/fixtures/ambiguous_param_{schema,query}.sql` — executable fixture pair (CTE + join over `users` / `teams` / `memberships`) reproducing the scenario from the issue.
- `test/query_analyzer_test.gleam` — adds `ambiguous_unqualified_param_column_is_rejected_test`.
- `test/complex_sql_test.gleam` — updates `$3`'s expected nullability in the `cte_window_case` fixture to `True`. With proper resolution against `scored_users.score` (which is itself nullable because of the casted arithmetic), the parameter correctly inherits the column's nullability instead of being rescued by the old fallback.

## Design decisions
- The primary-table fallback was masking two different bugs: the reported ambiguity problem and genuine \"column not found\" cases on qualified references. Both are now surfaced explicitly — unqualified-and-ambiguous as `AmbiguousColumnName`, qualified-and-missing as a skipped inference (the outer cast/macro hooks still get a chance to satisfy the param).
- `strip_leading_with` was added to `token_utils` rather than referencing the private helper in `column_inferencer` so parameter inference and result-column inference agree on the same \"outer scope\" boundary by construction.

## Test plan
- [x] `gleam format --check src/ test/`
- [x] `gleam check`
- [x] `gleam build --warnings-as-errors`
- [x] `gleam test` (859 passed, 0 failures)
- [x] `shellspec` (20 examples, 0 failures)
- [x] New regression fixture asserts the error shape and that the matching tables include all three top-level candidates (`memberships`, `active_users`, `teams`).

Closes #390