### PR TITLE
feat: add first-class MySQL ENUM and SET support to the schema pipeline

### DIFF
--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -76,6 +76,10 @@ pub fn render(
 
   let enum_types =
     catalog.enums
+    // MySqlSet resolves to a plain StringType column, so emitting a
+    // Gleam sum type for it would be unreferenced dead code. Values
+    // are still preserved in the catalog for future native SET support.
+    |> list.filter(fn(e) { e.kind != model.MySqlSet })
     |> list.map(render_enum_type)
     |> string.join("\n\n")
 

--- a/src/sqlode/model.gleam
+++ b/src/sqlode/model.gleam
@@ -225,8 +225,25 @@ pub type ScalarType {
   ArrayType(element: ScalarType)
 }
 
+pub type EnumKind {
+  /// PostgreSQL `CREATE TYPE name AS ENUM (...)` — declared as a
+  /// standalone type in the catalog. Codegen emits a Gleam sum type
+  /// plus `*_to_string` / `*_from_string` helpers.
+  PostgresEnum
+  /// MySQL inline `ENUM(...)` on a column. Synthesized at parse time
+  /// with a name of `<table>_<column>`. Codegen treats this
+  /// identically to `PostgresEnum` (sum type + helpers) — the column
+  /// is typed as `EnumType(synthetic_name)`.
+  MySqlEnum
+  /// MySQL inline `SET(...)` on a column. Values are preserved in the
+  /// catalog for future native SET support, but the column itself is
+  /// typed as `StringType` (documented fallback). Codegen skips
+  /// emission so there is no unreferenced sum type in the output.
+  MySqlSet
+}
+
 pub type EnumDef {
-  EnumDef(name: String, values: List(String))
+  EnumDef(name: String, values: List(String), kind: EnumKind)
 }
 
 /// Parse a SQL type name into a ScalarType by normalizing the type token

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -96,23 +96,35 @@ fn parse_content(
         False ->
           case is_alter_table_add_column_tokens(stmt_tokens) {
             True -> {
-              use new_tables <- result.try(apply_alter_table_add_column(
-                path,
-                stmt_tokens,
-                current_enums,
-                tables,
+              use #(new_tables, added_enums) <- result.try(
+                apply_alter_table_add_column(
+                  path,
+                  stmt_tokens,
+                  current_enums,
+                  tables,
+                  engine,
+                ),
+              )
+              Ok(#(
+                new_tables,
+                list.append(current_enums, added_enums),
+                warnings,
               ))
-              Ok(#(new_tables, current_enums, warnings))
             }
             False -> {
               use stmt_result <- result.try(parse_statement_tokens(
                 path,
                 stmt_tokens,
                 current_enums,
+                engine,
               ))
               case stmt_result {
-                CreateTableResult(table:) ->
-                  Ok(#([table, ..tables], current_enums, warnings))
+                CreateTableResult(table:, new_enums:) ->
+                  Ok(#(
+                    [table, ..tables],
+                    list.append(current_enums, new_enums),
+                    warnings,
+                  ))
                 DDLApplied(action:) -> {
                   let #(new_tables, new_enums) =
                     apply_ddl_action(action, tables, current_enums)
@@ -187,7 +199,7 @@ fn parse_create_enum_from_tokens(
         _ -> ""
       }
       let values = extract_enum_values(rest, [])
-      Ok(model.EnumDef(name:, values:))
+      Ok(model.EnumDef(name:, values:, kind: model.PostgresEnum))
     }
     _ -> Error(Nil)
   }
@@ -548,34 +560,41 @@ fn is_alter_table_add_column_tokens(tokens: List(lexer.Token)) -> Bool {
 }
 
 /// Parse ALTER TABLE <name> ADD [COLUMN] <col_def> and apply to existing tables.
+///
+/// Returns both the updated table list and any enum definitions synthesized
+/// from inline MySQL `ENUM(...)` / `SET(...)` column types, so the caller can
+/// thread them into the running catalog.
 fn apply_alter_table_add_column(
   path: String,
   tokens: List(lexer.Token),
   enums: List(model.EnumDef),
   tables: List(model.Table),
-) -> Result(List(model.Table), ParseError) {
+  engine: model.Engine,
+) -> Result(#(List(model.Table), List(model.EnumDef)), ParseError) {
   let #(table_name, col_tokens) = extract_alter_table_parts(tokens)
 
   case table_name {
-    "" -> Ok(tables)
+    "" -> Ok(#(tables, []))
     _ -> {
       use maybe_col <- result.try(parse_column_tokens(
         path,
         table_name,
         col_tokens,
         enums,
+        engine,
       ))
       case maybe_col {
-        None -> Ok(tables)
-        Some(col) ->
-          Ok(
+        None -> Ok(#(tables, []))
+        Some(#(col, new_enums)) ->
+          Ok(#(
             list.map(tables, fn(t) {
               case t.name == table_name {
                 True -> model.Table(..t, columns: list.append(t.columns, [col]))
                 False -> t
               }
             }),
-          )
+            new_enums,
+          ))
       }
     }
   }
@@ -613,7 +632,7 @@ fn extract_ident(token: lexer.Token) -> String {
 }
 
 type StatementResult {
-  CreateTableResult(table: model.Table)
+  CreateTableResult(table: model.Table, new_enums: List(model.EnumDef))
   DDLApplied(action: DDLAction)
   Ignored
 }
@@ -622,6 +641,7 @@ fn parse_statement_tokens(
   path: String,
   tokens: List(lexer.Token),
   enums: List(model.EnumDef),
+  engine: model.Engine,
 ) -> Result(StatementResult, ParseError) {
   case is_create_table_tokens(tokens) {
     True -> {
@@ -629,9 +649,10 @@ fn parse_statement_tokens(
         path,
         tokens,
         enums,
+        engine,
       ))
       case maybe_table {
-        Some(table) -> Ok(CreateTableResult(table:))
+        Some(#(table, new_enums)) -> Ok(CreateTableResult(table:, new_enums:))
         None -> Ok(Ignored)
       }
     }
@@ -1005,7 +1026,8 @@ fn parse_create_table_tokens(
   path: String,
   tokens: List(lexer.Token),
   enums: List(model.EnumDef),
-) -> Result(Option(model.Table), ParseError) {
+  engine: model.Engine,
+) -> Result(Option(#(model.Table, List(model.EnumDef))), ParseError) {
   // Find the table name: last Ident/QuotedIdent before the first LParen
   let #(header, body) = split_at_lparen(tokens, [])
 
@@ -1026,13 +1048,14 @@ fn parse_create_table_tokens(
       // Strip trailing RParen from body
       let body_tokens = strip_trailing_rparen(body)
 
-      use columns <- result.try(parse_columns_tokens(
+      use #(columns, new_enums) <- result.try(parse_columns_tokens(
         path,
         table_name,
         body_tokens,
         enums,
+        engine,
       ))
-      Ok(Some(model.Table(name: table_name, columns:)))
+      Ok(Some(#(model.Table(name: table_name, columns:), new_enums)))
     }
   }
 }
@@ -1082,21 +1105,31 @@ fn parse_columns_tokens(
   table_name: String,
   tokens: List(lexer.Token),
   enums: List(model.EnumDef),
-) -> Result(List(model.Column), ParseError) {
+  engine: model.Engine,
+) -> Result(#(List(model.Column), List(model.EnumDef)), ParseError) {
   split_tokens_by_comma(tokens)
-  |> list.try_fold([], fn(columns, col_tokens) {
+  |> list.try_fold(#([], []), fn(acc, col_tokens) {
+    let #(columns, collected_enums) = acc
+    // Each column sees all enums known so far (including ones synthesized
+    // from earlier inline MySQL ENUM(...) columns in the same table), so a
+    // later column referencing the synthesized name could in theory resolve
+    // it. This is symmetrical to how top-level CREATE TYPE enums are
+    // threaded through the fold in parse_content.
+    let visible_enums = list.append(enums, collected_enums)
     use maybe_column <- result.try(parse_column_tokens(
       path,
       table_name,
       col_tokens,
-      enums,
+      visible_enums,
+      engine,
     ))
-    Ok(case maybe_column {
-      Some(column) -> [column, ..columns]
-      None -> columns
-    })
+    case maybe_column {
+      Some(#(column, new_enums)) ->
+        Ok(#([column, ..columns], list.append(collected_enums, new_enums)))
+      None -> Ok(acc)
+    }
   })
-  |> result.map(list.reverse)
+  |> result.map(fn(pair) { #(list.reverse(pair.0), pair.1) })
 }
 
 /// Split a token list by top-level commas (depth-0 only).
@@ -1147,7 +1180,8 @@ fn parse_named_column(
   all_tokens: List(lexer.Token),
   rest: List(lexer.Token),
   enums: List(model.EnumDef),
-) -> Result(Option(model.Column), ParseError) {
+  engine: model.Engine,
+) -> Result(Option(#(model.Column, List(model.EnumDef))), ParseError) {
   let name = naming.normalize_identifier(raw_name)
   let type_toks = take_type_tokens_from_lexer(rest, [])
   case type_toks {
@@ -1157,32 +1191,16 @@ fn parse_named_column(
         table: table_name,
         detail: "missing type for column " <> name,
       ))
-    _ -> {
-      let type_text = render_type_tokens(type_toks)
-      let nullable = case
-        tokens_contain_not_null(all_tokens)
-        || tokens_contain_keyword(all_tokens, "primary")
-        || string.contains(type_text, "serial")
-      {
-        True -> False
-        False -> True
-      }
-      use scalar_type <- result.try(case find_enum(type_text, enums) {
-        Some(enum_name) -> Ok(model.EnumType(enum_name))
-        None ->
-          infer_scalar_type(type_text)
-          |> result.map_error(fn(detail) {
-            InvalidColumn(path: path, table: table_name, detail: detail)
-          })
-      })
-      Ok(
-        Some(model.Column(
-          name: name,
-          scalar_type: scalar_type,
-          nullable: nullable,
-        )),
+    _ ->
+      build_column_from_type_tokens(
+        path,
+        table_name,
+        name,
+        all_tokens,
+        type_toks,
+        enums,
+        engine,
       )
-    }
   }
 }
 
@@ -1191,7 +1209,8 @@ fn parse_column_tokens(
   table_name: String,
   tokens: List(lexer.Token),
   enums: List(model.EnumDef),
-) -> Result(Option(model.Column), ParseError) {
+  engine: model.Engine,
+) -> Result(Option(#(model.Column, List(model.EnumDef))), ParseError) {
   case tokens {
     [] -> Ok(None)
     [first, ..rest] ->
@@ -1205,7 +1224,7 @@ fn parse_column_tokens(
         // are frequently used as column identifiers in user schemas.
         // Accept them here the same way Ident/QuotedIdent are handled.
         lexer.Keyword(n) ->
-          parse_named_column(path, table_name, n, tokens, rest, enums)
+          parse_named_column(path, table_name, n, tokens, rest, enums, engine)
         lexer.Ident(n) | lexer.QuotedIdent(n) -> {
           let name = naming.normalize_identifier(n)
           let type_toks = take_type_tokens_from_lexer(rest, [])
@@ -1217,33 +1236,119 @@ fn parse_column_tokens(
                 table: table_name,
                 detail: "missing type for column " <> name,
               ))
-            _ -> {
-              let type_text = render_type_tokens(type_toks)
-              let nullable = case
-                tokens_contain_not_null(tokens)
-                || tokens_contain_keyword(tokens, "primary")
-                || string.contains(type_text, "serial")
-              {
-                True -> False
-                False -> True
-              }
-
-              use scalar_type <- result.try(case find_enum(type_text, enums) {
-                Some(enum_name) -> Ok(model.EnumType(enum_name))
-                None ->
-                  infer_scalar_type(type_text)
-                  |> result.map_error(fn(detail) {
-                    InvalidColumn(path:, table: table_name, detail:)
-                  })
-              })
-
-              Ok(Some(model.Column(name:, scalar_type:, nullable:)))
-            }
+            _ ->
+              build_column_from_type_tokens(
+                path,
+                table_name,
+                name,
+                tokens,
+                type_toks,
+                enums,
+                engine,
+              )
           }
         }
         _ -> Ok(None)
       }
   }
+}
+
+/// Shared logic for `parse_named_column` and `parse_column_tokens`.
+/// Inspects the column's type tokens, detects MySQL inline `ENUM(...)`
+/// or `SET(...)` when `engine == MySQL`, synthesizes enum definitions,
+/// and falls through to the shared lookup / `parse_sql_type` pipeline
+/// otherwise.
+fn build_column_from_type_tokens(
+  path: String,
+  table_name: String,
+  name: String,
+  all_tokens: List(lexer.Token),
+  type_toks: List(lexer.Token),
+  enums: List(model.EnumDef),
+  engine: model.Engine,
+) -> Result(Option(#(model.Column, List(model.EnumDef))), ParseError) {
+  let type_text = render_type_tokens(type_toks)
+  let nullable = case
+    tokens_contain_not_null(all_tokens)
+    || tokens_contain_keyword(all_tokens, "primary")
+    || string.contains(type_text, "serial")
+  {
+    True -> False
+    False -> True
+  }
+
+  case detect_mysql_inline_enum_set(type_toks, table_name, name, engine) {
+    Some(InlineEnum(scalar_type:, new_enum:)) ->
+      Ok(Some(#(model.Column(name:, scalar_type:, nullable:), [new_enum])))
+    None -> {
+      use scalar_type <- result.try(case find_enum(type_text, enums) {
+        Some(enum_name) -> Ok(model.EnumType(enum_name))
+        None ->
+          infer_scalar_type(type_text)
+          |> result.map_error(fn(detail) {
+            InvalidColumn(path:, table: table_name, detail:)
+          })
+      })
+      Ok(Some(#(model.Column(name:, scalar_type:, nullable:), [])))
+    }
+  }
+}
+
+type InlineEnumDetection {
+  InlineEnum(scalar_type: model.ScalarType, new_enum: model.EnumDef)
+}
+
+/// Detect MySQL inline `ENUM(...)` / `SET(...)` on a column's type
+/// tokens. Gated by `engine == MySQL` so PostgreSQL/SQLite schemas —
+/// where `enum` / `set` could conceivably appear as a non-type keyword
+/// elsewhere — keep their existing behavior.
+///
+/// The name synthesis rule is `<lowercased_table>_<column>`, which
+/// lets two tables carry columns with overlapping value sets without
+/// colliding. For SET the column resolves to `StringType` (the
+/// documented fallback per Issue #407) but the values are still
+/// preserved in the catalog for future native SET support.
+fn detect_mysql_inline_enum_set(
+  type_toks: List(lexer.Token),
+  table_name: String,
+  column_name: String,
+  engine: model.Engine,
+) -> Option(InlineEnumDetection) {
+  case engine {
+    model.MySQL ->
+      case type_toks {
+        [lexer.Keyword("enum"), lexer.LParen, ..rest] -> {
+          let values = extract_enum_values(rest, [])
+          let synthetic = synthetic_enum_name(table_name, column_name)
+          Some(InlineEnum(
+            scalar_type: model.EnumType(synthetic),
+            new_enum: model.EnumDef(
+              name: synthetic,
+              values:,
+              kind: model.MySqlEnum,
+            ),
+          ))
+        }
+        [lexer.Keyword("set"), lexer.LParen, ..rest] -> {
+          let values = extract_enum_values(rest, [])
+          let synthetic = synthetic_enum_name(table_name, column_name)
+          Some(InlineEnum(
+            scalar_type: model.StringType,
+            new_enum: model.EnumDef(
+              name: synthetic,
+              values:,
+              kind: model.MySqlSet,
+            ),
+          ))
+        }
+        _ -> None
+      }
+    _ -> None
+  }
+}
+
+fn synthetic_enum_name(table_name: String, column_name: String) -> String {
+  string.lowercase(table_name) <> "_" <> string.lowercase(column_name)
 }
 
 fn take_type_tokens_from_lexer(

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -1202,3 +1202,76 @@ pub fn readme_runtime_prepare_is_two_arg_test() {
   string.contains(readme, "\"$\",  // \"$\" for PostgreSQL")
   |> should.be_false()
 }
+
+// --- Issue #407: MySQL inline ENUM / SET codegen ---
+
+fn mysql_enum_set_catalog() -> model.Catalog {
+  let content =
+    "CREATE TABLE items (\n"
+    <> "  id BIGINT NOT NULL,\n"
+    <> "  status ENUM('active', 'inactive', 'archived') NOT NULL,\n"
+    <> "  tags SET('red', 'green', 'blue')\n"
+    <> ");"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files_with_engine(
+      [#("items.sql", content)],
+      model.MySQL,
+    )
+  catalog
+}
+
+pub fn render_mysql_inline_enum_emits_sum_type_test() {
+  // A MySqlEnum EnumDef should emit a Gleam sum type + helpers, just
+  // like a PostgresEnum. The column references the synthesized name
+  // (`items_status` → `ItemsStatus`) so the generated models module
+  // compiles against the table type.
+  let naming_ctx = naming.new()
+  let catalog = mysql_enum_set_catalog()
+  let rendered =
+    models.render(
+      naming_ctx,
+      catalog,
+      [],
+      dict.new(),
+      model.StringMapping,
+      False,
+    )
+
+  string.contains(rendered, "pub type ItemsStatus {")
+  |> should.be_true()
+  string.contains(rendered, "Active")
+  |> should.be_true()
+  string.contains(rendered, "Inactive")
+  |> should.be_true()
+  string.contains(rendered, "Archived")
+  |> should.be_true()
+  string.contains(rendered, "pub fn items_status_to_string(")
+  |> should.be_true()
+  string.contains(rendered, "pub fn items_status_from_string(")
+  |> should.be_true()
+}
+
+pub fn render_mysql_inline_set_skips_sum_type_test() {
+  // A MySqlSet EnumDef must not produce a Gleam sum type — the column
+  // is a StringType fallback, so an unreferenced sum type would be
+  // dead code. Values are still kept on the catalog for future native
+  // SET support.
+  let naming_ctx = naming.new()
+  let catalog = mysql_enum_set_catalog()
+  let rendered =
+    models.render(
+      naming_ctx,
+      catalog,
+      [],
+      dict.new(),
+      model.StringMapping,
+      False,
+    )
+
+  string.contains(rendered, "pub type ItemsTags")
+  |> should.be_false()
+  string.contains(rendered, "items_tags_to_string")
+  |> should.be_false()
+  string.contains(rendered, "items_tags_from_string")
+  |> should.be_false()
+}

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -159,6 +159,45 @@ pub fn schema_enum_type_test() {
   mood_col.scalar_type |> should.equal(model.EnumType("mood"))
 }
 
+pub fn mysql_inline_enum_and_set_columns_test() {
+  // Issue #407: MySQL `CREATE TABLE` may declare ENUM / SET inline on a
+  // column. The parser should preserve the allowed values in the catalog
+  // — ENUM columns as synthesized EnumType references, SET columns as
+  // a StringType fallback with values kept on the catalog side.
+  let content =
+    "CREATE TABLE items (\n"
+    <> "  id BIGINT NOT NULL,\n"
+    <> "  status ENUM('active', 'inactive', 'archived') NOT NULL,\n"
+    <> "  tags SET('red', 'green', 'blue')\n"
+    <> ");"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files_with_engine(
+      [#("items.sql", content)],
+      model.MySQL,
+    )
+
+  let assert [table] = catalog.tables
+  table.name |> should.equal("items")
+
+  let assert Ok(status_col) =
+    list.find(table.columns, fn(c) { c.name == "status" })
+  status_col.scalar_type |> should.equal(model.EnumType("items_status"))
+  status_col.nullable |> should.equal(False)
+
+  let assert Ok(tags_col) = list.find(table.columns, fn(c) { c.name == "tags" })
+  tags_col.scalar_type |> should.equal(model.StringType)
+
+  let assert Ok(status_enum) =
+    list.find(catalog.enums, fn(e) { e.name == "items_status" })
+  status_enum.values |> should.equal(["active", "inactive", "archived"])
+  status_enum.kind |> should.equal(model.MySqlEnum)
+
+  let assert Ok(tags_enum) =
+    list.find(catalog.enums, fn(e) { e.name == "items_tags" })
+  tags_enum.values |> should.equal(["red", "green", "blue"])
+  tags_enum.kind |> should.equal(model.MySqlSet)
+}
+
 pub fn view_with_cast_expression_test() {
   let content =
     "CREATE TABLE t (x TEXT NOT NULL, y TEXT NOT NULL);\n"


### PR DESCRIPTION
## Summary
- Parse MySQL inline `ENUM(...)` and `SET(...)` column types without requiring a user override.
- Preserve the allowed values in the catalog so codegen (or future consumers) can reason about them.
- Codegen emits a real Gleam sum type for MySQL `ENUM` columns and a documented `String` fallback for MySQL `SET` columns.

## Changes
- `src/sqlode/model.gleam`
  - New `EnumKind` variant: `PostgresEnum | MySqlEnum | MySqlSet`.
  - `EnumDef` grows a `kind: EnumKind` field. Existing construction site (`parse_create_enum_from_tokens`) sets `kind: PostgresEnum` so PostgreSQL enum handling is byte-compatible.
- `src/sqlode/schema_parser.gleam`
  - New `detect_mysql_inline_enum_set` helper recognises `[Keyword("enum"), LParen, ...]` or `[Keyword("set"), LParen, ...]` at the head of a column's type token slice when `engine == model.MySQL`.
  - Synthesises the enum name as `<lowercased_table>_<lowercased_column>` so two tables with overlapping value sets stay isolated.
  - Column parser signature grew an `engine` argument and returns `Option(#(Column, List(EnumDef)))`. The per-statement fold in `parse_content` accumulates the new EnumDefs into `current_enums` exactly like the top-level `CREATE TYPE` path.
  - `CreateTableResult` grew a `new_enums: List(EnumDef)` field; `apply_alter_table_add_column` returns the same information so `ALTER TABLE … ADD COLUMN` paths stay on the same rails.
  - Shared body extracted into `build_column_from_type_tokens` so the keyword and ident column-name branches don't duplicate the enum/set detection.
- `src/sqlode/codegen/models.gleam`
  - Filter `catalog.enums` by `kind != MySqlSet` before rendering — `MySqlEnum` still emits the identical sum type that `PostgresEnum` does. SET values remain in the catalog for future passes that want them.
- `test/schema_parser_test.gleam`
  - `mysql_inline_enum_and_set_columns_test` pins the catalog shape: `status` column resolves to `EnumType(\"items_status\")`, `tags` column resolves to `StringType`, and both EnumDefs land in the catalog with the expected `kind`.
- `test/codegen_test.gleam`
  - `render_mysql_inline_enum_emits_sum_type_test` asserts the generated Gleam code contains the enum sum type.
  - `render_mysql_inline_set_skips_sum_type_test` asserts the generated Gleam code contains no sum type for the SET variant.

## Design decisions
- **Discriminator via `EnumKind` rather than name prefixes**. The issue asks that values be preserved even when codegen picks a fallback representation. A typed discriminator keeps the catalog shape uniform while letting codegen make a per-kind decision, and leaves room for a future native SET codegen.
- **SET → `StringType` fallback**. SET stores a comma-separated subset, which doesn't map cleanly to a Gleam sum type. Emitting a typed alias or parser/serialiser pair here is its own design exercise; the issue explicitly lists a documented fallback as acceptable. Values are still recorded on the catalog `EnumDef` for later use.
- **`<table>_<column>` naming** avoids collisions when two tables pick overlapping literal sets. Going through `type_mapping.enum_type_name` produces `ItemsStatus` / `OrdersStatus` etc. in generated Gleam, which is unambiguous without extra work.
- **No new `ScalarType` variants**. Adding `MySqlEnumType` / `MySqlSetType` would have forced pattern-match updates across ~78 sites in 12 files. Reusing `EnumType` for MySQL enums keeps the diff local and lets the codegen sum-type path do all the heavy lifting unchanged.

## Limitations
- `ALTER TABLE ADD COLUMN` paths carry the same support as `CREATE TABLE`; `ALTER TABLE MODIFY COLUMN` that changes a column from a non-enum type to an enum/set form is not exercised by the new tests but uses the same code path.
- SET support stops at value preservation. Runtime validation or a typed SET wrapper would be a follow-up.
- MySQL is the only engine gated for inline enum/set parsing. PostgreSQL inline enums are unchanged — they still go through the top-level `CREATE TYPE … AS ENUM` path.

## Test plan
- [x] `just all` (format-check + check + build + test + integration-prepare + shellspec) all green — 885 unit tests, 22 shellspec examples, 0 failures.
- [x] New schema test parses a table with both ENUM and SET columns end-to-end.
- [x] New codegen tests pin MySQL enum and MySQL set rendering behaviour.

Closes #407