### PR TITLE
refactor: drive equality param inference from the expression-aware IR

### DIFF
--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -1,14 +1,16 @@
 import gleam/dict
 import gleam/int
 import gleam/list
-import gleam/option.{None, Some}
+import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 import sqlode/lexer
 import sqlode/model
+import sqlode/naming
 import sqlode/query_analyzer/context.{
   type AnalysisError, type AnalyzerContext, AmbiguousColumnName,
 }
+import sqlode/query_analyzer/expr_parser
 import sqlode/query_analyzer/placeholder
 import sqlode/query_analyzer/token_utils
 import sqlode/query_ir
@@ -126,7 +128,31 @@ pub fn infer_equality_params(
   case all_tables {
     [] -> Ok([])
     _ -> {
-      let matches = token_utils.find_equality_patterns(main_tokens)
+      // Prefer the IR-based walker. Token-based scanning remains the
+      // fallback for:
+      //
+      //   * `UnstructuredStmt(..)` — the IR parser hit a construct it
+      //     does not yet model; keep the existing token coverage.
+      //
+      //   * `InsertStmt(..)` — the IR does not carry the PostgreSQL /
+      //     SQLite `ON CONFLICT … DO UPDATE SET …` tail (only MySQL's
+      //     `ON DUPLICATE KEY UPDATE` is parsed, via
+      //     `on_duplicate_key_update`), so falling through to the IR
+      //     walker would silently drop SET-clause placeholders. Token
+      //     scanning covers the whole INSERT body and keeps upsert
+      //     inference working until the IR gains an `on_conflict` node.
+      //     Equality predicates inside INSERT … SELECT subqueries also
+      //     ride along, matching the pre-refactor behaviour.
+      //
+      // The IR walker itself descends into nested subqueries (EXISTS /
+      // scalar / IN) and transparently unwraps `Cast(Param)`, matching
+      // the source-order behaviour of
+      // `token_utils.find_equality_patterns`.
+      let matches = case expr_parser.parse_stmt(tokens, engine) {
+        query_ir.UnstructuredStmt(..) | query_ir.InsertStmt(..) ->
+          token_utils.find_equality_patterns(main_tokens)
+        stmt -> find_equality_matches_in_stmt(stmt)
+      }
       scan_token_matches(
         engine,
         catalog,
@@ -139,6 +165,265 @@ pub fn infer_equality_params(
       )
       |> result.map(list.reverse)
     }
+  }
+}
+
+// ============================================================
+// IR-based equality walker (Issue #406)
+// ============================================================
+
+/// Walk a parsed `Stmt` in source order and emit an `EqualityMatch`
+/// for each `col <op> placeholder` / `placeholder <op> col` /
+/// `col [I]LIKE placeholder` predicate reachable from the outer
+/// statement.
+///
+/// Scoping mirrors the token-based path: it descends through SELECT
+/// items, JOIN ON clauses of the outermost FROM, outermost
+/// WHERE / GROUP BY / HAVING, and (for UPDATE/DELETE) the single
+/// WHERE. Nested subqueries inside `EXISTS` / scalar subqueries /
+/// `IN (SELECT …)` are traversed too, because the pre-refactor
+/// `token_utils.find_equality_patterns` saw every placeholder in the
+/// main body regardless of paren depth. CTE bodies are excluded
+/// because `infer_equality_params` already strips them via
+/// `token_utils.strip_leading_with` before the ambiguity check.
+fn find_equality_matches_in_stmt(
+  stmt: query_ir.Stmt,
+) -> List(token_utils.EqualityMatch) {
+  case stmt {
+    query_ir.SelectStmt(core:, ..) -> walk_select_core(core)
+    query_ir.UpdateStmt(assignments:, where_:, ..) ->
+      // The legacy token-scanner treats every `col = placeholder` as a
+      // potential param regardless of which clause it's in, so SET
+      // assignments were caught by `find_equality_patterns` as well.
+      // Mirror that by emitting matches for the assignment targets so
+      // `UPDATE t SET col = $1 WHERE id = $2` still resolves $1's type.
+      list.flatten([
+        list.filter_map(assignments, assignment_match),
+        walk_optional_expr(where_),
+      ])
+    query_ir.DeleteStmt(where_:, ..) -> walk_optional_expr(where_)
+    // InsertStmt and UnstructuredStmt are handled at the call site by
+    // falling back to token scanning; the IR walker is never invoked
+    // for those branches.
+    query_ir.InsertStmt(..) -> []
+    query_ir.UnstructuredStmt(..) -> []
+  }
+}
+
+fn assignment_match(
+  assignment: query_ir.Assignment,
+) -> Result(token_utils.EqualityMatch, Nil) {
+  case assignment.value {
+    query_ir.Param(raw:, ..) ->
+      Ok(token_utils.EqualityMatch(
+        column_name: naming.normalize_identifier(assignment.column),
+        table_qualifier: None,
+        placeholder: raw,
+      ))
+    _ -> Error(Nil)
+  }
+}
+
+fn walk_select_core(
+  core: query_ir.SelectCore,
+) -> List(token_utils.EqualityMatch) {
+  // Walk SELECT items as well as JOIN/WHERE/HAVING so expressions like
+  // `SELECT EXISTS(SELECT 1 FROM t WHERE col = $1) …` still surface
+  // the inner placeholder. The legacy token scanner saw every
+  // placeholder in the main body; mirror that by descending through
+  // each select-list expression.
+  list.flatten([
+    list.flat_map(core.select_items, walk_select_item),
+    list.flat_map(core.from, walk_from_item_joins),
+    walk_optional_expr(core.where_),
+    list.flat_map(core.group_by, walk_expr),
+    walk_optional_expr(core.having),
+  ])
+}
+
+fn walk_select_item(
+  item: query_ir.SelectItemEx,
+) -> List(token_utils.EqualityMatch) {
+  case item {
+    query_ir.ExprItem(expr:, ..) -> walk_expr(expr)
+    query_ir.StarEx(..) -> []
+  }
+}
+
+fn walk_from_item_joins(
+  from: query_ir.FromItemEx,
+) -> List(token_utils.EqualityMatch) {
+  case from {
+    query_ir.FromJoin(left:, right:, on:, ..) ->
+      list.flatten([
+        walk_from_item_joins(left),
+        walk_from_item_joins(right),
+        walk_join_on(on),
+      ])
+    // Do not descend into subqueries / VALUES — those resolve against
+    // their own scope and the legacy token-based pass skipped them via
+    // `strip_leading_with` + the outermost-FROM extraction.
+    _ -> []
+  }
+}
+
+fn walk_join_on(on: query_ir.JoinOn) -> List(token_utils.EqualityMatch) {
+  case on {
+    query_ir.JoinOnExpr(expr:) -> walk_expr(expr)
+    _ -> []
+  }
+}
+
+fn walk_optional_expr(
+  expr: Option(query_ir.Expr),
+) -> List(token_utils.EqualityMatch) {
+  case expr {
+    Some(e) -> walk_expr(e)
+    None -> []
+  }
+}
+
+/// Walk an expression in left-to-right source order, emitting an
+/// `EqualityMatch` for every comparison/LIKE that binds a column to a
+/// placeholder. Nested subqueries (`EXISTS`, scalar, `IN (SELECT …)`)
+/// are traversed as well so the scoping matches the token-based path
+/// (which scans every token in the main body after `strip_leading_with`
+/// and therefore picked up placeholders inside subqueries). `IN
+/// (<list>)` and quantified forms stay the responsibility of
+/// `infer_in_params`, which is out of scope for this pass.
+fn walk_expr(expr: query_ir.Expr) -> List(token_utils.EqualityMatch) {
+  case expr {
+    // `AND` / `OR` / other boolean combinators → descend left then
+    // right so source order is preserved.
+    query_ir.Binary(op:, left:, right:) -> {
+      case is_comparison_op(op) {
+        True ->
+          case comparison_match(left, right) {
+            Some(m) -> [m]
+            None ->
+              // Not a column-vs-placeholder comparison; descend into
+              // both sides so e.g. `(a = $1) AND (b = $2)` still fires.
+              list.append(walk_expr(left), walk_expr(right))
+          }
+        False -> list.append(walk_expr(left), walk_expr(right))
+      }
+    }
+    query_ir.LikeExpr(expr: subject, pattern:, ..) ->
+      case like_match(subject, pattern) {
+        Some(m) -> [m]
+        None -> list.append(walk_expr(subject), walk_expr(pattern))
+      }
+    query_ir.Unary(arg:, ..) -> walk_expr(arg)
+    query_ir.Between(expr: subject, low:, high:, ..) ->
+      list.flatten([walk_expr(subject), walk_expr(low), walk_expr(high)])
+    query_ir.IsCheck(expr: subject, ..) -> walk_expr(subject)
+    query_ir.Case(scrutinee:, branches:, else_:) ->
+      list.flatten([
+        walk_optional_expr(scrutinee),
+        list.flat_map(branches, fn(b) {
+          list.append(walk_expr(b.when_), walk_expr(b.then))
+        }),
+        walk_optional_expr(else_),
+      ])
+    query_ir.Cast(expr: subject, ..) -> walk_expr(subject)
+    query_ir.Func(args:, ..) -> list.flat_map(args, fn(a) { walk_expr(a.expr) })
+    query_ir.Tuple(elements:) -> list.flat_map(elements, walk_expr)
+    query_ir.ArrayLit(elements:) -> list.flat_map(elements, walk_expr)
+    // Nested subqueries — descend so `SELECT EXISTS(SELECT 1 FROM t
+    // WHERE col = $1)` still emits the inner match, matching the
+    // token scanner's behaviour.
+    query_ir.Exists(core:, ..) -> walk_select_core(core)
+    query_ir.ScalarSubquery(core:) -> walk_select_core(core)
+    query_ir.InExpr(expr: subject, source:, ..) ->
+      list.append(walk_expr(subject), walk_in_source(source))
+    query_ir.Quantified(left:, right:, ..) ->
+      list.append(walk_expr(left), walk_expr(right))
+    // Remaining leaf nodes (NullLit / BoolLit / StringLit / NumberLit
+    // / Param / ColumnRef / StarRef / Macro / RawExpr) don't contain
+    // column-vs-placeholder predicates.
+    _ -> []
+  }
+}
+
+fn walk_in_source(source: query_ir.InSource) -> List(token_utils.EqualityMatch) {
+  case source {
+    query_ir.InSubquery(core:) -> walk_select_core(core)
+    query_ir.InList(values:) -> list.flat_map(values, walk_expr)
+    query_ir.InSliceMacro(..) -> []
+  }
+}
+
+fn is_comparison_op(op: String) -> Bool {
+  op == "="
+  || op == "!="
+  || op == "<>"
+  || op == "<"
+  || op == ">"
+  || op == "<="
+  || op == ">="
+}
+
+/// Emit a match for `ColumnRef <op> Param` or the reversed operand
+/// form `Param <op> ColumnRef`. The column operand is what we infer
+/// against either way — `col = ?` and `? = col` both constrain `col`.
+/// A PostgreSQL-style `$1::type` cast on the placeholder side is
+/// unwrapped so e.g. `score > $3::int` still binds $3 to `score`'s
+/// type (the cast is separately consumed by `extract_type_casts`).
+fn comparison_match(
+  left: query_ir.Expr,
+  right: query_ir.Expr,
+) -> Option(token_utils.EqualityMatch) {
+  case column_of(left), param_of(right) {
+    Some(#(table, name)), Some(raw) -> Some(build_match(table, name, raw))
+    _, _ ->
+      case column_of(right), param_of(left) {
+        Some(#(table, name)), Some(raw) -> Some(build_match(table, name, raw))
+        _, _ -> None
+      }
+  }
+}
+
+fn like_match(
+  subject: query_ir.Expr,
+  pattern: query_ir.Expr,
+) -> Option(token_utils.EqualityMatch) {
+  case column_of(subject), param_of(pattern) {
+    Some(#(table, name)), Some(raw) -> Some(build_match(table, name, raw))
+    _, _ -> None
+  }
+}
+
+fn column_of(expr: query_ir.Expr) -> Option(#(Option(String), String)) {
+  case expr {
+    query_ir.ColumnRef(table:, name:) -> Some(#(table, name))
+    _ -> None
+  }
+}
+
+fn param_of(expr: query_ir.Expr) -> Option(String) {
+  case expr {
+    query_ir.Param(raw:, ..) -> Some(raw)
+    query_ir.Cast(expr: inner, ..) -> param_of(inner)
+    _ -> None
+  }
+}
+
+fn build_match(
+  table: Option(String),
+  name: String,
+  placeholder: String,
+) -> token_utils.EqualityMatch {
+  token_utils.EqualityMatch(
+    column_name: naming.normalize_identifier(name),
+    table_qualifier: normalize_table_qualifier(table),
+    placeholder: placeholder,
+  )
+}
+
+fn normalize_table_qualifier(table: Option(String)) -> Option(String) {
+  case table {
+    Some(t) -> Some(string.lowercase(t))
+    None -> None
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2540,3 +2540,118 @@ pub fn ambiguous_unqualified_param_column_is_rejected_test() {
   list.contains(tables, "active_users") |> should.be_true()
   list.contains(tables, "teams") |> should.be_true()
 }
+
+// --- IR-based equality walker tests (Issue #406) ---
+//
+// These queries exercise the `find_equality_matches_in_stmt` walker
+// that `infer_equality_params` now prefers over the token-based
+// `find_equality_patterns`. Each case is driven through the public
+// `query_analyzer.analyze_queries` pipeline so the wiring is covered
+// end-to-end, not just the helper in isolation.
+
+pub fn ir_walker_infers_multiple_equality_params_in_order_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetByIdAndName :one\n"
+    <> "SELECT id, name FROM authors WHERE id = $1 AND name = $2;"
+  let assert Ok(queries) =
+    query_parser.parse_file("eq.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  query.params
+  |> should.equal([
+    model.QueryParam(
+      index: 1,
+      field_name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      is_list: False,
+    ),
+    model.QueryParam(
+      index: 2,
+      field_name: "name",
+      scalar_type: model.StringType,
+      nullable: False,
+      is_list: False,
+    ),
+  ])
+}
+
+pub fn ir_walker_resolves_qualified_equality_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetByQualifiedId :one\n"
+    <> "SELECT id, name FROM authors AS a WHERE a.id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("qualified.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("id")
+  param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn ir_walker_infers_like_predicate_param_test() {
+  // `WHERE name LIKE $1` must infer $1 as the column's type via the
+  // IR `LikeExpr(ColumnRef, _, Param, …)` branch. The pre-refactor
+  // token scanner covered this via its `column LIKE placeholder`
+  // patterns; the IR walker must match exactly.
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: SearchByName :many\n"
+    <> "SELECT id, name FROM authors WHERE name LIKE $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("like.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("name")
+  param.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn ir_walker_handles_reversed_operand_order_test() {
+  // `$1 = id` binds `id` just like `id = $1` — the walker handles both
+  // `Binary(_, ColumnRef, Param)` and `Binary(_, Param, ColumnRef)`.
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetByReversedId :one\n"
+    <> "SELECT id, name FROM authors WHERE $1 = id;"
+  let assert Ok(queries) =
+    query_parser.parse_file("reversed.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("id")
+  param.scalar_type |> should.equal(model.IntType)
+}


### PR DESCRIPTION
## Summary
- Make `infer_equality_params` consume the expression-aware IR instead of rescanning tokens, so parser features only need to be taught once.
- Keep the token scanner as an explicit fallback for IR gaps (`UnstructuredStmt`, `InsertStmt` with non-MySQL upserts) so existing coverage is preserved.
- First slice of Issue #406's "drive analysis from the rich IR" refactor.

## Changes
- `src/sqlode/query_analyzer/param_inferencer.gleam`
  - `infer_equality_params` now calls `expr_parser.parse_stmt(tokens, engine)` once and dispatches on the resulting `Stmt`:
    - Structured `SelectStmt` / `UpdateStmt` / `DeleteStmt` → the new IR walker.
    - `InsertStmt` → token fallback (PostgreSQL `ON CONFLICT ... DO UPDATE` tails are not yet modelled in the IR).
    - `UnstructuredStmt` → token fallback.
  - New private walker `find_equality_matches_in_stmt` emits `token_utils.EqualityMatch` records compatible byte-for-byte with `find_equality_patterns`. Cases covered:
    - `Binary(op, ColumnRef, Param)` and the reversed `Binary(op, Param, ColumnRef)` for `=, !=, <>, <, >, <=, >=`.
    - `LikeExpr(ColumnRef, _, Param, …)` — both `LIKE` and `ILIKE`.
    - Transparent `Cast(Param, …)` unwrap on the placeholder side so `col > \$3::int` still binds \$3 to `col`.
  - Descends through SELECT items, `FromJoin.on`, WHERE, GROUP BY, HAVING, UPDATE SET, UPDATE/DELETE WHERE, and nested subqueries (`Exists`, `ScalarSubquery`, `InExpr(InSubquery)`, `Quantified`, `Case`, `Between`, `Func`, `Tuple`, `ArrayLit`, `Unary`, `IsCheck`, `Cast`) — mirroring what `token_utils.find_equality_patterns` previously reached via naive token walking. CTE bodies intentionally stay out, matching the existing `strip_leading_with` scoping.
- `test/query_analyzer_test.gleam`
  - Four new tests driven through `query_analyzer.analyze_queries` that pin the IR path end-to-end: multi-parameter `WHERE col = \$1 AND other = \$2`, qualified column `t.col = \$1`, `LIKE` predicate, and reversed `Param = ColumnRef` operand order.

## Design decisions
- Kept the output shape and source ordering identical to `token_utils.find_equality_patterns` so `scan_token_matches` + `placeholder.resolve_index` keep working unchanged. This is the safe migration path — if the walker misses a pattern the token fallback already covers, the scan still succeeds.
- Left `InsertStmt` on the token path. The IR models MySQL `ON DUPLICATE KEY UPDATE` (added in #405) but not PostgreSQL / SQLite `ON CONFLICT ... DO UPDATE SET ...`. Extending the IR for the other dialects is its own change; the token fallback makes this refactor non-breaking.
- Left `infer_in_params` and CTE / values / derived-table / alias extraction alone. Those acceptance criteria on #406 are each their own slice.

## Limitations
- Does not address Issue #406's "drive CTE/alias/derived-table scope from the IR" or "replace `infer_in_params` with expression-tree traversal" sub-tasks. Both remain on the same Issue for follow-up PRs.
- `column_inferencer` still uses token-based helpers for result-column inference. Separate slice.

## Test plan
- [x] `just all` (format-check + check + build + test + integration-prepare + shellspec) all green — 877 unit tests, 22 shellspec examples, 0 failures.
- [x] New IR-path tests cover multi-param, qualified-column, LIKE, and reversed-operand cases.
- [x] Token fallback still exercised by the existing `InsertStmt` / `ON CONFLICT` suite (no regressions).

Refs #406