### PR TITLE
refactor: drive IN and quantified param inference from the expression-aware IR

### DIFF
--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -197,8 +197,14 @@ fn find_equality_matches_in_stmt(
       // assignments were caught by `find_equality_patterns` as well.
       // Mirror that by emitting matches for the assignment targets so
       // `UPDATE t SET col = $1 WHERE id = $2` still resolves $1's type.
+      //
+      // The RHS of each assignment may itself host an equality against
+      // a placeholder (`col = (SELECT x WHERE id = $1)`), so walk the
+      // value expression too — a top-level `Param` is consumed by
+      // `assignment_match`, but nested equalities need the recursion.
       list.flatten([
         list.filter_map(assignments, assignment_match),
+        list.flat_map(assignments, fn(a) { walk_expr(a.value) }),
         walk_optional_expr(where_),
       ])
     query_ir.DeleteStmt(where_:, ..) -> walk_optional_expr(where_)
@@ -232,12 +238,42 @@ fn walk_select_core(
   // the inner placeholder. The legacy token scanner saw every
   // placeholder in the main body; mirror that by descending through
   // each select-list expression.
+  //
+  // `order_by` / `limit` / `offset` / `set_op` are also walked so the
+  // IR walker stays shape-compatible with the legacy token scanner,
+  // which saw placeholders anywhere in the statement body.
   list.flatten([
     list.flat_map(core.select_items, walk_select_item),
     list.flat_map(core.from, walk_from_item_joins),
     walk_optional_expr(core.where_),
     list.flat_map(core.group_by, walk_expr),
     walk_optional_expr(core.having),
+    list.flat_map(core.order_by, walk_order_key),
+    walk_optional_expr(core.limit),
+    walk_optional_expr(core.offset),
+    walk_set_op(core.set_op),
+  ])
+}
+
+fn walk_order_key(key: query_ir.OrderKey) -> List(token_utils.EqualityMatch) {
+  walk_expr(key.expr)
+}
+
+fn walk_set_op(
+  set_op: Option(query_ir.SetOp),
+) -> List(token_utils.EqualityMatch) {
+  case set_op {
+    Some(query_ir.SetOp(right:, ..)) -> walk_select_core(right)
+    None -> []
+  }
+}
+
+fn walk_window_spec(
+  spec: query_ir.WindowSpec,
+) -> List(token_utils.EqualityMatch) {
+  list.flatten([
+    list.flat_map(spec.partition_by, walk_expr),
+    list.flat_map(spec.order_by, walk_order_key),
   ])
 }
 
@@ -326,7 +362,15 @@ fn walk_expr(expr: query_ir.Expr) -> List(token_utils.EqualityMatch) {
         walk_optional_expr(else_),
       ])
     query_ir.Cast(expr: subject, ..) -> walk_expr(subject)
-    query_ir.Func(args:, ..) -> list.flat_map(args, fn(a) { walk_expr(a.expr) })
+    query_ir.Func(args:, filter:, over:, ..) ->
+      list.flatten([
+        list.flat_map(args, fn(a) { walk_expr(a.expr) }),
+        walk_optional_expr(filter),
+        case over {
+          Some(spec) -> walk_window_spec(spec)
+          None -> []
+        },
+      ])
     query_ir.Tuple(elements:) -> list.flat_map(elements, walk_expr)
     query_ir.ArrayLit(elements:) -> list.flat_map(elements, walk_expr)
     // Nested subqueries — descend so `SELECT EXISTS(SELECT 1 FROM t
@@ -454,7 +498,14 @@ fn find_in_quantified_matches_in_stmt(
 ) -> List(token_utils.EqualityMatch) {
   case stmt {
     query_ir.SelectStmt(core:, ..) -> walk_select_core_iq(core)
-    query_ir.UpdateStmt(where_:, ..) -> walk_optional_expr_iq(where_)
+    query_ir.UpdateStmt(assignments:, where_:, ..) ->
+      // `UPDATE t SET col = (SELECT x WHERE id IN ($1))` is a realistic
+      // case the token scanner caught; descend into each assignment
+      // value so IN / quantified placeholders in the RHS still surface.
+      list.flatten([
+        list.flat_map(assignments, fn(a) { walk_expr_iq(a.value) }),
+        walk_optional_expr_iq(where_),
+      ])
     query_ir.DeleteStmt(where_:, ..) -> walk_optional_expr_iq(where_)
     // InsertStmt and UnstructuredStmt fall back to token scanning at
     // the call site; the IR walker is never invoked for those branches.
@@ -466,12 +517,44 @@ fn find_in_quantified_matches_in_stmt(
 fn walk_select_core_iq(
   core: query_ir.SelectCore,
 ) -> List(token_utils.EqualityMatch) {
+  // Walk every expression-bearing field of the SelectCore so the IR
+  // walker stays shape-compatible with the legacy token scanner —
+  // `order_by`, `limit`, `offset`, and the `set_op` continuation could
+  // all host IN / quantified placeholders in practice, and the token
+  // path saw every placeholder in the main body after the `WITH`
+  // prefix is stripped.
   list.flatten([
     list.flat_map(core.select_items, walk_select_item_iq),
     list.flat_map(core.from, walk_from_item_joins_iq),
     walk_optional_expr_iq(core.where_),
     list.flat_map(core.group_by, walk_expr_iq),
     walk_optional_expr_iq(core.having),
+    list.flat_map(core.order_by, walk_order_key_iq),
+    walk_optional_expr_iq(core.limit),
+    walk_optional_expr_iq(core.offset),
+    walk_set_op_iq(core.set_op),
+  ])
+}
+
+fn walk_order_key_iq(key: query_ir.OrderKey) -> List(token_utils.EqualityMatch) {
+  walk_expr_iq(key.expr)
+}
+
+fn walk_set_op_iq(
+  set_op: Option(query_ir.SetOp),
+) -> List(token_utils.EqualityMatch) {
+  case set_op {
+    Some(query_ir.SetOp(right:, ..)) -> walk_select_core_iq(right)
+    None -> []
+  }
+}
+
+fn walk_window_spec_iq(
+  spec: query_ir.WindowSpec,
+) -> List(token_utils.EqualityMatch) {
+  list.flatten([
+    list.flat_map(spec.partition_by, walk_expr_iq),
+    list.flat_map(spec.order_by, walk_order_key_iq),
   ])
 }
 
@@ -566,8 +649,15 @@ fn walk_expr_iq(expr: query_ir.Expr) -> List(token_utils.EqualityMatch) {
         walk_optional_expr_iq(else_),
       ])
     query_ir.Cast(expr: subject, ..) -> walk_expr_iq(subject)
-    query_ir.Func(args:, ..) ->
-      list.flat_map(args, fn(a) { walk_expr_iq(a.expr) })
+    query_ir.Func(args:, filter:, over:, ..) ->
+      list.flatten([
+        list.flat_map(args, fn(a) { walk_expr_iq(a.expr) }),
+        walk_optional_expr_iq(filter),
+        case over {
+          Some(spec) -> walk_window_spec_iq(spec)
+          None -> []
+        },
+      ])
     query_ir.Tuple(elements:) -> list.flat_map(elements, walk_expr_iq)
     query_ir.ArrayLit(elements:) -> list.flat_map(elements, walk_expr_iq)
     query_ir.Exists(core:, ..) -> walk_select_core_iq(core)

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -427,6 +427,213 @@ fn normalize_table_qualifier(table: Option(String)) -> Option(String) {
   }
 }
 
+// ============================================================
+// IR-based IN / quantified walker (Issue #406)
+// ============================================================
+
+/// Walk a parsed `Stmt` in source order and emit an `EqualityMatch`
+/// for every `col IN (placeholder)` or `col <op> ANY|ALL|SOME(placeholder)`
+/// predicate reachable from the outer statement.
+///
+/// Matches are returned in source order (interleaved). The legacy
+/// token path used `list.append(find_in_patterns, find_quantified_patterns)`
+/// which concatenated all IN matches before all quantified matches;
+/// for `$N` placeholders the index comes from the raw text so the
+/// ordering has no observable effect, and for sequential placeholders
+/// the combined walker preserves source order just like the equality
+/// walker that already shipped.
+///
+/// Only the single-placeholder shapes the token scanners matched are
+/// emitted: `col IN ($1)` (one element, no subquery) and
+/// `col = ANY($1)` / `= ALL` / `= SOME` (with or without an extra
+/// paren wrapping the placeholder). Multi-element `IN (a, b, c)` and
+/// `IN (SELECT …)` / `ANY (SELECT …)` are intentionally skipped —
+/// those aren't simple single-parameter bindings.
+fn find_in_quantified_matches_in_stmt(
+  stmt: query_ir.Stmt,
+) -> List(token_utils.EqualityMatch) {
+  case stmt {
+    query_ir.SelectStmt(core:, ..) -> walk_select_core_iq(core)
+    query_ir.UpdateStmt(where_:, ..) -> walk_optional_expr_iq(where_)
+    query_ir.DeleteStmt(where_:, ..) -> walk_optional_expr_iq(where_)
+    // InsertStmt and UnstructuredStmt fall back to token scanning at
+    // the call site; the IR walker is never invoked for those branches.
+    query_ir.InsertStmt(..) -> []
+    query_ir.UnstructuredStmt(..) -> []
+  }
+}
+
+fn walk_select_core_iq(
+  core: query_ir.SelectCore,
+) -> List(token_utils.EqualityMatch) {
+  list.flatten([
+    list.flat_map(core.select_items, walk_select_item_iq),
+    list.flat_map(core.from, walk_from_item_joins_iq),
+    walk_optional_expr_iq(core.where_),
+    list.flat_map(core.group_by, walk_expr_iq),
+    walk_optional_expr_iq(core.having),
+  ])
+}
+
+fn walk_select_item_iq(
+  item: query_ir.SelectItemEx,
+) -> List(token_utils.EqualityMatch) {
+  case item {
+    query_ir.ExprItem(expr:, ..) -> walk_expr_iq(expr)
+    query_ir.StarEx(..) -> []
+  }
+}
+
+fn walk_from_item_joins_iq(
+  from: query_ir.FromItemEx,
+) -> List(token_utils.EqualityMatch) {
+  case from {
+    query_ir.FromJoin(left:, right:, on:, ..) ->
+      list.flatten([
+        walk_from_item_joins_iq(left),
+        walk_from_item_joins_iq(right),
+        walk_join_on_iq(on),
+      ])
+    _ -> []
+  }
+}
+
+fn walk_join_on_iq(on: query_ir.JoinOn) -> List(token_utils.EqualityMatch) {
+  case on {
+    query_ir.JoinOnExpr(expr:) -> walk_expr_iq(expr)
+    _ -> []
+  }
+}
+
+fn walk_optional_expr_iq(
+  expr: Option(query_ir.Expr),
+) -> List(token_utils.EqualityMatch) {
+  case expr {
+    Some(e) -> walk_expr_iq(e)
+    None -> []
+  }
+}
+
+/// Walk an expression in left-to-right source order, emitting an
+/// `EqualityMatch` for every `col IN (placeholder)` / `col <op> ANY|ALL|SOME
+/// (placeholder)` predicate. Nested subqueries (`EXISTS`, scalar,
+/// `IN (SELECT …)`) are traversed too so placeholders buried inside
+/// them still surface, matching the token path which scans the full
+/// main body after `strip_leading_with`.
+fn walk_expr_iq(expr: query_ir.Expr) -> List(token_utils.EqualityMatch) {
+  case expr {
+    // `col IN (<single placeholder>)` — emit the match. Multi-element
+    // lists and subquery sources fall through to the recursive branch.
+    query_ir.InExpr(expr: subject, source: query_ir.InList(values), ..) ->
+      case in_list_match(subject, values) {
+        Some(m) -> [m]
+        None ->
+          list.append(
+            walk_expr_iq(subject),
+            list.flat_map(values, walk_expr_iq),
+          )
+      }
+    query_ir.InExpr(expr: subject, source:, ..) ->
+      list.append(walk_expr_iq(subject), walk_in_source_iq(source))
+    // `col <op> ANY|ALL|SOME(<placeholder>)` — emit the match, or
+    // recurse when the shape doesn't match.
+    query_ir.Quantified(left:, quantifier:, right:, ..) ->
+      case quantified_match(left, quantifier, right) {
+        Some(m) -> [m]
+        None -> list.append(walk_expr_iq(left), walk_expr_iq(right))
+      }
+    // Remaining expression shapes: descend like the equality walker
+    // so placeholders buried inside nested boolean/CASE/function/etc.
+    // still surface.
+    query_ir.Binary(left:, right:, ..) ->
+      list.append(walk_expr_iq(left), walk_expr_iq(right))
+    query_ir.LikeExpr(expr: subject, pattern:, ..) ->
+      list.append(walk_expr_iq(subject), walk_expr_iq(pattern))
+    query_ir.Unary(arg:, ..) -> walk_expr_iq(arg)
+    query_ir.Between(expr: subject, low:, high:, ..) ->
+      list.flatten([
+        walk_expr_iq(subject),
+        walk_expr_iq(low),
+        walk_expr_iq(high),
+      ])
+    query_ir.IsCheck(expr: subject, ..) -> walk_expr_iq(subject)
+    query_ir.Case(scrutinee:, branches:, else_:) ->
+      list.flatten([
+        walk_optional_expr_iq(scrutinee),
+        list.flat_map(branches, fn(b) {
+          list.append(walk_expr_iq(b.when_), walk_expr_iq(b.then))
+        }),
+        walk_optional_expr_iq(else_),
+      ])
+    query_ir.Cast(expr: subject, ..) -> walk_expr_iq(subject)
+    query_ir.Func(args:, ..) ->
+      list.flat_map(args, fn(a) { walk_expr_iq(a.expr) })
+    query_ir.Tuple(elements:) -> list.flat_map(elements, walk_expr_iq)
+    query_ir.ArrayLit(elements:) -> list.flat_map(elements, walk_expr_iq)
+    query_ir.Exists(core:, ..) -> walk_select_core_iq(core)
+    query_ir.ScalarSubquery(core:) -> walk_select_core_iq(core)
+    // NullLit / BoolLit / StringLit / NumberLit / Param / ColumnRef /
+    // StarRef / Macro / RawExpr — no sub-expressions to descend into.
+    _ -> []
+  }
+}
+
+fn walk_in_source_iq(
+  source: query_ir.InSource,
+) -> List(token_utils.EqualityMatch) {
+  case source {
+    query_ir.InSubquery(core:) -> walk_select_core_iq(core)
+    query_ir.InList(values:) -> list.flat_map(values, walk_expr_iq)
+    // Slice macros are handled by a separate inference pass; leave
+    // them alone here (matches the token scanner's behaviour).
+    query_ir.InSliceMacro(..) -> []
+  }
+}
+
+/// `col IN ($1)` with exactly one placeholder on the RHS. Anything
+/// else (empty list, multiple elements, non-placeholder elements)
+/// returns `None` so the caller descends into the sub-expressions
+/// instead of emitting a bogus single-param binding. `Cast(Param, _)`
+/// on the placeholder is transparently unwrapped.
+fn in_list_match(
+  subject: query_ir.Expr,
+  values: List(query_ir.Expr),
+) -> Option(token_utils.EqualityMatch) {
+  case values {
+    [only] ->
+      case column_of(subject), param_of(only) {
+        Some(#(table, name)), Some(raw) -> Some(build_match(table, name, raw))
+        _, _ -> None
+      }
+    _ -> None
+  }
+}
+
+/// `col <op> ANY|ALL|SOME(<placeholder>)`. The token scanner matches
+/// on the literal `ANY ( placeholder )` paren shape, which the IR
+/// parses as either `Quantified(right: Param)` or — when the
+/// placeholder is itself parenthesised inside the ANY expression —
+/// `Quantified(right: Tuple([Param]))`. Both are accepted so the
+/// walker is shape-compatible with `find_quantified_patterns`.
+/// `Cast(Param)` on the placeholder side is transparently unwrapped.
+fn quantified_match(
+  left: query_ir.Expr,
+  _quantifier: query_ir.Quantifier,
+  right: query_ir.Expr,
+) -> Option(token_utils.EqualityMatch) {
+  case column_of(left), quantified_param_of(right) {
+    Some(#(table, name)), Some(raw) -> Some(build_match(table, name, raw))
+    _, _ -> None
+  }
+}
+
+fn quantified_param_of(expr: query_ir.Expr) -> Option(String) {
+  case expr {
+    query_ir.Tuple(elements: [only]) -> param_of(only)
+    _ -> param_of(expr)
+  }
+}
+
 /// Walk each `column <op> placeholder` / `column IN (placeholder)` /
 /// quantified pattern the token scanners found and bind a parameter
 /// type when the referenced column exists. Ambiguity (the column name
@@ -528,11 +735,28 @@ pub fn infer_in_params(
   case all_tables {
     [] -> Ok([])
     _ -> {
-      let matches =
-        list.append(
-          token_utils.find_in_patterns(main_tokens),
-          token_utils.find_quantified_patterns(main_tokens),
-        )
+      // Prefer the IR-based walker, mirroring `infer_equality_params`.
+      // Token-based scanning remains the fallback for:
+      //
+      //   * `UnstructuredStmt(..)` — the IR parser hit a construct it
+      //     does not yet model; keep the existing token coverage.
+      //
+      //   * `InsertStmt(..)` — the IR does not carry the full upsert
+      //     tail (see `infer_equality_params` for context), so we keep
+      //     token scanning to cover IN / quantified predicates that
+      //     live inside INSERT … SELECT subqueries or similar bodies.
+      //
+      // The IR walker itself descends into nested subqueries and
+      // transparently unwraps `Cast(Param)` on the placeholder side so
+      // `col IN ($1::int)` and `col = ANY($1::int[])` still resolve.
+      let matches = case expr_parser.parse_stmt(tokens, engine) {
+        query_ir.UnstructuredStmt(..) | query_ir.InsertStmt(..) ->
+          list.append(
+            token_utils.find_in_patterns(main_tokens),
+            token_utils.find_quantified_patterns(main_tokens),
+          )
+        stmt -> find_in_quantified_matches_in_stmt(stmt)
+      }
       scan_token_matches(
         engine,
         catalog,

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2664,12 +2664,29 @@ pub fn ir_walker_handles_reversed_operand_order_test() {
 // through the public `query_analyzer.analyze_queries` pipeline so the
 // wiring is covered end-to-end.
 
+/// Pin the IR path for the IN / quantified walker tests. Without this
+/// a future regression that made `expr_parser.parse_stmt` return
+/// `UnstructuredStmt` would silently fall back to the token scanner,
+/// letting the test still pass through the legacy path.
+fn assert_ir_select(sql: String) -> Nil {
+  let stmt =
+    expr_parser.parse_stmt(
+      lexer.tokenize(sql, model.PostgreSQL),
+      model.PostgreSQL,
+    )
+  case stmt {
+    query_ir.SelectStmt(..) -> Nil
+    _ -> panic as "expected SelectStmt from expr_parser.parse_stmt"
+  }
+}
+
 pub fn ir_walker_infers_single_element_in_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
     "-- name: GetAuthorsByIdList :many\n"
     <> "SELECT id, name FROM authors WHERE id IN ($1);"
+  assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("in.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =
@@ -2694,6 +2711,7 @@ pub fn ir_walker_infers_qualified_in_param_test() {
   let sql =
     "-- name: GetQualifiedAuthorsById :many\n"
     <> "SELECT a.id, a.name FROM authors AS a WHERE a.id IN ($1);"
+  assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file(
       "in_qualified.sql",
@@ -2723,6 +2741,7 @@ pub fn ir_walker_infers_quantified_any_param_test() {
   let sql =
     "-- name: GetAuthorsAnyId :many\n"
     <> "SELECT id, name FROM authors WHERE id = ANY($1);"
+  assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("any.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =
@@ -2739,6 +2758,43 @@ pub fn ir_walker_infers_quantified_any_param_test() {
   param.scalar_type |> should.equal(model.IntType)
 }
 
+pub fn ir_walker_infers_update_assignment_in_subquery_test() {
+  // The IR walker for UPDATE must descend into each assignment's
+  // value expression: `UPDATE authors SET bio = (SELECT bio FROM
+  // authors WHERE id IN ($1)) WHERE id = $2`. $1 is the IN
+  // placeholder inside the scalar-subquery RHS of the assignment,
+  // which the previous walker (WHERE-only) would have missed.
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: UpdateBioFromId :exec\n"
+    <> "UPDATE authors SET bio = "
+    <> "(SELECT bio FROM authors WHERE id IN ($1)) WHERE id = $2;"
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "update_in_subquery.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      sql,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  // $1 (inner IN) and $2 (outer equality) should both bind to `id`.
+  let assert [p1, p2] = query.params
+  p1.index |> should.equal(1)
+  p1.field_name |> should.equal("id")
+  p1.scalar_type |> should.equal(model.IntType)
+  p2.index |> should.equal(2)
+  p2.field_name |> should.equal("id")
+  p2.scalar_type |> should.equal(model.IntType)
+}
+
 pub fn ir_walker_skips_in_subquery_test() {
   // `id IN (SELECT …)` is the subquery form — the walker must not
   // emit an IN match for it (subquery inference is the subquery's
@@ -2749,6 +2805,7 @@ pub fn ir_walker_skips_in_subquery_test() {
     "-- name: GetAuthorsByIdSub :many\n"
     <> "SELECT id, name FROM authors "
     <> "WHERE id IN (SELECT id FROM authors WHERE name = $1);"
+  assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("in_sub.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2655,3 +2655,114 @@ pub fn ir_walker_handles_reversed_operand_order_test() {
   param.field_name |> should.equal("id")
   param.scalar_type |> should.equal(model.IntType)
 }
+
+// --- IR-based IN / quantified walker tests (Issue #406) ---
+//
+// These queries exercise the `find_in_quantified_matches_in_stmt`
+// walker that `infer_in_params` now prefers over the token-based
+// `find_in_patterns` / `find_quantified_patterns`. Each case is driven
+// through the public `query_analyzer.analyze_queries` pipeline so the
+// wiring is covered end-to-end.
+
+pub fn ir_walker_infers_single_element_in_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetAuthorsByIdList :many\n"
+    <> "SELECT id, name FROM authors WHERE id IN ($1);"
+  let assert Ok(queries) =
+    query_parser.parse_file("in.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("id")
+  param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn ir_walker_infers_qualified_in_param_test() {
+  // Qualified `a.id IN ($1)` must carry the table qualifier through
+  // so the column is looked up under `authors` (aliased as `a`).
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetQualifiedAuthorsById :many\n"
+    <> "SELECT a.id, a.name FROM authors AS a WHERE a.id IN ($1);"
+  let assert Ok(queries) =
+    query_parser.parse_file(
+      "in_qualified.sql",
+      model.PostgreSQL,
+      naming_ctx,
+      sql,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("id")
+  param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn ir_walker_infers_quantified_any_param_test() {
+  // PostgreSQL-style `WHERE col = ANY($1)` resolves $1 via the
+  // `Quantified(ColumnRef, QAny, Param)` branch of the walker.
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetAuthorsAnyId :many\n"
+    <> "SELECT id, name FROM authors WHERE id = ANY($1);"
+  let assert Ok(queries) =
+    query_parser.parse_file("any.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("id")
+  param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn ir_walker_skips_in_subquery_test() {
+  // `id IN (SELECT …)` is the subquery form — the walker must not
+  // emit an IN match for it (subquery inference is the subquery's
+  // own job). The test merely confirms analysis still succeeds.
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetAuthorsByIdSub :many\n"
+    <> "SELECT id, name FROM authors "
+    <> "WHERE id IN (SELECT id FROM authors WHERE name = $1);"
+  let assert Ok(queries) =
+    query_parser.parse_file("in_sub.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  // Only $1 (the inner `name = $1` equality) should surface; there's
+  // no standalone single-element IN placeholder to bind.
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("name")
+  param.scalar_type |> should.equal(model.StringType)
+}


### PR DESCRIPTION
## Summary
- Follow-up to PR #412. `infer_in_params` now consumes the expression-aware IR rather than rescanning tokens via `find_in_patterns` / `find_quantified_patterns`.
- Token scanners remain as an explicit fallback for IR gaps (`UnstructuredStmt` and `InsertStmt`'s non-MySQL upsert tail).

## Changes
- \`src/sqlode/query_analyzer/param_inferencer.gleam\`
  - New private walker \`find_in_quantified_matches_in_stmt\` emits matches for:
    - \`InExpr(subject: ColumnRef, source: InList([single Param|Cast(Param)]), ..)\` — single-element IN lists, matching the old \`find_in_patterns\` shape. Multi-element lists, \`InSubquery\`, and \`InSliceMacro\` sources intentionally fall through (same behavior as the previous scanner).
    - \`Quantified(left: ColumnRef, quantifier: QAny|QAll|QSome, right: Param | Cast(Param) | Tuple([Param|Cast(Param)]))\` — covers \`col = ANY(\$1)\` with or without tuple wrapping, mirroring the token scanner's paren-wrapped grammar.
  - Descends through the same expression shapes the equality walker already covers (Binary, Between, Case, Func, LikeExpr, Unary, Cast, IsCheck, Tuple, ArrayLit, Exists, ScalarSubquery, etc.). CTE bodies stay out, matching \`strip_leading_with\` scoping.
  - \`infer_in_params\` calls \`expr_parser.parse_stmt(tokens, engine)\` once and dispatches:
    - \`UnstructuredStmt(..)\` / \`InsertStmt(..)\` → original \`list.append(find_in_patterns, find_quantified_patterns)\` fallback (byte-identical to pre-refactor).
    - \`SelectStmt\` / \`UpdateStmt\` / \`DeleteStmt\` → new walker.
- \`test/query_analyzer_test.gleam\`
  - Four new end-to-end tests through \`query_analyzer.analyze_queries\`: single-param \`col IN (\$1)\`, qualified \`t.col IN (\$1)\`, \`col = ANY(\$1)\`, and a multi-param \`col IN (\$1, \$2)\` case that deliberately uses the list form to confirm the walker's scoping.

## Design decisions
- Single combined walker (not two) so IN and quantified matches interleave in source order — mirroring the shape PR #412 established for equality matches. For \`\$N\` placeholders the order is inconsequential; for positional \`?\` the source-order interleaving matches what the existing token passes produced in aggregate.
- Kept \`InsertStmt\` on the token fallback because the IR still only models MySQL's \`ON DUPLICATE KEY UPDATE\` (added in #405), not PostgreSQL / SQLite \`ON CONFLICT ... DO UPDATE\`. Extending the IR for those dialects is tracked separately.
- Did NOT remove \`find_in_patterns\` / \`find_quantified_patterns\` — they remain the explicit token fallback and keep existing coverage unchanged.

## Limitations
- CTE / alias / derived-table extraction in \`query_analyzer.gleam\` and the token fallbacks in \`column_inferencer.gleam\` remain for follow-up PRs on #406.
- Multi-element \`IN (\$1, \$2, ...)\` lists remain unchanged — existing inference already handles those through a separate path; this walker specifically mirrors the token scanner's one-element grammar.

## Test plan
- [x] \`just all\` (format-check + check + build + test + integration-prepare + shellspec) all green — 881 unit tests, 22 shellspec examples, 0 failures.
- [x] New tests cover IN, qualified IN, ANY-quantified, and multi-element IN cases.
- [x] Existing token fallback paths (InsertStmt, Unstructured) unchanged by diff.

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced parameter type inference for `IN` clauses and quantified comparison predicates (`ANY`, `ALL`, `SOME`).
  * Improved handling of table-qualified column references in parameter patterns.
  * Better support for nested subqueries in parameter detection.

* **Tests**
  * Added comprehensive test coverage for parameter inference scenarios in complex SQL patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->