### PR TITLE
chore(deps): bump action-gh-release to 3 and download-artifact to 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.TAG_NAME }}
           name: ${{ steps.tag.outputs.TAG_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sqlode
           path: .


### PR DESCRIPTION
## Summary

Replays #425 and #426 (dependabot bumps for `softprops/action-gh-release` and `actions/download-artifact`) on top of the post-#427 main, since the originals were stale relative to the merged MySQL epic. The actual code change is identical to dependabot's two commits.

* `softprops/action-gh-release` v2 → v3
* `actions/download-artifact` v4 → v8

#425 and #426 will close automatically when this lands and dependabot's next scan sees the new versions.

## Test plan

- [x] Cherry-picked dependabot's two commits unchanged
- [ ] CI runs on this branch (no behavioural code change, only release-workflow action versions)