### PR TITLE
fix: create parent directories for sqlode init --output

### DIFF
--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -258,19 +258,49 @@ fn run_init(path: String, engine: String, runtime: String) -> Nil {
           halt(1)
         }
         _ -> {
-          case simplifile.write(path, template) {
-            Ok(_) -> {
-              io.println("Created " <> path)
-              create_stub_files(filepath.directory_name(path), engine)
-            }
-            Error(_) -> {
-              io.println_error("Error: failed to write " <> path)
+          let parent_dir = filepath.directory_name(path)
+          case ensure_parent_directory(parent_dir) {
+            Error(msg) -> {
+              io.println_error("Error: " <> msg)
               halt(1)
             }
+            Ok(Nil) ->
+              case simplifile.write(path, template) {
+                Ok(_) -> {
+                  io.println("Created " <> path)
+                  create_stub_files(parent_dir, engine)
+                }
+                Error(err) -> {
+                  io.println_error(
+                    "Error: failed to write "
+                    <> path
+                    <> ": "
+                    <> simplifile.describe_error(err),
+                  )
+                  halt(1)
+                }
+              }
           }
         }
       }
     }
+  }
+}
+
+fn ensure_parent_directory(dir: String) -> Result(Nil, String) {
+  case dir {
+    "" | "." -> Ok(Nil)
+    _ ->
+      case simplifile.create_directory_all(dir) {
+        Ok(Nil) -> Ok(Nil)
+        Error(err) ->
+          Error(
+            "failed to create directory "
+            <> dir
+            <> ": "
+            <> simplifile.describe_error(err),
+          )
+      }
   }
 }
 

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -162,6 +162,24 @@ pub fn init_sqlite_native_runtime_test() {
   cleanup("sqlite_native")
 }
 
+pub fn init_creates_missing_parent_directory_test() {
+  cleanup("missing_parent")
+  let dir = base_dir <> "/missing_parent"
+  let nested_dir = dir <> "/config/nested"
+  let config_path = nested_dir <> "/sqlode.yaml"
+
+  run_init(config_path)
+  |> result.is_ok
+  |> should.be_true
+
+  simplifile.is_file(config_path) |> should.equal(Ok(True))
+  simplifile.is_file(nested_dir <> "/db/schema.sql")
+  |> should.equal(Ok(True))
+  simplifile.is_file(nested_dir <> "/db/query.sql") |> should.equal(Ok(True))
+
+  cleanup("missing_parent")
+}
+
 pub fn init_mysql_engine_generates_mysql_schema_test() {
   setup("mysql_engine")
   let dir = base_dir <> "/mysql_engine"


### PR DESCRIPTION
## Summary
- `sqlode init --output=./config/sqlode.yaml` now creates the missing parent directory before writing the config, instead of failing with a generic write error.
- Failures in directory creation are reported separately from file-write failures so the error message points at the actual step that broke.

## Changes
- `src/sqlode/cli.gleam`
  - `run_init` now computes the parent directory from the output path and calls a new `ensure_parent_directory` helper before `simplifile.write`.
  - `ensure_parent_directory` is a no-op for `""` and `"."`; for any other directory it runs `simplifile.create_directory_all` and surfaces `simplifile.describe_error` on failure.
  - Write failures also include the underlying error via `describe_error`, so a write error after the directory has been created is unambiguous.
- `test/cli_test.gleam`
  - New `init_creates_missing_parent_directory_test` drives `sqlode init` at a config path two directories deep from the existing test base and asserts that the config and stub files are created.

## Design Decisions
- Kept the existing `create_stub_files` path untouched. It already uses `create_directory_all` for the `db/` subdirectory, so the fix is scoped to the top-level config write.
- Used a small `ensure_parent_directory` helper rather than inlining, so the empty / current-directory cases (`filepath.directory_name` returns `""` for bare filenames, `"."` for `./foo.yaml`) stay out of the main flow.
- Error strings include `simplifile.describe_error(err)` so a user hitting a permissions or similar failure sees an actionable message rather than the previous generic `failed to write ...`.

Closes #402

## Test plan
- [x] `just all` (format-check + check + build + test + shellspec) all green
- [x] Manual reproduction from the issue:
  ```
  gleam run -- init --output=/tmp/sqlode-init-missing-parent/config/sqlode.yaml
  ```
  now scaffolds the config and `db/` stubs instead of erroring out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Init command now automatically creates missing parent directories instead of failing
  * Improved error messages with more descriptive details when initialization encounters issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->