### PR TITLE
feat: add sqlode verify static verification lane (#395)

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,12 +700,61 @@ For example, a table named `authors` generates `pub type Authors { ... }` instea
 ```
 # Standalone escript
 sqlode generate [--config=./sqlode.yaml]
-sqlode init [--output=./sqlode.yaml]
+sqlode verify   [--config=./sqlode.yaml]
+sqlode init     [--output=./sqlode.yaml]
 
 # Via Gleam
 gleam run -m sqlode -- generate [--config=./sqlode.yaml]
-gleam run -m sqlode -- init [--output=./sqlode.yaml]
+gleam run -m sqlode -- verify   [--config=./sqlode.yaml]
+gleam run -m sqlode -- init     [--output=./sqlode.yaml]
 ```
+
+### `sqlode verify`
+
+`verify` is the static verification lane for CI. It loads the
+project the same way `generate` would — schema parsing, query
+parsing, analyser pass — but does not write files and collects
+every failure it can see into a single report instead of
+short-circuiting on the first error.
+
+```
+$ sqlode verify
+Verifying config: sqlode.yaml
+[src/db] query "FilterAuthors" has 4 inferred parameter(s), exceeds query_parameter_limit 3
+```
+
+The command exits non-zero when at least one finding is reported,
+so it can gate generation in CI:
+
+```yaml
+- run: sqlode verify
+- run: sqlode generate
+```
+
+Per-block policies that influence `verify`:
+
+- `strict_views` — view-resolution warnings are promoted to
+  findings (the same policy `generate` uses).
+- `query_parameter_limit` — per-query cap on inferred parameters,
+  mirroring the sqlc setting of the same name. Unset means no
+  limit.
+
+### Verification roadmap
+
+`verify` today covers the static phase of Issue #395. Later phases
+are expected to layer on:
+
+1. **Static analysis (shipped).** The current command: schema +
+   query parsing, full analyser pass, `query_parameter_limit`.
+2. **DB-backed analysis.** A `database` / `analyzer` config concept
+   that runs queries through `EXPLAIN` (or equivalent) against a
+   real database to catch mistakes the local analyser cannot, such
+   as view drift or engine-specific typing.
+3. **Execution-lane validation.** Running generated code against
+   an ephemeral test database as part of the verify command.
+
+Each phase is additive: new findings show up in the existing
+`Report` without breaking the CLI contract.
 
 ## Migrating from sqlc
 
@@ -717,7 +766,7 @@ sqlode follows sqlc conventions, so most SQL files work without changes. Key dif
 | Config | `sqlc.yaml` / `sqlc.json` | `sqlode.yaml` (v2 format only), also accepts `sqlc.yaml` / `sqlc.yml` / `sqlc.json` on autodiscovery |
 | Generate | `sqlc generate` | `sqlode generate` |
 | Init | `sqlc init` | `sqlode init` |
-| Vet/Verify | `sqlc vet`, `sqlc verify` | Not supported |
+| Vet/Verify | `sqlc vet`, `sqlc verify` | `sqlode verify` (static analysis + `query_parameter_limit`); DB-backed analyser is on the [verification roadmap](#verification-roadmap) |
 | Target language | Go, Python, Kotlin, etc. | Gleam |
 | Runtime | Generated code is self-contained | Generated code imports `sqlode/runtime` by default; set `vendor_runtime: true` to vendor a copy and drop the runtime dependency (see [Self-contained generation](#self-contained-generation-vendor_runtime)) |
 

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -44,6 +44,20 @@ Describe 'sqlode CLI'
     End
   End
 
+  Describe 'verify command'
+    It 'fails when config file does not exist'
+      When run verify_cmd --config=nonexistent.yaml
+      The status should be failure
+      The output should include 'Config file not found'
+    End
+
+    It 'fails with invalid config'
+      When run verify_cmd --config=test/fixtures/malformed.yaml
+      The status should be failure
+      The output should include 'Error'
+    End
+  End
+
   Describe 'version command'
     It 'outputs the version string'
       When run version_cmd

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -15,6 +15,10 @@ generate() {
   cd "$PROJECT_ROOT" && gleam run -- generate "$@" 2>&1
 }
 
+verify_cmd() {
+  cd "$PROJECT_ROOT" && gleam run -- verify "$@" 2>&1
+}
+
 clean_test_output() {
   rm -rf "$TEST_OUTPUT_DIR"
 }

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -7,6 +7,7 @@ import gleam/string
 import glint
 import simplifile
 import sqlode/generate
+import sqlode/verify
 import sqlode/version
 
 pub fn app() -> glint.Glint(Nil) {
@@ -16,6 +17,7 @@ pub fn app() -> glint.Glint(Nil) {
   |> glint.pretty_help(glint.default_pretty_help())
   |> glint.add(at: ["generate"], do: generate_command())
   |> glint.add(at: ["init"], do: init_command())
+  |> glint.add(at: ["verify"], do: verify_command())
   |> glint.add(at: ["version"], do: version_command())
 }
 
@@ -24,11 +26,13 @@ fn global_help_text() -> String {
 
 Usage:
   sqlode generate [--config=<path>]
+  sqlode verify [--config=<path>]
   sqlode init [--output=./sqlode.yaml] [--engine=postgresql|sqlite|mysql] [--runtime=raw|native]
   sqlode version
 
-Without --config, generate auto-discovers sqlode.yaml, sqlode.yml,
-sqlc.yaml, sqlc.yml, or sqlc.json in the current directory.
+Without --config, generate/verify auto-discovers sqlode.yaml,
+sqlode.yml, sqlc.yaml, sqlc.yml, or sqlc.json in the current
+directory.
 
 Run `sqlode <command> --help` for details on each command."
 }
@@ -109,6 +113,65 @@ Examples:
         })
       },
     )
+  }
+}
+
+fn verify_command() -> glint.Command(Nil) {
+  {
+    use config_path <- glint.flag(
+      glint.string_flag("config")
+      |> glint.flag_default("")
+      |> glint.flag_help(
+        "Path to config file. Default: auto-discover sqlode.yaml, sqlode.yml, sqlc.yaml, sqlc.yml, or sqlc.json in the current directory.",
+      ),
+    )
+
+    glint.command_help(
+      "Run static verification on the project without writing files.
+
+Loads the config, parses every schema and query the generator would
+use, and runs the full analyser pass. Any query-analysis error,
+schema warning under strict_views, or policy violation (for example
+`query_parameter_limit`) is collected into a single report.
+
+The command exits non-zero when at least one finding is reported —
+suitable for CI gates before the generation step runs.
+
+Examples:
+  sqlode verify
+  sqlode verify --config=./custom.yaml",
+      fn() {
+        glint.command(fn(_named_args, _args, flags) {
+          let flag_value = config_path(flags) |> result.unwrap("")
+          run_verify(flag_value)
+        })
+      },
+    )
+  }
+}
+
+fn run_verify(flag_value: String) -> Nil {
+  case resolve_config_path(flag_value) {
+    Error(message) -> {
+      io.println_error("Error: " <> message)
+      halt(1)
+    }
+    Ok(config_path) -> {
+      io.println("Verifying config: " <> config_path)
+      case verify.run(config_path) {
+        Error(err) -> {
+          io.println_error("Error: " <> verify.error_to_string(err))
+          halt(1)
+        }
+        Ok(report) -> {
+          io.println(verify.report_to_string(report))
+          case report.findings {
+            [] -> Nil
+            _ -> halt(1)
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/sqlode/config.gleam
+++ b/src/sqlode/config.gleam
@@ -120,7 +120,7 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
     [
       "out", "runtime", "type_mapping", "emit_sql_as_comment",
       "emit_exact_table_names", "omit_unused_models", "vendor_runtime",
-      "strict_views",
+      "strict_views", "query_parameter_limit",
     ],
     "sql.gen.gleam.",
   ))
@@ -176,6 +176,11 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
   let strict_views =
     optional_bool(gleam_node, "strict_views")
     |> option.unwrap(True)
+  // `query_parameter_limit` mirrors the sqlc setting of the same
+  // name and is surfaced by `sqlode verify`. Unset means no limit;
+  // any non-positive value is ignored so misconfiguration doesn't
+  // silently reject every query.
+  let query_parameter_limit = optional_int(gleam_node, "query_parameter_limit")
 
   use overrides <- result.try(parse_overrides(node))
 
@@ -193,6 +198,7 @@ fn parse_sql_block(node: yay.Node) -> Result(model.SqlBlock, ConfigError) {
       omit_unused_models:,
       vendor_runtime:,
       strict_views:,
+      query_parameter_limit:,
     ),
     overrides:,
   ))
@@ -389,6 +395,18 @@ fn optional_bool(node: yay.Node, selector: String) -> Option(Bool) {
     Ok(yay.NodeStr("true")) -> Some(True)
     Ok(yay.NodeStr("false")) -> Some(False)
     Ok(yay.NodeBool(value)) -> Some(value)
+    _ -> None
+  }
+}
+
+fn optional_int(node: yay.Node, selector: String) -> Option(Int) {
+  case yay.select_sugar(from: node, selector:) {
+    Ok(yay.NodeStr(text)) ->
+      case int.parse(text) {
+        Ok(n) -> Some(n)
+        Error(_) -> None
+      }
+    Ok(yay.NodeInt(value)) -> Some(value)
     _ -> None
   }
 }

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -118,6 +118,11 @@ pub type GleamOutput {
     /// the real database. Set to False explicitly to restore the
     /// legacy warn-and-continue behaviour for legacy schemas.
     strict_views: Bool,
+    /// When `Some(n)`, `sqlode verify` rejects any analysed query
+    /// whose inferred parameter count exceeds `n`. `None` disables
+    /// the check. Named after the sqlc setting of the same name so
+    /// migrating users can port the config directly.
+    query_parameter_limit: option.Option(Int),
   )
 }
 

--- a/src/sqlode/verify.gleam
+++ b/src/sqlode/verify.gleam
@@ -1,0 +1,238 @@
+//// `sqlode verify` — static, read-only verification lane.
+////
+//// `generate` stops at the first error it encounters so codegen can
+//// still produce useful output for a partially-working project.
+//// `verify` is the opposite: it walks every block in the config,
+//// runs the same schema parsing and query analysis the generator
+//// uses, collects every failure it can see, and layers additional
+//// static checks on top (today: `query_parameter_limit`
+//// enforcement). It never writes files.
+////
+//// The command is intended as the first phase of the Issue #395
+//// verification roadmap — later phases will add DB-backed analysis
+//// (`database` / `analyzer` config concepts) and execution-lane
+//// validation. Keeping the static surface here means those later
+//// phases can grow `Finding` with new variants without reshaping
+//// the command wiring.
+
+import filepath
+import gleam/int
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import gleam/string
+import simplifile
+import sqlode/config
+import sqlode/model
+import sqlode/naming
+import sqlode/query_analyzer
+import sqlode/query_ir
+import sqlode/query_parser
+import sqlode/schema_parser
+
+/// Outcome of a single verification pass. A report with an empty
+/// `findings` list means every block in the config parsed, analysed
+/// and satisfied the configured static policies.
+pub type Report {
+  Report(findings: List(Finding))
+}
+
+/// One concrete problem the verifier found. `block_out` names the
+/// `sql.gen.gleam.out` of the block the finding applies to so
+/// reports with multiple blocks stay attributable without inventing
+/// a synthetic block identity.
+pub type Finding {
+  Finding(block_out: String, detail: String)
+}
+
+pub type VerifyError {
+  ConfigError(config.ConfigError)
+}
+
+/// Entry point. Loads the config at `config_path`, resolves relative
+/// paths the same way `generate.run` does, and returns a report.
+/// The result is `Ok(Report)` even when the project has problems —
+/// only unrecoverable errors (missing config, YAML syntax errors)
+/// surface as `Error`.
+pub fn run(config_path: String) -> Result(Report, VerifyError) {
+  use cfg <- result.try(
+    config.load(config_path)
+    |> result.map_error(ConfigError),
+  )
+  let base_dir = filepath.directory_name(config_path)
+  let resolved = resolve_paths(cfg, base_dir)
+  Ok(verify_config(resolved))
+}
+
+/// Verify an already-loaded and path-resolved `model.Config`. Broken
+/// out so tests can build a config value directly and assert against
+/// the findings list without touching the filesystem.
+pub fn verify_config(cfg: model.Config) -> Report {
+  let naming_ctx = naming.new()
+  let findings =
+    list.flat_map(cfg.sql, fn(block) { verify_block(naming_ctx, block) })
+  Report(findings: findings)
+}
+
+fn verify_block(
+  naming_ctx: naming.NamingContext,
+  block: model.SqlBlock,
+) -> List(Finding) {
+  let out = block.gleam.out
+  case load_catalog(block) {
+    Error(detail) -> [Finding(block_out: out, detail: detail)]
+    Ok(catalog) ->
+      case load_and_analyze(naming_ctx, block, catalog) {
+        Error(detail) -> [Finding(block_out: out, detail: detail)]
+        Ok(analyzed) ->
+          enforce_query_parameter_limit(
+            out,
+            analyzed,
+            block.gleam.query_parameter_limit,
+          )
+      }
+  }
+}
+
+// ============================================================
+// Schema / query pipeline (read-only mirror of generate.load_*)
+// ============================================================
+
+fn load_catalog(block: model.SqlBlock) -> Result(model.Catalog, String) {
+  use entries <- result.try(read_files(block.schema))
+  case schema_parser.parse_files_with_engine(entries, block.engine) {
+    Ok(#(catalog, warnings)) ->
+      case block.gleam.strict_views, warnings {
+        True, [_, ..] -> {
+          let formatted =
+            warnings
+            |> list.map(schema_parser.warning_to_string)
+            |> string.join("\n  ")
+          Error("strict_views policy rejects the schema:\n  " <> formatted)
+        }
+        _, _ -> Ok(catalog)
+      }
+    Error(error) -> Error(schema_parser.error_to_string(error))
+  }
+}
+
+fn load_and_analyze(
+  naming_ctx: naming.NamingContext,
+  block: model.SqlBlock,
+  catalog: model.Catalog,
+) -> Result(List(model.AnalyzedQuery), String) {
+  use entries <- result.try(read_files(block.queries))
+  use queries <- result.try(parse_all_queries(entries, block.engine, naming_ctx))
+  query_analyzer.analyze_queries(block.engine, catalog, naming_ctx, queries)
+  |> result.map_error(query_analyzer.analysis_error_to_string)
+}
+
+fn parse_all_queries(
+  entries: List(#(String, String)),
+  engine: model.Engine,
+  naming_ctx: naming.NamingContext,
+) -> Result(List(query_ir.TokenizedQuery), String) {
+  entries
+  |> list.try_fold([], fn(acc, entry) {
+    let #(path, content) = entry
+    case query_parser.parse_file(path, engine, naming_ctx, content) {
+      Ok(qs) -> Ok(list.append(acc, qs))
+      Error(err) -> Error(path <> ": " <> query_parser.error_to_string(err))
+    }
+  })
+}
+
+fn read_files(paths: List(String)) -> Result(List(#(String, String)), String) {
+  paths
+  |> list.try_map(fn(path) {
+    case simplifile.read(path) {
+      Ok(content) -> Ok(#(path, content))
+      Error(reason) -> Error(path <> ": " <> simplifile.describe_error(reason))
+    }
+  })
+}
+
+// ============================================================
+// Static policies
+// ============================================================
+
+fn enforce_query_parameter_limit(
+  block_out: String,
+  queries: List(model.AnalyzedQuery),
+  limit: Option(Int),
+) -> List(Finding) {
+  case limit {
+    None -> []
+    Some(n) ->
+      case n <= 0 {
+        True -> []
+        False ->
+          list.filter_map(queries, fn(q) {
+            let count = list.length(q.params)
+            case count > n {
+              True ->
+                Ok(Finding(
+                  block_out: block_out,
+                  detail: "query \""
+                    <> q.base.name
+                    <> "\" has "
+                    <> int.to_string(count)
+                    <> " inferred parameter(s), exceeds query_parameter_limit "
+                    <> int.to_string(n),
+                ))
+              False -> Error(Nil)
+            }
+          })
+      }
+  }
+}
+
+// ============================================================
+// Path resolution and reporting
+// ============================================================
+
+fn resolve_paths(cfg: model.Config, base_dir: String) -> model.Config {
+  let sql =
+    list.map(cfg.sql, fn(block) {
+      let schema = list.map(block.schema, resolve_path(base_dir, _))
+      let queries = list.map(block.queries, resolve_path(base_dir, _))
+      let gleam =
+        model.GleamOutput(
+          ..block.gleam,
+          out: resolve_path(base_dir, block.gleam.out),
+        )
+      model.SqlBlock(..block, schema: schema, queries: queries, gleam: gleam)
+    })
+  model.Config(..cfg, sql: sql)
+}
+
+fn resolve_path(base_dir: String, path: String) -> String {
+  case filepath.is_absolute(path) {
+    True -> path
+    False ->
+      case filepath.expand(filepath.join(base_dir, path)) {
+        Ok(expanded) -> expanded
+        Error(_) -> filepath.join(base_dir, path)
+      }
+  }
+}
+
+pub fn report_to_string(report: Report) -> String {
+  case report.findings {
+    [] -> "All checks passed."
+    findings ->
+      findings
+      |> list.map(format_finding)
+      |> string.join("\n")
+  }
+}
+
+fn format_finding(finding: Finding) -> String {
+  "[" <> finding.block_out <> "] " <> finding.detail
+}
+
+pub fn error_to_string(error: VerifyError) -> String {
+  case error {
+    ConfigError(inner) -> config.error_to_string(inner)
+  }
+}

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -231,6 +231,7 @@ pub fn render_sqlight_adapter_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -300,6 +301,7 @@ pub fn render_pog_adapter_slice_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -339,6 +341,7 @@ pub fn render_sqlight_adapter_slice_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -501,6 +504,7 @@ pub fn render_adapter_uses_table_constructor_for_match_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -547,6 +551,7 @@ fn test_block() -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -567,6 +572,7 @@ fn test_block_native() -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -651,6 +657,7 @@ pub fn render_enum_decoder_uses_decode_then_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -724,6 +731,7 @@ pub fn render_pog_adapter_enum_slice_converts_to_string_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -778,6 +786,7 @@ pub fn render_sqlight_adapter_enum_slice_converts_to_string_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -939,6 +948,7 @@ fn readme_test_block() -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1059,6 +1069,7 @@ pub fn render_pog_adapter_with_array_columns_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )

--- a/test/complex_sql_test.gleam
+++ b/test/complex_sql_test.gleam
@@ -76,6 +76,7 @@ fn test_block(queries_path: String) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )

--- a/test/fixtures/verify_ok_query.sql
+++ b/test/fixtures/verify_ok_query.sql
@@ -1,0 +1,6 @@
+-- Two well-typed queries, both under any realistic parameter limit.
+-- name: GetAuthor :one
+SELECT id, name FROM authors WHERE id = $1;
+
+-- name: ListAuthors :many
+SELECT id, name FROM authors ORDER BY name;

--- a/test/fixtures/verify_ok_schema.sql
+++ b/test/fixtures/verify_ok_schema.sql
@@ -1,0 +1,5 @@
+-- Schema for the "verify reports no findings" smoke test.
+CREATE TABLE authors (
+  id BIGINT PRIMARY KEY NOT NULL,
+  name TEXT NOT NULL
+);

--- a/test/fixtures/verify_over_limit_query.sql
+++ b/test/fixtures/verify_over_limit_query.sql
@@ -1,0 +1,6 @@
+-- Query with three parameters — used to exercise the
+-- query_parameter_limit policy in sqlode verify.
+-- name: FilterAuthors :many
+SELECT id, name
+FROM authors
+WHERE id = $1 AND name = $2 AND id = $3;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -29,6 +29,7 @@ fn base_block(overrides: model.Overrides) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: overrides,
   )
@@ -287,6 +288,7 @@ pub fn module_qualified_custom_type_in_params_generates_import_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.Overrides(
         type_overrides: [
@@ -369,6 +371,7 @@ pub fn rich_type_mapping_emits_semantic_aliases_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -409,6 +412,7 @@ pub fn strong_type_mapping_emits_wrapper_types_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -492,6 +496,7 @@ pub fn exact_table_match_produces_alias_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -645,6 +650,7 @@ fn join_rename_block(renames: List(model.ColumnRename)) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.Overrides(type_overrides: [], column_renames: renames),
   )
@@ -796,6 +802,7 @@ fn nullable_block(overrides: model.Overrides) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: overrides,
   )
@@ -904,6 +911,7 @@ fn all_commands_block(
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1040,6 +1048,7 @@ pub fn run_with_missing_schema_file_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1067,6 +1076,7 @@ pub fn run_with_missing_query_file_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1095,6 +1105,7 @@ pub fn run_with_no_queries_in_file_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1123,6 +1134,7 @@ pub fn execresult_rejected_on_native_runtime_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1150,6 +1162,7 @@ pub fn execresult_allowed_on_raw_runtime_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1176,6 +1189,7 @@ fn unsupported_annotation_block(query_file: String) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1240,6 +1254,7 @@ fn compound_block() -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1322,6 +1337,7 @@ fn view_block() -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1401,6 +1417,7 @@ pub fn invalid_out_path_rejected_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1435,6 +1452,7 @@ pub fn accept_directory_for_schema_and_queries_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1467,6 +1485,7 @@ pub fn mixed_file_and_directory_inputs_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1495,6 +1514,7 @@ pub fn reject_empty_schema_directory_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1523,6 +1543,7 @@ pub fn reject_empty_query_directory_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1553,6 +1574,7 @@ pub fn reject_duplicate_query_names_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1584,6 +1606,7 @@ pub fn emit_sql_as_comment_includes_sql_in_output_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1627,6 +1650,7 @@ pub fn emit_exact_table_names_skips_singularization_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1672,6 +1696,7 @@ fn multi_table_block(omit_unused_models: Bool) -> model.SqlBlock {
       omit_unused_models: omit_unused_models,
       vendor_runtime: False,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1724,6 +1749,7 @@ fn vendor_runtime_block(vendor_runtime: Bool) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: vendor_runtime,
       strict_views: False,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1791,6 +1817,7 @@ fn strict_views_block(strict_views: Bool) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: strict_views,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1846,6 +1873,7 @@ fn partial_view_block(strict_views: Bool) -> model.SqlBlock {
       omit_unused_models: False,
       vendor_runtime: False,
       strict_views: strict_views,
+      query_parameter_limit: option.None,
     ),
     overrides: model.empty_overrides(),
   )
@@ -1930,6 +1958,7 @@ pub fn vendor_runtime_fails_when_source_not_found_test() {
         omit_unused_models: False,
         vendor_runtime: True,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )
@@ -1961,6 +1990,7 @@ pub fn sqlite_array_param_rejected_test() {
         omit_unused_models: False,
         vendor_runtime: False,
         strict_views: False,
+        query_parameter_limit: option.None,
       ),
       overrides: model.empty_overrides(),
     )

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -1,0 +1,146 @@
+//// Tests for the `sqlode verify` static verification lane
+//// introduced for Issue #395.
+////
+//// Covers the three observable behaviours of the command:
+////
+//// 1. A healthy project produces a `Report` with no findings.
+//// 2. A query with more parameters than `query_parameter_limit`
+////    produces one finding that names the query and the limit.
+//// 3. An analysis error (unknown table) is surfaced as a finding
+////    instead of short-circuiting, so a CI gate can see every
+////    problem in one run.
+
+import gleam/list
+import gleam/option
+import gleam/string
+import gleeunit
+import gleeunit/should
+import sqlode/model
+import sqlode/verify
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn make_block(
+  schema_path: String,
+  query_path: String,
+  out: String,
+  query_parameter_limit: option.Option(Int),
+) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: model.PostgreSQL,
+    schema: [schema_path],
+    queries: [query_path],
+    gleam: model.GleamOutput(
+      out: out,
+      runtime: model.Raw,
+      type_mapping: model.StringMapping,
+      emit_sql_as_comment: False,
+      emit_exact_table_names: False,
+      omit_unused_models: False,
+      vendor_runtime: False,
+      strict_views: False,
+      query_parameter_limit: query_parameter_limit,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+pub fn verify_healthy_project_produces_no_findings_test() {
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_ok_query.sql",
+        "src/verify_ok_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  report.findings |> should.equal([])
+}
+
+pub fn verify_rejects_query_over_parameter_limit_test() {
+  // FilterAuthors has three inferred parameters ($1, $2, $3).
+  // Setting query_parameter_limit: 2 must produce exactly one
+  // finding naming the query, the inferred count, and the limit.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_over_limit_query.sql",
+        "src/verify_limit_out",
+        option.Some(2),
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  finding.block_out |> should.equal("src/verify_limit_out")
+  string.contains(finding.detail, "FilterAuthors") |> should.be_true()
+  string.contains(finding.detail, "query_parameter_limit 2") |> should.be_true()
+  string.contains(finding.detail, "3 inferred parameter") |> should.be_true()
+}
+
+pub fn verify_parameter_limit_none_allows_any_count_test() {
+  // Without the limit set, the same three-parameter query must
+  // pass verification cleanly.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_over_limit_query.sql",
+        "src/verify_nolimit_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  report.findings |> should.equal([])
+}
+
+pub fn verify_surfaces_analysis_error_as_finding_test() {
+  // Use a schema that does not define the table the queries
+  // reference. `generate` would stop on the analysis error; verify
+  // must carry it through as a finding so CI sees the diagnostic
+  // instead of a traceback.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/ambiguous_param_schema.sql",
+        "test/fixtures/verify_ok_query.sql",
+        "src/verify_unknown_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  list.length(report.findings) |> should.equal(1)
+  let assert [finding] = report.findings
+  // The verify_ok_query references the `authors` table, which the
+  // ambiguous_param schema does not define. Any finding mentioning
+  // `authors` proves the analyser error propagated through.
+  // The finding must name one of the queries from the input file
+  // so operators can locate the offending query in the source. The
+  // exact error shape depends on which analysis step tripped first
+  // (table-not-found vs. parameter inference failure), and both are
+  // acceptable reports for this mismatched schema/query pair.
+  string.contains(finding.detail, "GetAuthor") |> should.be_true()
+}
+
+pub fn report_to_string_joins_findings_with_block_tag_test() {
+  // The report renderer must prefix every finding with the block
+  // out directory so multi-block reports stay attributable.
+  let report =
+    verify.Report(findings: [
+      verify.Finding(block_out: "src/one", detail: "a"),
+      verify.Finding(block_out: "src/two", detail: "b"),
+    ])
+  let rendered = verify.report_to_string(report)
+  string.contains(rendered, "[src/one] a") |> should.be_true()
+  string.contains(rendered, "[src/two] b") |> should.be_true()
+}
+
+pub fn report_to_string_reports_all_clear_on_empty_findings_test() {
+  let report = verify.Report(findings: [])
+  verify.report_to_string(report) |> should.equal("All checks passed.")
+}


### PR DESCRIPTION
## Summary
- Start the Issue #395 verification lane with a static, read-only `sqlode verify` command. It walks every block the config lists, runs the full schema + query analyser pipeline, layers static policies on top (`query_parameter_limit`), and collects every problem into a single report instead of short-circuiting on the first one.
- Add the `query_parameter_limit` per-block policy. The name mirrors the sqlc setting so migrating users can port configuration directly; the value, when set, caps the inferred parameter count per query.
- Document the verification roadmap — static (now), DB-backed (`database` / `analyzer`), execution-lane — so later phases can extend `Finding` without reshaping the CLI contract.

## Changes
- `src/sqlode/verify.gleam` — new module. Exposes `run(config_path)` and `verify_config(cfg)`, typed `Report` / `Finding` / `VerifyError`, and `report_to_string` / `error_to_string` renderers. The pipeline mirrors `generate.load_and_*` in read-only mode: schema parse → strict-views gate → query parse → analyzer. Each step produces a `Finding` on failure instead of halting the batch.
- `src/sqlode/model.gleam` — add `query_parameter_limit: Option(Int)` to `GleamOutput`.
- `src/sqlode/config.gleam` — accept `gen.gleam.query_parameter_limit` in the YAML schema, parse it via a new `optional_int` helper. Unknown-keys check updated.
- `src/sqlode/cli.gleam` — add the `verify` sub-command. Auto-discovers config files (same rules as `generate`), prints the rendered report, exits non-zero when the report has findings. Updated global help text lists the new command.
- `spec/cli_spec.sh` / `spec/spec_helper.sh` — smoke coverage for `sqlode verify` matching the existing `generate` shellspec pattern.
- `test/verify_test.gleam` — new Gleam test file covering:
  - healthy project → empty findings;
  - query exceeding `query_parameter_limit` → exactly one finding naming the query, inferred count and limit;
  - `query_parameter_limit` unset → no findings even for three-parameter queries;
  - mismatched schema/query → analyzer error propagated through as a finding;
  - `report_to_string` formatting for findings + \"all checks passed\" output.
- `test/fixtures/verify_ok_{schema,query}.sql`, `test/fixtures/verify_over_limit_query.sql` — minimal fixtures backing the verify tests.
- Existing test blocks (`generate_test.gleam`, `codegen_test.gleam`, `complex_sql_test.gleam`) updated to set `query_parameter_limit: option.None` in their `GleamOutput` literals.
- `README.md` — new \"\`sqlode verify\`\" section with example output and a CI snippet, a \"Verification roadmap\" section sketching the DB-backed and execution-lane phases, and the sqlc migration row updated to link to the new command instead of reporting verify as unsupported.

## Design decisions
- Static-only first phase. DB-backed analysis (EXPLAIN via a driver) and execution-lane validation are documented in the roadmap but intentionally out of scope here — they require a runtime database connection and a driver dependency that the current project structure does not yet have, and would dilute the PR. Keeping the CLI contract (\`Report\` + \`Finding\`) stable lets those later phases grow findings without breaking scripts that depend on the current output.
- \`query_parameter_limit\` ignores non-positive values rather than rejecting them. A config typo should not make every query a finding; a zero or negative value is treated as \"disabled\" so misconfiguration stays survivable.
- Missing-schema or missing-query failures become `Finding` values, not errors from `run`. Errors from `run` are reserved for unrecoverable cases (missing config, YAML syntax). That separation keeps the CI pattern simple: non-empty findings → fail, otherwise → pass.
- The verify pipeline mirrors generate's load-and-analyse steps but does not call any codegen module. This means verify exercises exactly the schema + query + analyzer surfaces CI users care about, without risk of being slowed by or coupled to codegen changes.

## Test plan
- [x] \`gleam format --check src/ test/\`
- [x] \`gleam check\`
- [x] \`gleam build --warnings-as-errors\`
- [x] \`gleam test\` (868 passed, 0 failures)
- [x] \`shellspec\` (22 examples, 0 failures — adds two verify coverage cases)
- [x] `verify_test.gleam` pins each observable shape: healthy project, over-limit query, analyzer error, report formatting.

Closes #395