### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-19
+
+### Added
+
+- **Engine-aware expression parser with MySQL clause preservation**
+  (#405). `expr_parser.parse_stmt` / `parse_select_core` / `parse_expr`
+  now accept a `model.Engine` argument. `InsertStmt` grows an
+  `on_duplicate_key_update: List(Assignment)` field so MySQL
+  `ON DUPLICATE KEY UPDATE` survives parsing as first-class IR instead
+  of being silently skipped. MySQL's two-argument `LIMIT offset, count`
+  form is now recognised and populates `offset` / `limit` in the
+  expected order, while PostgreSQL's `LIMIT count OFFSET offset`
+  semantics are preserved.
+- **First-class MySQL `ENUM(...)` and `SET(...)` columns** (#407).
+  Inline `ENUM` and `SET` column types on a MySQL `CREATE TABLE` no
+  longer require a type override. `EnumDef` gains an `EnumKind`
+  discriminator (`PostgresEnum | MySqlEnum | MySqlSet`). `ENUM`
+  columns resolve to `EnumType(<table>_<column>)` and codegen emits
+  the same Gleam sum type it has always emitted for PostgreSQL enums.
+  `SET` columns resolve to `StringType` as a documented fallback,
+  with the allowed values preserved on the catalog `EnumDef` for
+  future consumers.
+- **`sqlode init` creates missing parent directories** (#402). Running
+  `sqlode init --output=./config/sqlode.yaml` used to fail with a
+  generic write error when `config/` did not exist; the CLI now
+  creates the parent directory and distinguishes directory-creation
+  failures from file-write failures in diagnostics.
+- **`just regen-capabilities` target** (#403). The capabilities
+  snapshot test used to point contributors at a `gleam run -m
+  sqlode/scripts/print_capabilities` entry point that did not exist;
+  the script and just target are now real, and the failure message
+  plus the tracked file header point at `just regen-capabilities`.
+
+### Changed
+
+- **Query analysis now consumes the expression-aware IR end-to-end**
+  (#406). `analyze_query` parses the statement once via
+  `expr_parser.parse_stmt` and drives parameter equality / `IN` /
+  quantified inference from the rich `Expr` tree, plus table-scope
+  (CTE / VALUES / derived / alias) extraction from `Stmt.ctes` and
+  `SelectCore.from`. Token scanners remain as an explicit fallback
+  only for `UnstructuredStmt` and for PostgreSQL / SQLite `ON
+  CONFLICT` tails the IR does not yet model. Result: new parser
+  features no longer need to be taught in parallel to several
+  token scanners.
+- **Generated-project compile checks are reproducible** (#404). The
+  `spec/compile_spec.sh` harness now seeds each temporary Gleam
+  project with a pinned `manifest.toml` copied from a checked-in
+  `integration_test/warmup/` project. A new `just integration-prepare`
+  target pre-populates the Hex cache and is the single explicit
+  online step `just all` requires; `just integration-refresh` refreshes
+  the committed pins. `CONTRIBUTING.md` documents the online/offline
+  contract.
+
+### Fixed
+
+- None.
+
 ## [0.3.0] - 2026-04-18
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.3.0"
+version = "0.4.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -25,7 +25,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.3.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.4.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.3.0"
+pub const version = "0.4.0"


### PR DESCRIPTION
Release v0.4.0. Highlights:

### Added

- **Engine-aware expression parser with MySQL clause preservation** (#405). `parse_stmt` / `parse_select_core` / `parse_expr` now accept `model.Engine`; MySQL `ON DUPLICATE KEY UPDATE` survives parsing as first-class IR on `InsertStmt`; MySQL `LIMIT offset, count` is recognised in the expected order.
- **First-class MySQL `ENUM(...)` and `SET(...)` columns** (#407). `EnumDef` grows an `EnumKind` discriminator (`PostgresEnum | MySqlEnum | MySqlSet`). ENUM columns emit the same Gleam sum type PostgreSQL enums have always emitted; SET columns resolve to `StringType` with values preserved on the catalog.
- **`sqlode init` creates missing parent directories** (#402), with directory-creation failures distinguished from file-write failures in diagnostics.
- **`just regen-capabilities` target** (#403). The capabilities snapshot test's failure message now points at a real regeneration command instead of a stale hint.

### Changed

- **Query analysis consumes the expression-aware IR end-to-end** (#406 — four slices). Parameter equality / `IN` / quantified inference and CTE / VALUES / derived-table / alias scope extraction are now driven from `query_ir.Stmt`. Token scanners remain only as an explicit fallback for `UnstructuredStmt` and the PostgreSQL / SQLite `ON CONFLICT` tails the IR does not yet model.
- **Generated-project compile checks are reproducible** (#404). `spec/compile_spec.sh` seeds each temporary project with a pinned `manifest.toml` copied from `integration_test/warmup/`; `just integration-prepare` is the single explicit online step; `just integration-refresh` refreshes the committed pins. `CONTRIBUTING.md` documents the contract.

## Test plan
- [x] `just all` (format-check + check + build + test + integration-prepare + shellspec) green on the release branch — 889 unit tests, 22 shellspec examples, 0 failures.
- [x] `src/sqlode/version.gleam` and `gleam.toml` both show `0.4.0`; the integration warmup manifest now pins `sqlode = 0.4.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.4.0

* **New Features**
  * MySQL `ENUM` and `SET` column types now fully supported.
  * MySQL `LIMIT offset, count` syntax recognized alongside PostgreSQL format.
  * `ON DUPLICATE KEY UPDATE` clause preservation for MySQL inserts.
  * `sqlode init` now creates missing parent directories automatically.

* **Improvements**
  * Enhanced query analysis pipeline with improved accuracy.
  * Better test reproducibility with pinned dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->