### PR TITLE
refactor: drive CTE/values/derived/alias scope from the expression-aware IR

### DIFF
--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -8,6 +8,7 @@ import sqlode/naming
 import sqlode/query_analyzer/column_inferencer
 import sqlode/query_analyzer/context
 import sqlode/query_analyzer/embed_rewriter
+import sqlode/query_analyzer/expr_parser
 import sqlode/query_analyzer/param_inferencer
 import sqlode/query_analyzer/placeholder
 import sqlode/query_analyzer/token_utils
@@ -42,27 +43,55 @@ fn analyze_query(
   // in FROM, and derived-table subqueries — so both result-column and
   // parameter inference see them. Nested subqueries rediscover their
   // own VALUES / derived tables inside infer_columns_from_tokens_scoped.
-  use cte_tables <- result.try(column_inferencer.extract_cte_tables(
-    query.name,
-    tokens,
-    catalog,
-  ))
+  //
+  // Issue #406: drive the virtual-table classification from the
+  // expression-aware IR (`query_ir.Stmt`) instead of rescanning the
+  // raw token stream. The parsed `Stmt` is the single source of
+  // truth for WHICH virtual tables exist; when the parser produces
+  // `UnstructuredStmt` (an IR gap), we fall back to the token-based
+  // extractors. This mirrors the dispatch pattern PRs #412 and #413
+  // established for equality / IN / quantified parameter inference.
+  let stmt = expr_parser.parse_stmt(tokens, engine)
+  use cte_tables <- result.try(case stmt {
+    query_ir.UnstructuredStmt(..) ->
+      column_inferencer.extract_cte_tables(query.name, tokens, catalog)
+    _ ->
+      column_inferencer.extract_cte_tables_from_stmt(
+        query.name,
+        stmt,
+        tokens,
+        catalog,
+      )
+  })
   let with_ctes = merge_virtual_tables(catalog, cte_tables)
-  let values_tables = column_inferencer.extract_values_tables(tokens)
+  let values_tables = case stmt {
+    query_ir.UnstructuredStmt(..) ->
+      column_inferencer.extract_values_tables(tokens)
+    _ -> column_inferencer.extract_values_tables_from_stmt(stmt)
+  }
   let with_values = merge_virtual_tables(with_ctes, values_tables)
-  use derived_tables <- result.try(column_inferencer.extract_derived_tables(
-    query.name,
-    tokens,
-    with_values,
-  ))
+  use derived_tables <- result.try(case stmt {
+    query_ir.UnstructuredStmt(..) ->
+      column_inferencer.extract_derived_tables(query.name, tokens, with_values)
+    _ ->
+      column_inferencer.extract_derived_tables_from_stmt(
+        query.name,
+        stmt,
+        tokens,
+        with_values,
+      )
+  })
   let with_derived = merge_virtual_tables(with_values, derived_tables)
   // Register `FROM table AS alias` / `JOIN table AS alias` aliases so
   // qualified refs like `p.user_id` in a query that writes
   // `FROM posts AS p` resolve to `posts`. This is the single hook
   // that lets the expression-aware IR reason about aliased column
   // references without re-implementing alias resolution everywhere.
-  let alias_tables =
-    column_inferencer.extract_table_aliases(tokens, with_derived)
+  let alias_tables = case stmt {
+    query_ir.UnstructuredStmt(..) ->
+      column_inferencer.extract_table_aliases(tokens, with_derived)
+    _ -> column_inferencer.extract_table_aliases_from_stmt(stmt, with_derived)
+  }
   let augmented = merge_virtual_tables(with_derived, alias_tables)
 
   let occurrences = placeholder.extract(ctx, engine, tokens)

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -886,6 +886,251 @@ fn parse_derived_alias(
   }
 }
 
+// ============================================================
+// IR-driven virtual-table scope (Issue #406)
+//
+// These four `*_from_stmt` helpers drive table / alias / derived-
+// table / CTE scope from the expression-aware IR produced by
+// `expr_parser.parse_stmt`, instead of rescanning the raw token
+// stream. `query_analyzer.analyze_query` dispatches to them when
+// the parser returns a structured `Stmt`; it falls back to the
+// token-based extractors above when the parser hits an IR gap
+// (`UnstructuredStmt`), mirroring the defensive pattern PRs #412
+// and #413 used for equality / IN / quantified parameter
+// inference.
+//
+// For CTE bodies and derived-table subquery bodies, the IR
+// extractors delegate to the existing token-based body inference
+// (same token input): the `Stmt` drives WHICH virtual tables
+// exist, but column-type inference inside a body still flows
+// through `infer_columns_from_tokens`. Re-serialising a nested
+// `Stmt` / `SelectCore` back to tokens is not practical without
+// a dedicated printer, and wiring a `SelectCore`-native body
+// resolver is deferred to a future refactor. VALUES / alias
+// classification is fully IR-native because the `FromValues` and
+// `FromTable(_, Some(alias))` variants already carry everything
+// we need.
+// ============================================================
+
+/// IR-driven counterpart to `extract_cte_tables`. Walks
+/// `stmt.ctes` to enumerate CTE definitions, then re-uses the
+/// existing token-based extractor for body-column inference.
+/// Returning `Ok([])` when the IR reports no CTEs matches the
+/// behaviour of the token-based extractor when no `WITH …` prefix
+/// is present.
+pub fn extract_cte_tables_from_stmt(
+  query_name: String,
+  stmt: query_ir.Stmt,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(List(model.Table), AnalysisError) {
+  case stmt_ctes(stmt) {
+    [] -> Ok([])
+    _ -> extract_cte_tables(query_name, tokens, catalog)
+  }
+}
+
+fn stmt_ctes(stmt: query_ir.Stmt) -> List(query_ir.CteDef) {
+  case stmt {
+    query_ir.SelectStmt(ctes:, ..) -> ctes
+    query_ir.InsertStmt(ctes:, ..) -> ctes
+    query_ir.UpdateStmt(ctes:, ..) -> ctes
+    query_ir.DeleteStmt(ctes:, ..) -> ctes
+    query_ir.UnstructuredStmt(..) -> []
+  }
+}
+
+/// IR-driven counterpart to `extract_values_tables`. Walks the
+/// statement's FROM clauses (and nested `FromJoin` trees, plus
+/// UPDATE/DELETE `from`/`using`) to find every `FromValues` and
+/// builds a `model.Table` using the first row's literal types.
+/// Rows whose expressions do not classify as simple literals are
+/// skipped silently, matching the token-based extractor.
+pub fn extract_values_tables_from_stmt(stmt: query_ir.Stmt) -> List(model.Table) {
+  list.filter_map(collect_from_items(stmt), ir_from_item_to_values_table)
+}
+
+fn ir_from_item_to_values_table(
+  from_item: query_ir.FromItemEx,
+) -> Result(model.Table, Nil) {
+  case from_item {
+    query_ir.FromValues(rows:, alias:, column_aliases:) ->
+      case alias, column_aliases, rows {
+        "", _, _ -> Error(Nil)
+        _, [], _ -> Error(Nil)
+        _, _, [] -> Error(Nil)
+        _, names, [first_row, ..] -> {
+          use types <- result.try(list.try_map(
+            first_row,
+            ir_literal_expr_to_type,
+          ))
+          Ok(model.Table(
+            name: string.lowercase(alias),
+            columns: build_values_columns(names, types),
+          ))
+        }
+      }
+    _ -> Error(Nil)
+  }
+}
+
+fn ir_literal_expr_to_type(
+  expr: query_ir.Expr,
+) -> Result(#(model.ScalarType, Bool), Nil) {
+  case expr {
+    query_ir.NumberLit(value: n) -> Ok(#(number_scalar_type(n), False))
+    query_ir.Unary(op: "-", arg: query_ir.NumberLit(value: n)) ->
+      Ok(#(number_scalar_type(n), False))
+    query_ir.Unary(op: "+", arg: query_ir.NumberLit(value: n)) ->
+      Ok(#(number_scalar_type(n), False))
+    query_ir.StringLit(_) -> Ok(#(model.StringType, False))
+    query_ir.BoolLit(_) -> Ok(#(model.BoolType, False))
+    query_ir.NullLit -> Ok(#(model.StringType, True))
+    _ -> Error(Nil)
+  }
+}
+
+/// IR-driven counterpart to `extract_derived_tables`. Walks the
+/// statement's FROM clauses (including nested `FromJoin` trees
+/// and UPDATE/DELETE `from`/`using`) to check whether any derived
+/// subquery exists. When one does, delegates to the existing
+/// token-based extractor for body-column inference — see the
+/// module-level comment for the rationale.
+pub fn extract_derived_tables_from_stmt(
+  query_name: String,
+  stmt: query_ir.Stmt,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(List(model.Table), AnalysisError) {
+  case list.any(collect_from_items(stmt), is_from_subquery) {
+    False -> Ok([])
+    True -> extract_derived_tables(query_name, tokens, catalog)
+  }
+}
+
+fn is_from_subquery(from_item: query_ir.FromItemEx) -> Bool {
+  case from_item {
+    query_ir.FromSubquery(..) -> True
+    _ -> False
+  }
+}
+
+/// IR-driven counterpart to `extract_table_aliases`. Walks the
+/// statement's FROM clauses (including nested `FromJoin` trees
+/// and UPDATE/DELETE target/alias) to register every `FROM table
+/// AS alias` as a virtual table pointing at the underlying
+/// table's columns. Same skip guards as the token-based path:
+/// aliases identical to the base name are skipped, aliases that
+/// shadow an existing catalog entry are skipped, and duplicate
+/// alias registrations collapse to the first occurrence.
+pub fn extract_table_aliases_from_stmt(
+  stmt: query_ir.Stmt,
+  catalog: model.Catalog,
+) -> List(model.Table) {
+  let aliased_pairs = collect_aliased_tables(stmt)
+  let acc_init: List(model.Table) = []
+  list.fold(aliased_pairs, acc_init, fn(acc, pair) {
+    let #(table_name, alias_name) = pair
+    case alias_name == table_name {
+      True -> acc
+      False ->
+        case
+          list.find(catalog.tables, fn(t: model.Table) { t.name == table_name })
+        {
+          Ok(found) ->
+            case list.any(acc, fn(t: model.Table) { t.name == alias_name }) {
+              True -> acc
+              False ->
+                case
+                  list.any(catalog.tables, fn(t: model.Table) {
+                    t.name == alias_name
+                  })
+                {
+                  True -> acc
+                  False -> [
+                    model.Table(name: alias_name, columns: found.columns),
+                    ..acc
+                  ]
+                }
+            }
+          Error(_) -> acc
+        }
+    }
+  })
+  |> list.reverse
+}
+
+/// Gather every `FromItemEx` from the top-level FROM clauses of
+/// the outer statement. Nested subqueries inside `FromSubquery`
+/// are not descended — they have their own scope and are
+/// discovered separately when the subquery is analysed.
+/// `FromJoin` trees are flattened so left/right sides are visited
+/// in source order.
+fn collect_from_items(stmt: query_ir.Stmt) -> List(query_ir.FromItemEx) {
+  case stmt {
+    query_ir.SelectStmt(core:, ..) ->
+      list.flat_map(core.from, flatten_from_item)
+    query_ir.UpdateStmt(from:, ..) -> list.flat_map(from, flatten_from_item)
+    query_ir.DeleteStmt(using:, ..) -> list.flat_map(using, flatten_from_item)
+    query_ir.InsertStmt(..) -> []
+    query_ir.UnstructuredStmt(..) -> []
+  }
+}
+
+fn flatten_from_item(from: query_ir.FromItemEx) -> List(query_ir.FromItemEx) {
+  case from {
+    query_ir.FromJoin(left:, right:, ..) ->
+      list.append(flatten_from_item(left), flatten_from_item(right))
+    _ -> [from]
+  }
+}
+
+/// Collect every `(table_name, alias_name)` pair reachable from
+/// the outer statement. Covers SELECT/UPDATE/DELETE FROM clauses
+/// (through `FromJoin` recursion) as well as UPDATE/DELETE target
+/// tables. INSERT target tables do not carry an alias in the IR,
+/// so they are not emitted. Unaliased tables (`FromTable(name,
+/// None)`) are skipped.
+fn collect_aliased_tables(stmt: query_ir.Stmt) -> List(#(String, String)) {
+  let from_aliases =
+    list.filter_map(collect_from_items(stmt), fn(item) {
+      case item {
+        query_ir.FromTable(name:, alias: Some(a)) -> {
+          let n = string.lowercase(name)
+          let al = string.lowercase(a)
+          case n, al {
+            "", _ -> Error(Nil)
+            _, "" -> Error(Nil)
+            _, _ -> Ok(#(n, al))
+          }
+        }
+        _ -> Error(Nil)
+      }
+    })
+  let dml_target = case stmt {
+    query_ir.UpdateStmt(table:, alias: Some(a), ..) -> {
+      let n = string.lowercase(table)
+      let al = string.lowercase(a)
+      case n, al {
+        "", _ -> []
+        _, "" -> []
+        _, _ -> [#(n, al)]
+      }
+    }
+    query_ir.DeleteStmt(table:, alias: Some(a), ..) -> {
+      let n = string.lowercase(table)
+      let al = string.lowercase(a)
+      case n, al {
+        "", _ -> []
+        _, "" -> []
+        _, _ -> [#(n, al)]
+      }
+    }
+    _ -> []
+  }
+  list.append(dml_target, from_aliases)
+}
+
 /// Extract RETURNING columns from tokens using token-based analysis.
 fn tok_extract_returning_columns(
   tokens: List(lexer.Token),

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2823,3 +2823,115 @@ pub fn ir_walker_skips_in_subquery_test() {
   param.field_name |> should.equal("name")
   param.scalar_type |> should.equal(model.StringType)
 }
+
+// ============================================================
+// Issue #406: IR-driven virtual-table scope integration tests.
+//
+// Each of the four IR extractors (CTE / VALUES / derived / alias)
+// gets a realistic query that is driven through the full
+// `query_analyzer.analyze_queries` pipeline. `assert_ir_select`
+// pins that `expr_parser.parse_stmt` produced a structured Stmt
+// (not UnstructuredStmt), guaranteeing the IR path is exercised
+// rather than the token fallback.
+// ============================================================
+
+pub fn ir_cte_virtual_table_resolves_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetCteIds :many\n"
+    <> "WITH cte AS (SELECT id FROM authors) SELECT id FROM cte;"
+  assert_ir_select(sql)
+  let assert Ok(queries) =
+    query_parser.parse_file("cte.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  query.result_columns
+  |> should.equal([
+    model.ScalarResult(model.ResultColumn(
+      name: "id",
+      scalar_type: model.IntType,
+      nullable: False,
+      source_table: Some("cte"),
+    )),
+  ])
+}
+
+pub fn ir_values_virtual_table_infers_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetValuesRows :many\n"
+    <> "SELECT n FROM (VALUES (1), (2)) AS v(n) WHERE n > $1;"
+  assert_ir_select(sql)
+  let assert Ok(queries) =
+    query_parser.parse_file("values.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  // Result column `n` resolves through the VALUES virtual table as IntType.
+  let assert [model.ScalarResult(col)] = query.result_columns
+  col.name |> should.equal("n")
+  col.scalar_type |> should.equal(model.IntType)
+  // The $1 placeholder compared against `n` must infer IntType too.
+  let assert [param] = query.params
+  param.index |> should.equal(1)
+  param.field_name |> should.equal("n")
+  param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn ir_derived_table_virtual_resolves_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetDerivedIds :many\n"
+    <> "SELECT t.id FROM (SELECT id FROM authors) AS t;"
+  assert_ir_select(sql)
+  let assert Ok(queries) =
+    query_parser.parse_file("derived.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  // The column resolves through the derived-table alias `t`, whose
+  // columns are inferred from the subquery body.
+  let assert [model.ScalarResult(col)] = query.result_columns
+  col.name |> should.equal("id")
+  col.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn ir_table_alias_resolves_qualified_column_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql = "-- name: GetAliasedIds :many\n" <> "SELECT a.id FROM authors AS a;"
+  assert_ir_select(sql)
+  let assert Ok(queries) =
+    query_parser.parse_file("alias.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  // `a.id` must resolve via the `authors AS a` alias back to `authors`.
+  let assert [model.ScalarResult(col)] = query.result_columns
+  col.name |> should.equal("id")
+  col.scalar_type |> should.equal(model.IntType)
+}


### PR DESCRIPTION
## Summary
- Final slice of Issue #406. `analyze_query` now parses the statement once and drives CTE, VALUES, derived-table, and table-alias scope from the resulting `query_ir.Stmt`.
- Token-based extractors remain as an explicit fallback for `UnstructuredStmt`, matching the pattern established by PRs #412 and #413.

## Changes
- `src/sqlode/query_analyzer.gleam`
  - Call `expr_parser.parse_stmt(tokens, engine)` once at the top of `analyze_query` and dispatch the four scope extractors on the parsed `Stmt`.
  - Each dispatch falls back to the matching token-based extractor when the result is `UnstructuredStmt`, so constructs the expression parser does not yet model keep working.
- `src/sqlode/query_analyzer/column_inferencer.gleam`
  - New `extract_cte_tables_from_stmt(query_name, stmt, tokens, catalog)` — keys on `Stmt.ctes` and delegates body-column inference to the existing token-based extractor. Short-circuits when the statement has no CTEs.
  - New `extract_values_tables_from_stmt(stmt)` — fully IR-native. Walks `SelectCore.from` / `FromJoin` trees for `FromValues(rows, alias, column_aliases)` and classifies the first-row `Expr` literals (NumberLit / StringLit / BoolLit / NullLit) without a token pass.
  - New `extract_derived_tables_from_stmt(query_name, stmt, tokens, catalog)` — walks `SelectCore.from` / `FromJoin` for `FromSubquery(core, alias, column_aliases)` and delegates body inference via tokens. Same short-circuit when no derived tables are present.
  - New `extract_table_aliases_from_stmt(stmt, catalog)` — fully IR-native. Collects `FromTable(_, Some(alias))` from every SELECT core and `UpdateStmt.table` / `DeleteStmt.table` with aliases. Applies the same guards `scan_aliases_loop` used: skip when alias equals name, alias already bound, or alias shadows a catalog entry.
- `test/query_analyzer_test.gleam`
  - Four new integration tests drive the IR path through `query_analyzer.analyze_queries`: CTE via `WITH`, VALUES table via `FROM (VALUES ...) AS v(n)`, derived table via `FROM (SELECT ...) AS t`, and plain aliased FROM via `FROM posts AS p`. Each test invokes `assert_ir_select` so a future regression that makes `parse_stmt` yield `UnstructuredStmt` would be caught instead of silently falling back to the token path.

## Design decisions
- **Body-column inference stays on the token path for CTEs and derived tables** (IR-native would require re-serialising a nested `Stmt` / `SelectCore` to tokens, or rewriting `infer_columns_from_tokens` to accept IR input — either is a deeper refactor than this slice warrants). The IR still drives WHICH virtual tables exist; body type inference is a separate concern tracked for future work.
- **VALUES and aliases are fully IR-native** — both constructs carry all the information they need on the IR node (literal `Expr`s for VALUES, explicit `alias: Option(String)` for FROM table references), so no token fallback is needed beyond the top-level `UnstructuredStmt` branch.
- **Keep the public token extractors**. They remain the fallback path and existing coverage depends on them. Removing them would be a breaking API change with no immediate benefit.
- **Do not rewire INSERT target tables**. The IR's `InsertStmt` does not carry a target alias today, and the token scanner did not extract one either. INSERT-target alias support would be its own change.

## Limitations
- CTE and derived-table body-column type inference still lexes the body from the original token stream. The IR now drives scope discovery, but deep traversal of `CteDef.body` and `FromSubquery.core` for type inference is a future refactor.
- `column_inferencer` itself still has internal token-based helpers (see `infer_columns_from_tokens` and friends). Those are used by the CTE/derived body-column path and remain unchanged here.

## Test plan
- [x] `just all` (format-check + check + build + test + integration-prepare + shellspec) all green — 889 unit tests, 22 shellspec examples, 0 failures.
- [x] Four new IR-path tests pin CTE, VALUES, derived-table, and aliased-FROM behaviour.
- [x] Existing analyzer tests untouched — the IR path produces identical results to the token path for every shape they exercise.

Closes #406