### PR TITLE
feat: generate prepare_<query> function-first helpers (#394)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,36 @@ pub fn list_authors() -> runtime.RawQuery(Nil) { ... }
 pub fn create_author() -> runtime.RawQuery(params.CreateAuthorParams) { ... }
 ```
 
-Usage example — always use `runtime.prepare` to execute parameterized queries.
-The generated SQL contains engine-agnostic markers for all parameter types
-(`sqlode.arg`, `sqlode.narg`, and `sqlode.slice`), and `runtime.prepare`
-substitutes the correct engine-specific placeholders at runtime:
+Usage example — for the common case, use the generated
+`prepare_<function_name>` helper. It constructs the params record
+and delegates to `runtime.prepare` in a single call, returning the
+`(sql, values)` pair that Gleam database drivers consume directly:
+
+```gleam
+let #(sql, values) = queries.prepare_get_author(id: 1)
+// sql has final placeholders: "... WHERE id = $1"
+// values is the encoded parameter list
+```
+
+The generated SQL contains engine-agnostic markers for all parameter
+types (`sqlode.arg`, `sqlode.narg`, and `sqlode.slice`), and the
+helper substitutes the correct engine-specific placeholders at
+runtime.
+
+Slice parameters (`sqlode.slice`) work the same way — the helper
+accepts a `List` for each slice field and the generated SQL expands
+it into the correct number of placeholders:
+
+```gleam
+let #(sql, values) = queries.prepare_get_authors_by_ids(ids: [1, 2, 3])
+// sql has expanded placeholders: "... WHERE id IN ($1, $2, $3)"
+// values is the flattened parameter list
+```
+
+If you need to hold the `RawQuery` descriptor (for caching, batch
+execution, or building custom wrappers), the low-level pieces are
+still exported. `queries.get_author()` returns the descriptor and
+`runtime.prepare` composes it with a params record:
 
 ```gleam
 let q = queries.get_author()
@@ -208,21 +234,6 @@ let #(sql, values) = runtime.prepare(
   q,
   params.GetAuthorParams(id: 1),
 )
-// sql has final placeholders: "... WHERE id = $1"
-// values is the encoded parameter list
-```
-
-For queries using `sqlode.slice()`, `runtime.prepare` additionally expands
-slice parameters into the correct number of placeholders:
-
-```gleam
-let q = queries.get_authors_by_ids()
-let #(sql, values) = runtime.prepare(
-  q,
-  params.GetAuthorsByIdsParams(ids: [1, 2, 3]),
-)
-// sql has expanded placeholders: "... WHERE id IN ($1, $2, $3)"
-// values is the flattened parameter list
 ```
 
 The placeholder dialect (`$1` for PostgreSQL, `?` for SQLite) is baked into the `RawQuery` by the generator, so `runtime.prepare` does not take a placeholder argument.

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -34,6 +34,18 @@ pub fn render(
     ))
     |> string.join("\n\n")
 
+  // Function-first convenience wrappers. For each generated query
+  // descriptor, emit a `prepare_<function_name>(...)` helper that
+  // constructs the params record inline and returns the pair that
+  // Gleam database drivers consume directly — collapsing the
+  // three-step "descriptor + params constructor + runtime.prepare"
+  // composition into a single call at the use site (Issue #394).
+  let prepare_functions =
+    queries
+    |> list.map(render_prepare_function(naming_ctx, _, gleam.type_mapping))
+    |> list.filter(fn(s) { s != "" })
+    |> string.join("\n\n")
+
   let all_items = case queries {
     [] -> "[]"
     _ ->
@@ -66,15 +78,18 @@ pub fn render(
 
   let has_decoders = !list.is_empty(decoder_queries)
   let has_nullable =
-    has_decoders
-    && list.any(decoder_queries, fn(q) {
-      list.any(q.result_columns, fn(col) {
-        case col {
-          model.ScalarResult(model.ResultColumn(nullable: True, ..)) -> True
-          _ -> False
-        }
+    {
+      has_decoders
+      && list.any(decoder_queries, fn(q) {
+        list.any(q.result_columns, fn(col) {
+          case col {
+            model.ScalarResult(model.ResultColumn(nullable: True, ..)) -> True
+            _ -> False
+          }
+        })
       })
-    })
+    }
+    || list.any(queries, fn(q) { list.any(q.params, fn(p) { p.nullable }) })
 
   let imports =
     list.flatten([
@@ -118,6 +133,10 @@ pub fn render(
         "",
         query_functions,
       ],
+      case prepare_functions {
+        "" -> []
+        _ -> ["", prepare_functions]
+      },
       case decoder_functions {
         "" -> []
         _ -> ["", decoder_functions]
@@ -204,6 +223,81 @@ fn render_query_function(
     ]),
     "\n",
   )
+}
+
+/// Emit a `prepare_<function_name>` convenience wrapper that
+/// constructs the generated params record inline (for parameterised
+/// queries) or passes `Nil` (for parameterless queries) and then
+/// returns `runtime.prepare(…)` directly. Callers consume the
+/// `#(sql, values)` tuple without composing the descriptor, params
+/// record and `runtime.prepare` call by hand.
+fn render_prepare_function(
+  naming_ctx: naming.NamingContext,
+  query: model.AnalyzedQuery,
+  type_mapping: model.TypeMapping,
+) -> String {
+  let type_name = naming.to_pascal_case(naming_ctx, query.base.name) <> "Params"
+  let descriptor_call = query.base.function_name <> "()"
+  case query.params {
+    [] ->
+      string.join(
+        [
+          "pub fn prepare_"
+            <> query.base.function_name
+            <> "() -> #(String, List(runtime.Value)) {",
+          "  runtime.prepare(" <> descriptor_call <> ", Nil)",
+          "}",
+        ],
+        "\n",
+      )
+    params -> {
+      let arg_list =
+        params
+        |> list.map(fn(p) {
+          p.field_name <> ": " <> param_arg_type(p, type_mapping)
+        })
+        |> string.join(", ")
+      let constructor_args =
+        params
+        |> list.map(fn(p) { p.field_name <> ": " <> p.field_name })
+        |> string.join(", ")
+      string.join(
+        [
+          "pub fn prepare_"
+            <> query.base.function_name
+            <> "("
+            <> arg_list
+            <> ") -> #(String, List(runtime.Value)) {",
+          "  runtime.prepare(",
+          "    " <> descriptor_call <> ",",
+          "    params." <> type_name <> "(" <> constructor_args <> "),",
+          "  )",
+          "}",
+        ],
+        "\n",
+      )
+    }
+  }
+}
+
+/// Render the Gleam type of a single parameter for a `prepare_*`
+/// argument position. Mirrors the type used in the `Params` record
+/// field: base type, optionally wrapped in `Option(…)` when the
+/// parameter is nullable or `List(…)` when it is a slice.
+fn param_arg_type(
+  param: model.QueryParam,
+  type_mapping: model.TypeMapping,
+) -> String {
+  let base =
+    type_mapping.scalar_type_to_gleam_type(param.scalar_type, type_mapping)
+  case param.is_list {
+    True -> "List(" <> base <> ")"
+    False ->
+      case param.nullable {
+        True -> "Option(" <> base <> ")"
+        False -> base
+      }
+  }
 }
 
 fn has_result_columns(query: model.AnalyzedQuery) -> Bool {

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -54,6 +54,38 @@ pub fn render_queries_module_test() {
   |> should.be_true()
 }
 
+pub fn render_prepare_helpers_test() {
+  // Function-first wrapper (Issue #394): the generated module should
+  // expose `prepare_<function_name>(...)` helpers that construct the
+  // params record inline and return the `(sql, values)` pair, so the
+  // common call site is a single function call instead of descriptor
+  // + params constructor + runtime.prepare composition.
+  let naming_ctx = naming.new()
+  let block = test_block()
+  let analyzed = analyzed_queries("test/fixtures/query.sql")
+  let rendered = queries.render(naming_ctx, block, analyzed, dict.new(), False)
+
+  // Parameterised query — arg list mirrors the params record fields.
+  string.contains(
+    rendered,
+    "pub fn prepare_get_author(id: Int) -> #(String, List(runtime.Value)) {",
+  )
+  |> should.be_true()
+  string.contains(rendered, "runtime.prepare(")
+  |> should.be_true()
+  string.contains(rendered, "params.GetAuthorParams(id: id),")
+  |> should.be_true()
+
+  // Parameterless query — no arguments, passes Nil to runtime.prepare.
+  string.contains(
+    rendered,
+    "pub fn prepare_list_authors() -> #(String, List(runtime.Value)) {",
+  )
+  |> should.be_true()
+  string.contains(rendered, "runtime.prepare(list_authors(), Nil)")
+  |> should.be_true()
+}
+
 pub fn render_params_module_test() {
   let naming_ctx = naming.new()
   let analyzed = analyzed_queries("test/fixtures/query.sql")


### PR DESCRIPTION
## Summary
- Emit a `prepare_<function_name>(...)` convenience wrapper in the generated `queries` module for every query. The wrapper constructs the generated params record inline and delegates to `runtime.prepare`, returning the `#(sql, values)` pair that Gleam database drivers consume directly.
- Collapses the common call site from *descriptor + params constructor + \`runtime.prepare\`* (three pieces stitched by hand) to a single function call.
- Preserves the low-level API for advanced users who need the `RawQuery` descriptor for caching, batch execution, or custom wrappers.

## Changes
- `src/sqlode/codegen/queries.gleam`
  - Add `render_prepare_function` covering both parameterised (inline params record construction) and parameterless (`Nil`) queries.
  - Generated parameter Gleam types mirror the existing params record: base type, `Option(…)` for nullable params, `List(…)` for slice params.
  - Extend `has_nullable` so the generated `queries` module imports `gleam/option.{type Option}` whenever the new helpers need it for argument types, not only for decoders.
- `test/codegen_test.gleam` — add `render_prepare_helpers_test` that asserts on the emitted signatures and bodies for both a parameterised query (`GetAuthor`) and a parameterless one (`ListAuthors`).
- `README.md` — rewrite the "Usage example" section to lead with `queries.prepare_get_author(id: 1)` as the recommended pattern, keep the slice-parameter example, and document the lower-level descriptor + `runtime.prepare` composition as the escape hatch.

## Design decisions
- Helpers live in `queries.gleam` rather than a new module so there is one import to wire into downstream code and no new generated file to maintain. The lower-level `<function_name>()` descriptor functions are kept unchanged, so this PR is purely additive on the generated surface.
- Argument names match the params record field names (`id: Int`, `team_ids: List(Int)`, `deleted_at: Option(DateTime)`, …). That means the helper call site reads the same as the record constructor, which keeps the mental model aligned with the lower-level API for users who mix both styles.
- No new flag gates the feature — emitting a tiny convenience function has no runtime cost for users who don't call it, and having it always available prevents generated projects from diverging on what the \"standard\" helper looks like.

## Test plan
- [x] \`gleam format --check src/ test/\`
- [x] \`gleam check\`
- [x] \`gleam build --warnings-as-errors\`
- [x] \`gleam test\` (862 passed, 0 failures)
- [x] \`shellspec\` (20 examples, 0 failures)
- [x] \`render_prepare_helpers_test\` pins the emitted signatures for the two shapes (parameterised + parameterless).

Closes #394