### PR TITLE
chore: add regeneration command for doc/capabilities.md

### DIFF
--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -2,7 +2,7 @@
 
 This file is generated from `src/sqlode/capabilities.gleam` and
 verified by `test/capabilities_test.gleam`. Do not edit by hand;
-update the capabilities module and run `just test` to refresh.
+update the capabilities module and run `just regen-capabilities`.
 
 ## Engines
 

--- a/justfile
+++ b/justfile
@@ -24,6 +24,10 @@ test:
 shellspec:
   shellspec
 
+regen-capabilities:
+  gleam build
+  gleam run -m sqlode/scripts/print_capabilities > doc/capabilities.md
+
 all:
   gleam format --check src/ test/
   gleam check

--- a/src/sqlode/capabilities.gleam
+++ b/src/sqlode/capabilities.gleam
@@ -85,7 +85,7 @@ pub fn manifest_markdown() -> String {
       "",
       "This file is generated from `src/sqlode/capabilities.gleam` and",
       "verified by `test/capabilities_test.gleam`. Do not edit by hand;",
-      "update the capabilities module and run `just test` to refresh.",
+      "update the capabilities module and run `just regen-capabilities`.",
       "",
       "## Engines",
       "",

--- a/src/sqlode/scripts/print_capabilities.gleam
+++ b/src/sqlode/scripts/print_capabilities.gleam
@@ -1,0 +1,19 @@
+//// Entry point for regenerating `doc/capabilities.md`.
+////
+//// Run with:
+////
+////   just regen-capabilities
+////
+//// or directly:
+////
+////   gleam run -m sqlode/scripts/print_capabilities > doc/capabilities.md
+////
+//// The output is exactly what `test/capabilities_test.gleam` pins against
+//// the tracked file.
+
+import gleam/io
+import sqlode/capabilities
+
+pub fn main() -> Nil {
+  io.print(capabilities.manifest_markdown())
+}

--- a/test/capabilities_test.gleam
+++ b/test/capabilities_test.gleam
@@ -22,7 +22,7 @@ pub fn manifest_matches_tracked_file_test() {
       let message =
         "doc/capabilities.md is out of sync with src/sqlode/capabilities.gleam.\n"
         <> "Regenerate the file with:\n"
-        <> "  gleam run -m sqlode/scripts/print_capabilities > doc/capabilities.md\n"
+        <> "  just regen-capabilities\n"
         <> "or copy the expected output below verbatim:\n"
         <> "--- expected ---\n"
         <> rendered


### PR DESCRIPTION
## Summary
- Add a real regeneration entry point for `doc/capabilities.md` so the capabilities snapshot test stops pointing contributors at a command that does not exist.
- Point the test failure message and the manifest header at the same command (`just regen-capabilities`).

## Changes
- `src/sqlode/scripts/print_capabilities.gleam`
  - New module exposing `pub fn main()` that prints `capabilities.manifest_markdown()` via `io.print` (no trailing newline, so redirected output matches the tracked file byte-for-byte).
- `justfile`
  - New `regen-capabilities` target. Runs `gleam build` before `gleam run -m sqlode/scripts/print_capabilities > doc/capabilities.md` so the script does not leak rebar compile traces (`{compiling,...}` / `{compiled,...}`) into the file on a cold checkout.
- `test/capabilities_test.gleam`
  - Replace the stale regeneration hint (`gleam run -m sqlode/scripts/print_capabilities > doc/capabilities.md`) with `just regen-capabilities`.
- `src/sqlode/capabilities.gleam`
  - Update the manifest header text from "run `just test` to refresh" (which never regenerated anything) to "run `just regen-capabilities`", matching the test hint.
- `doc/capabilities.md`
  - Regenerated via the new target so the header matches the source of truth.

## Design decisions
- Placed the script under `src/sqlode/scripts/` to keep the module path aligned with the hint the test used to print. Future CLI-like helpers can live in the same directory.
- Kept the script to a single `main()` that delegates to `capabilities.manifest_markdown()`; all shape decisions stay in the capabilities module.
- Prepended `gleam build` in the just target rather than using a separate dedicated Erlang entry point. A cold `gleam run -m ...` would otherwise include rebar compile traces on stdout, which would contaminate the regenerated file and fail the snapshot test on the next run.

## Test plan
- [x] `just all` (format-check + check + build + test + shellspec) all green
- [x] Cold-build run: `rm -rf build/dev/erlang/sqlode && just regen-capabilities` — resulting `doc/capabilities.md` contains no compiler output and matches the snapshot test expectation
- [x] Warm-build run: `just regen-capabilities` — file is idempotent

Closes #403