### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-18
+
+### Added
+
+- **`sqlode verify` command**: A static verification lane that walks
+  every SQL block listed in the config, runs the full schema /
+  strict-views / query / analyzer pipeline, and reports every finding
+  without writing files. Exits non-zero when any finding is present,
+  suitable as a CI gate before `sqlode generate`. The new
+  `query_parameter_limit` config option (mirroring sqlc's setting of
+  the same name) becomes the first enforced policy — queries whose
+  inferred parameter count exceeds the limit produce a finding.
+- **Function-first `prepare_<query>` helpers**: Every generated query
+  now emits a `prepare_<function_name>(...)` helper that takes the
+  params record fields as positional arguments and returns the
+  `#(sql, values)` tuple Gleam database drivers consume directly.
+  Call sites can now use `queries.prepare_get_author(id: 1)` instead
+  of manually composing a query descriptor, a params record, and
+  `runtime.prepare`. The low-level descriptor API is preserved for
+  batching, caching, or custom wrappers.
+- **Expression-aware SQL IR**: Replaced the thin statement IR with a
+  normalised IR (`Stmt` / `SelectCore` / `CteDef` / `Expr`) covering
+  CTEs, LATERAL, select items, predicates, arithmetic, CASE,
+  functions, casts, `IN`, `EXISTS`, `ANY` / `ALL`, window specs, and
+  RETURNING. Type inference now operates on the IR instead of
+  reverse-engineering semantics from raw token slices, and
+  `col = ANY(placeholder)` / sibling quantified patterns now
+  participate in parameter inference alongside `IN`. LATERAL subquery
+  aliases are treated as nullable when the surrounding join is
+  `LEFT [OUTER] JOIN LATERAL`. Four executable fixtures under
+  `test/fixtures/complex_sql_*.sql` pin the new behaviour.
+
+### Changed
+
+- **`strict_views: true` is now the default**. A configuration that
+  omits `strict_views` previously warned and continued with a partial
+  catalog, letting a generated model silently drift away from the
+  real database shape. Generation now fails with a `SchemaParseError`
+  when a view references an unknown column. Set `strict_views: false`
+  to restore the legacy permissive behaviour for schemas that still
+  need it.
+- RETURNING resolution is now scoped to the DML target table, so
+  `INSERT .. SELECT .. RETURNING` no longer sees CTE / SELECT source
+  tables as ambiguous candidates.
+- The schema parser now accepts non-reserved keywords (`action`,
+  `name`, `order`, …) as column identifiers.
+
+### Fixed
+
+- **Ambiguous unqualified parameter columns are now rejected.**
+  Parameter inference previously swallowed ambiguity from
+  `context.find_column_in_tables` and fell back to the primary
+  table, so `WHERE id = $1` in a multi-table query silently bound the
+  param type to whichever table came first. Unqualified predicate
+  columns that match more than one in-scope table now raise
+  `AmbiguousColumnName`. The token scan's FROM scope is also
+  restricted to the outermost statement via
+  `token_utils.strip_leading_with`, so CTE-internal tables no longer
+  leak into the ambiguity check for the outer predicate.
+
 ## [0.2.1] - 2026-04-18
 
 ### Fixed

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.2.1"
+version = "0.3.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.2.1"
+pub const version = "0.3.0"


### PR DESCRIPTION
## Summary

Release v0.3.0. Bumps `gleam.toml`, `src/sqlode/version.gleam`, and adds the v0.3.0 section to `CHANGELOG.md`.

### Highlights since v0.2.1

- **`sqlode verify` command** (#395) — static verification lane that walks every SQL block, runs the full analyser, and reports every finding without writing files. Exits non-zero when any finding is present, suitable as a CI gate before `sqlode generate`. First enforced policy: `query_parameter_limit`.
- **`prepare_<query>` function-first helpers** (#394) — generated queries module now emits `prepare_<function_name>(...)` taking params fields as positional arguments and returning `#(sql, values)` directly. Low-level descriptor API preserved.
- **Expression-aware SQL IR** (#393) — replaces the thin statement IR with `Stmt` / `SelectCore` / `CteDef` / `Expr` covering CTEs, LATERAL, CASE, arithmetic, `IN` / `EXISTS` / `ANY` / `ALL`, window specs, RETURNING. LATERAL aliases under LEFT JOIN are now nullable; `col = ANY(placeholder)` participates in parameter inference.
- **`strict_views: true` is now the default** (#391) — partial view resolution fails loudly instead of silently dropping columns. Opt out with `strict_views: false` for legacy schemas.
- **Reject ambiguous unqualified parameter columns** (#390) — `WHERE id = $1` in a multi-table query now raises `AmbiguousColumnName` instead of silently binding to the primary table.

## Test plan

- [x] `gleam test` — 868 tests passing
- [ ] CI green on this branch