### PR TITLE
fix: make strict_views the default policy (#391)

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,9 +637,9 @@ Other statements (`CREATE INDEX`, transaction blocks, comments) are silently ski
 
 ### View resolution
 
-`CREATE VIEW ... AS SELECT ...` columns are resolved against the base tables so the generated models have correct types. By default, columns that cannot be resolved (unknown base table, ambiguous expression, etc.) are skipped with a stderr warning; if every column of a view is unresolvable the view itself is dropped from the catalog.
+`CREATE VIEW ... AS SELECT ...` columns are resolved against the base tables so the generated models have correct types. By default sqlode fails generation when any view column cannot be resolved (unknown base table, ambiguous expression, etc.) — a partially resolved view almost always means the schema and the configuration are out of sync, and silently dropping the column would let that mismatch reach generated code.
 
-Enable `strict_views: true` to fail-fast on any view resolution warning:
+For legacy schemas that still need the old warn-and-continue behaviour, set `strict_views: false` explicitly:
 
 ```yaml
 sql:
@@ -649,10 +649,10 @@ sql:
     gen:
       gleam:
         out: "src/db"
-        strict_views: true
+        strict_views: false
 ```
 
-Strict-by-default is planned for a future release.
+With `strict_views: false` each unresolvable column is reported to stderr and dropped from the generated model (and the view itself is dropped if every column is unresolvable).
 
 ### Custom types must be transparent aliases
 

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -167,9 +167,15 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
   let vendor_runtime =
     optional_bool(gleam_node, "vendor_runtime")
     |> option.unwrap(False)
+  // Strict-views is the default: any unresolvable view column is a
+  // generation error so the emitted model never silently drifts away
+  // from the actual schema. `strict_views: false` is still accepted
+  // as an explicit opt-out for legacy schemas that need the old
+  // warn-and-continue behaviour, but new configurations should leave
+  // it unset.
   let strict_views =
     optional_bool(gleam_node, "strict_views")
-    |> option.unwrap(False)
+    |> option.unwrap(True)
 
   use overrides <- result.try(parse_overrides(node))
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -112,10 +112,11 @@ pub type GleamOutput {
     vendor_runtime: Bool,
     /// When True, any schema warning from view resolution
     /// (unresolvable view columns, dropped views) is promoted to a
-    /// fatal error. Defaults to False — the legacy behaviour is to
-    /// print warnings to stderr and drop columns/views silently so
-    /// generation can still produce models for the rest of the
-    /// catalog. Strict-by-default is planned for a future release.
+    /// fatal error. Defaults to True — a partially resolved view is
+    /// almost always a schema/config mismatch, and letting it reach
+    /// codegen produces a model that is silently out of sync with
+    /// the real database. Set to False explicitly to restore the
+    /// legacy warn-and-continue behaviour for legacy schemas.
     strict_views: Bool,
   )
 }

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -190,10 +190,13 @@ pub fn default_block_name_is_none_test() {
   block.name |> should.equal(option.None)
 }
 
-pub fn default_strict_views_is_false_test() {
+pub fn default_strict_views_is_true_test() {
+  // A config that does not mention `strict_views` defaults to the
+  // strict policy. Issue #391 tightened the default so partial view
+  // resolution cannot silently reach codegen.
   let assert Ok(cfg) = config.load("test/fixtures/sqlode.yaml")
   let assert [block] = cfg.sql
-  block.gleam.strict_views |> should.equal(False)
+  block.gleam.strict_views |> should.equal(True)
 }
 
 pub fn strict_views_true_roundtrips_test() {

--- a/test/fixtures/partial_view_query.sql
+++ b/test/fixtures/partial_view_query.sql
@@ -1,0 +1,2 @@
+-- name: ListUserRollups :many
+SELECT * FROM user_rollups;

--- a/test/fixtures/partial_view_schema.sql
+++ b/test/fixtures/partial_view_schema.sql
@@ -1,0 +1,36 @@
+-- Schema fixture for Issue #391: a view with one intentionally
+-- unresolved column (`missing_source.value`) — sqlode must refuse
+-- to produce a partial catalog from this schema by default.
+
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY NOT NULL,
+  email TEXT NOT NULL
+);
+
+CREATE TABLE posts (
+  id BIGINT PRIMARY KEY NOT NULL,
+  user_id BIGINT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  published BOOL NOT NULL
+);
+
+CREATE VIEW user_rollups AS
+SELECT
+  u.id,
+  COALESCE(pub_counts.published_posts, 0) AS published_posts,
+  latest_post.created_at AS latest_post_at,
+  missing_source.value AS broken_col
+FROM users AS u
+LEFT JOIN (
+  SELECT p.user_id, COUNT(*) AS published_posts
+  FROM posts AS p
+  WHERE p.published = TRUE
+  GROUP BY p.user_id
+) AS pub_counts ON pub_counts.user_id = u.id
+LEFT JOIN LATERAL (
+  SELECT p.created_at
+  FROM posts AS p
+  WHERE p.user_id = u.id
+  ORDER BY p.created_at DESC
+  LIMIT 1
+) AS latest_post ON TRUE;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -3,6 +3,7 @@ import gleam/option
 import gleam/string
 import gleeunit/should
 import simplifile
+import sqlode/config
 import sqlode/generate
 import sqlode/model
 
@@ -1820,6 +1821,94 @@ pub fn strict_views_false_preserves_legacy_silent_drop_test() {
   let cfg = model.Config(version: 2, sql: [strict_views_block(False)])
   let assert Ok(_) = generate.generate_config(cfg)
   cleanup()
+}
+
+// --- strict_views default — Issue #391 ---
+
+const partial_view_out = "test_output/generate_test_partial_view"
+
+fn partial_view_block(strict_views: Bool) -> model.SqlBlock {
+  // A block where strict_views reflects the user's setting. The
+  // `ListUserRollups` query selects from a view that contains one
+  // intentionally unresolved column (`missing_source.value`), so the
+  // strict default must reject this configuration.
+  model.SqlBlock(
+    name: option.None,
+    engine: model.PostgreSQL,
+    schema: ["test/fixtures/partial_view_schema.sql"],
+    queries: ["test/fixtures/partial_view_query.sql"],
+    gleam: model.GleamOutput(
+      out: partial_view_out,
+      runtime: model.Raw,
+      type_mapping: model.StringMapping,
+      emit_sql_as_comment: False,
+      emit_exact_table_names: False,
+      omit_unused_models: False,
+      vendor_runtime: False,
+      strict_views: strict_views,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+fn cleanup_partial_view() {
+  let _ = simplifile.delete(partial_view_out)
+  Nil
+}
+
+pub fn strict_views_is_default_for_partial_view_test() {
+  // Regression for Issue #391. A fresh configuration without an
+  // explicit `strict_views` setting must now fail when a view
+  // contains an unresolvable column, instead of silently dropping
+  // the column and producing a partial model. This mirrors the
+  // reproduction in the issue body.
+  cleanup_partial_view()
+
+  let yaml_path = "test/fixtures/partial_view.yaml"
+  let content =
+    "version: \"2\"\n"
+    <> "sql:\n"
+    <> "  - engine: postgresql\n"
+    <> "    schema: test/fixtures/partial_view_schema.sql\n"
+    <> "    queries: test/fixtures/partial_view_query.sql\n"
+    <> "    gen:\n"
+    <> "      gleam:\n"
+    <> "        out: "
+    <> partial_view_out
+    <> "\n"
+  let assert Ok(_) = simplifile.write(yaml_path, content)
+
+  let assert Ok(cfg) = config.load(yaml_path)
+  let assert [block] = cfg.sql
+  // Sanity-check: the configuration must have picked up the strict
+  // default even though the YAML does not mention strict_views.
+  block.gleam.strict_views |> should.equal(True)
+
+  case generate.generate_config(cfg) {
+    Error(generate.SchemaParseError(detail)) -> {
+      string.contains(detail, "broken_col") |> should.be_true
+    }
+    Error(other) ->
+      panic as {
+        "expected SchemaParseError for partial view, got "
+        <> string.inspect(other)
+      }
+    Ok(_) ->
+      panic as "expected generation to fail on partial view with default policy"
+  }
+
+  let _ = simplifile.delete(yaml_path)
+  cleanup_partial_view()
+}
+
+pub fn strict_views_false_still_accepts_partial_view_test() {
+  // Opt-out still works: users who explicitly set
+  // `strict_views: false` get the legacy warn-and-continue behaviour
+  // for migrating legacy schemas that produce resolution warnings.
+  cleanup_partial_view()
+  let cfg = model.Config(version: 2, sql: [partial_view_block(False)])
+  let assert Ok(_) = generate.generate_config(cfg)
+  cleanup_partial_view()
 }
 
 // --- vendor_runtime failure test ---


### PR DESCRIPTION
## Summary
- \`strict_views\` is now the default view-resolution policy. A config that doesn't mention \`strict_views\` refuses to emit a model when any view column cannot be resolved, instead of warning to stderr and continuing with a partial catalog.
- \`strict_views: false\` is still accepted as an explicit opt-out for legacy schemas that need the old warn-and-continue behaviour.

## Changes
- \`src/sqlode/config.gleam\` — default \`strict_views\` to \`True\` in \`parse_sql_block\`, with a comment anchoring the new policy.
- \`src/sqlode/model.gleam\` — rewrite the \`strict_views\` doc comment to describe the default and the opt-out.
- \`test/fixtures/partial_view_{schema,query}.sql\` — fixture pair mirroring the reproduction in Issue #391 (a view whose last column references an unknown source).
- \`test/generate_test.gleam\`
  - \`strict_views_is_default_for_partial_view_test\` — loads a YAML configuration that does not set \`strict_views\` and asserts the schema default, then asserts that generation fails with a \`SchemaParseError\` naming the unresolved column.
  - \`strict_views_false_still_accepts_partial_view_test\` — proves the explicit opt-out still produces a catalog for the resolvable parts so users with legacy schemas can migrate in their own time.
- \`test/config_test.gleam\` — rename \`default_strict_views_is_false_test\` to \`default_strict_views_is_true_test\` and invert the assertion so the default is pinned in config-level tests too.
- \`README.md\` — rewrite the \"View resolution\" section to lead with the strict default and document \`strict_views: false\` as the escape hatch.

## Design decisions
- The \`strict_views\` flag is kept rather than removed/renamed. After the default is tightened it still adds value as the sole opt-out for users with legacy schemas that produce resolution warnings; removing it would force a hard upgrade, and renaming (e.g. to \`lenient_views\`) would churn YAML config for every existing user. Keeping the name and flipping the default is the minimum user-visible change that enforces the new policy.
- The regression asserts on a config parsed from YAML (not a hand-built \`Config\`) to make sure the default genuinely flows through \`config.parse_sql_block\`, not just the model record default.

## Test plan
- [x] \`gleam format --check src/ test/\`
- [x] \`gleam check\`
- [x] \`gleam build --warnings-as-errors\`
- [x] \`gleam test\` (861 passed, 0 failures)
- [x] \`shellspec\` (20 examples, 0 failures)
- [x] \`strict_views_is_default_for_partial_view_test\` proves the new default fails on the issue's reproduction; \`strict_views_false_still_accepts_partial_view_test\` proves the opt-out still works.

Closes #391