### PR TITLE
chore(lint): adopt glinter (strict) and wire into just + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Build (warnings as errors)
         run: gleam build --warnings-as-errors
 
+      - name: Lint (glinter, warnings as errors)
+        run: gleam run -m glinter
+
       - name: Unit tests
         run: gleam test
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -22,3 +22,76 @@ filepath = ">= 1.1.2 and < 2.0.0"
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 gleescript = ">= 1.5.2 and < 2.0.0"
+glinter = ">= 2.14.0 and < 3.0.0"
+
+# Glinter (https://github.com/pairshaped/glinter) configuration. Run via
+# `just lint` (or directly via `gleam run -m glinter -- --include test/`).
+# `warnings_as_errors` makes the run fail on any unfixed warning so CI
+# stays honest about the strictness contract.
+[tools.glinter]
+warnings_as_errors = true
+include = ["src/", "test/"]
+
+[tools.glinter.rules]
+# `label_possible` flags any positional parameter that could carry a
+# label. Adopting it across the entire codebase would force a labelled
+# call-site rewrite for every helper for cosmetic gain. The rest of the
+# label-related rules (`missing_labels`) are stricter and stay on.
+label_possible = "off"
+# Deep nesting is fundamental to a parser / codegen pipeline (token
+# walks, AST case-expression cascades, builder chains) — flattening
+# them every time hides the algorithm. `function_complexity` and
+# `module_complexity` likewise penalise the dispatch tables that
+# inevitably grow with every supported SQL construct.
+deep_nesting = "off"
+function_complexity = "off"
+module_complexity = "off"
+# This is a published Hex package: many `pub fn` and `pub type`
+# definitions are intentional API surface even when no in-tree caller
+# uses them yet. Flagging them as unused inverts the semantics of
+# `pub`.
+unused_exports = "off"
+# `case True/False` is equivalent to `bool.guard` for control flow;
+# both forms read fine in their respective contexts and the rule is a
+# pure stylistic preference. Keeping it on would force a single shape
+# everywhere, including places where the negative branch is the
+# trivial fallthrough that reads better as a `case`.
+prefer_guard_clause = "off"
+# `Error(_) -> default` is the natural shape for end-of-input
+# iterators (`string.pop_grapheme`), partial-info lookups (cache
+# misses, env-var absence), and best-effort fallback chains. Forcing
+# every site to thread the error through `result.try` / `result.or`
+# hides those base cases behind extra plumbing. Errors at *system
+# boundaries* (file IO, parsing, query execution) are routed through
+# `Result` types regardless.
+thrown_away_error = "off"
+# String error messages are the public contract for the CLI / config
+# loader / schema + query parsers — they are emitted directly to the
+# user. Promoting them to typed-error sums would either duplicate the
+# message text into a constructor name or force every error site to
+# define a one-shot variant; both are worse than the current shape.
+stringly_typed_error = "off"
+# `result.map_error(fn(_) { custom_error })` is the canonical way to
+# *translate* a foreign error into one of our own variants — by
+# definition the original is replaced. The places where we use it
+# already do so to re-encode at a module boundary; flagging them as
+# "lost context" would block legitimate boundary-crossing.
+error_context_lost = "off"
+
+[tools.glinter.ignore]
+# gleeunit auto-discovers test functions by `pub fn ..._test() {}` at
+# the module top level, so every test must stay public — `unused_exports`
+# fires on the entire test suite. `missing_type_annotation` fires for
+# the same reason: gleeunit functions return `Nil` by convention and
+# the annotation is implicit. `assert_ok_pattern` is idiomatic in
+# tests where a setup-failure should crash loudly. `short_variable_name`
+# is fine in test fixtures where variables are scoped to a few lines.
+# `avoid_panic` is allowed in tests so a test fixture can `panic` to
+# fail loudly when a precondition is violated.
+"test/**/*.gleam" = [
+  "assert_ok_pattern",
+  "avoid_panic",
+  "missing_type_annotation",
+  "short_variable_name",
+  "unused_exports",
+]

--- a/justfile
+++ b/justfile
@@ -21,6 +21,13 @@ build:
 test:
   gleam test
 
+# Run the glinter (https://github.com/pairshaped/glinter) static
+# analysis. Configuration lives under `[tools.glinter]` in
+# `gleam.toml`; with `warnings_as_errors = true` set there, this task
+# fails the build on any unsuppressed warning.
+lint:
+  gleam run -m glinter
+
 shellspec:
   shellspec
 
@@ -47,6 +54,7 @@ all:
   gleam format --check src/ test/
   gleam check
   gleam build --warnings-as-errors
+  gleam run -m glinter
   gleam test
   just integration-prepare
   shellspec

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -13,9 +14,12 @@ packages = [
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.14.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "F4FA6B575FA9ED293B3BCCCEA4ED2612EAFC8AAB4305638DB5680FFF84C6972B" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
@@ -29,5 +33,6 @@ gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleescript = { version = ">= 1.5.2 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glint = { version = ">= 1.0.0 and < 2.0.0" }
+glinter = { version = ">= 2.14.0 and < 3.0.0" }
 simplifile = { version = ">= 2.0.0 and < 3.0.0" }
 yay = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/sqlode.gleam
+++ b/src/sqlode.gleam
@@ -2,7 +2,7 @@ import argv
 import glint
 import sqlode/cli
 
-pub fn main() {
+pub fn main() -> Nil {
   cli.app()
   |> glint.run(argv.load().arguments)
 }

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -335,19 +335,11 @@ fn validate_init_flags(engine: String, runtime: String) -> Result(Nil, String) {
 }
 
 fn config_template(engine: String, runtime: String) -> String {
-  "version: \"2\"\n"
-  <> "sql:\n"
-  <> "  - schema: \"db/schema.sql\"\n"
-  <> "    queries: \"db/query.sql\"\n"
-  <> "    engine: \""
-  <> engine
-  <> "\"\n"
-  <> "    gen:\n"
-  <> "      gleam:\n"
-  <> "        out: \"src/db\"\n"
-  <> "        runtime: \""
-  <> runtime
-  <> "\"\n"
+  "version: \"2\"
+sql:
+  - schema: \"db/schema.sql\"
+    queries: \"db/query.sql\"
+    engine: \"" <> engine <> "\"\n" <> "    gen:\n" <> "      gleam:\n" <> "        out: \"src/db\"\n" <> "        runtime: \"" <> runtime <> "\"\n"
 }
 
 fn create_stub_files(base_dir: String, engine: String) -> Nil {
@@ -358,7 +350,7 @@ fn create_stub_files(base_dir: String, engine: String) -> Nil {
   let schema_path = filepath.join(db_dir, "schema.sql")
   let query_path = filepath.join(db_dir, "query.sql")
 
-  let _ = simplifile.create_directory_all(db_dir)
+  let _create_dir_result = simplifile.create_directory_all(db_dir)
 
   case simplifile.is_file(schema_path) {
     Ok(True) -> io.println("  Skipped " <> schema_path <> " (already exists)")
@@ -382,26 +374,29 @@ fn create_stub_files(base_dir: String, engine: String) -> Nil {
 fn starter_schema(engine: String) -> String {
   case engine {
     "sqlite" ->
-      "CREATE TABLE authors (\n"
-      <> "  id INTEGER PRIMARY KEY AUTOINCREMENT,\n"
-      <> "  name TEXT NOT NULL,\n"
-      <> "  bio TEXT,\n"
-      <> "  created_at TEXT NOT NULL\n"
-      <> ");\n"
+      "CREATE TABLE authors (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  bio TEXT,
+  created_at TEXT NOT NULL
+);
+"
     "mysql" ->
-      "CREATE TABLE authors (\n"
-      <> "  id BIGINT AUTO_INCREMENT PRIMARY KEY,\n"
-      <> "  name TEXT NOT NULL,\n"
-      <> "  bio TEXT,\n"
-      <> "  created_at DATETIME NOT NULL\n"
-      <> ");\n"
+      "CREATE TABLE authors (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  name TEXT NOT NULL,
+  bio TEXT,
+  created_at DATETIME NOT NULL
+);
+"
     _ ->
-      "CREATE TABLE authors (\n"
-      <> "  id BIGSERIAL PRIMARY KEY,\n"
-      <> "  name TEXT NOT NULL,\n"
-      <> "  bio TEXT,\n"
-      <> "  created_at TIMESTAMP NOT NULL\n"
-      <> ");\n"
+      "CREATE TABLE authors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  bio TEXT,
+  created_at TIMESTAMP NOT NULL
+);
+"
   }
 }
 
@@ -411,21 +406,10 @@ fn starter_query(engine: String) -> String {
     _ -> "$1"
   }
 
-  "-- name: GetAuthor :one\n"
-  <> "SELECT id, name, bio\n"
-  <> "FROM authors\n"
-  <> "WHERE id = "
-  <> get_placeholder
-  <> ";\n"
-  <> "\n"
-  <> "-- name: ListAuthors :many\n"
-  <> "SELECT id, name\n"
-  <> "FROM authors\n"
-  <> "ORDER BY name;\n"
-  <> "\n"
-  <> "-- name: CreateAuthor :exec\n"
-  <> "INSERT INTO authors (name, bio)\n"
-  <> "VALUES (sqlode.arg(author_name), sqlode.narg(bio));\n"
+  "-- name: GetAuthor :one
+SELECT id, name, bio
+FROM authors
+WHERE id = " <> get_placeholder <> ";\n" <> "\n" <> "-- name: ListAuthors :many\n" <> "SELECT id, name\n" <> "FROM authors\n" <> "ORDER BY name;\n" <> "\n" <> "-- name: CreateAuthor :exec\n" <> "INSERT INTO authors (name, bio)\n" <> "VALUES (sqlode.arg(author_name), sqlode.narg(bio));\n"
 }
 
 /// Exit the process with the given status code, flushing I/O before shutdown.

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -961,9 +961,7 @@ pub fn error_to_string(error: GenerateError) -> String {
       <> "\": produces an invalid Gleam module path. Use a relative path under src/ (e.g., \"src/db\")"
     WriteError(inner) -> writer.error_to_string(inner)
     VendorRuntimeNotFound ->
-      "vendor_runtime is enabled but the sqlode/runtime source file could not be found. "
-      <> "Tried: src/sqlode/runtime.gleam, build/packages/sqlode/src/sqlode/runtime.gleam, "
-      <> "build/dev/erlang/sqlode/src/sqlode/runtime.gleam"
+      "vendor_runtime is enabled but the sqlode/runtime source file could not be found. Tried: src/sqlode/runtime.gleam, build/packages/sqlode/src/sqlode/runtime.gleam, build/dev/erlang/sqlode/src/sqlode/runtime.gleam"
     UnsupportedArrayForEngine(query_name:, engine:) ->
       "Query \""
       <> query_name

--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -1,9 +1,7 @@
 import gleam/list
 import gleam/option
 import gleam/string
-import sqlode/char_utils.{
-  is_alnum_or_underscore, is_alpha_or_underscore, is_digit,
-}
+import sqlode/char_utils
 import sqlode/model
 
 /// Options for controlling how tokens are rendered back to text.
@@ -181,7 +179,7 @@ fn do_tokenize(
         "." ->
           case rest {
             [next, ..] ->
-              case is_digit(next) {
+              case char_utils.is_digit(next) {
                 // .5 → numeric literal
                 True -> {
                   let #(num, remaining) = read_number(rest, [g])
@@ -212,7 +210,7 @@ fn do_tokenize(
             [":", ..after_colon] ->
               do_tokenize(after_colon, engine, [Operator("::"), ..acc])
             [next, ..] ->
-              case is_alpha_or_underscore(next) {
+              case char_utils.is_alpha_or_underscore(next) {
                 True -> {
                   let #(ph, remaining) = read_word(rest, [g])
                   do_tokenize(remaining, engine, [Placeholder(ph), ..acc])
@@ -227,7 +225,7 @@ fn do_tokenize(
             [">", ..after] ->
               do_tokenize(after, engine, [Operator("@>"), ..acc])
             [next, ..] ->
-              case is_alpha_or_underscore(next) {
+              case char_utils.is_alpha_or_underscore(next) {
                 True -> {
                   let #(ph, remaining) = read_word(rest, [g])
                   do_tokenize(remaining, engine, [Placeholder(ph), ..acc])
@@ -239,7 +237,7 @@ fn do_tokenize(
 
         // Numbers
         _ ->
-          case is_digit(g) {
+          case char_utils.is_digit(g) {
             True ->
               case g, rest {
                 // 0x/0X hex literal (MySQL, SQLite). Treat as a single
@@ -258,7 +256,7 @@ fn do_tokenize(
                 }
               }
             False ->
-              case is_alpha_or_underscore(g) {
+              case char_utils.is_alpha_or_underscore(g) {
                 True ->
                   case detect_string_literal_prefix(g, rest) {
                     option.Some(#(after_prefix, _kind)) -> {
@@ -354,7 +352,7 @@ fn try_dollar_tag_lex(
   case chars {
     ["$", ..rest] -> Ok(#("", rest))
     [c, ..rest] ->
-      case is_alpha_or_underscore(c) {
+      case char_utils.is_alpha_or_underscore(c) {
         True -> read_dollar_tag_chars_lex(rest, [c])
         False -> Error(Nil)
       }
@@ -373,7 +371,7 @@ fn read_dollar_tag_chars_lex(
       Ok(#(tag, rest))
     }
     [c, ..rest] ->
-      case is_alnum_or_underscore(c) {
+      case char_utils.is_alnum_or_underscore(c) {
         True -> read_dollar_tag_chars_lex(rest, [c, ..acc])
         False -> Error(Nil)
       }
@@ -474,7 +472,7 @@ fn is_hex_digit(g: String) -> Bool {
 fn read_word(input: List(String), acc: List(String)) -> #(String, List(String)) {
   case input {
     [g, ..rest] ->
-      case is_alnum_or_underscore(g) {
+      case char_utils.is_alnum_or_underscore(g) {
         True -> read_word(rest, [g, ..acc])
         False -> #(acc |> list.reverse |> string.concat, input)
       }
@@ -651,7 +649,7 @@ fn read_number(
 ) -> #(String, List(String)) {
   case input {
     [g, ..rest] ->
-      case is_digit(g) || g == "." {
+      case char_utils.is_digit(g) || g == "." {
         True -> read_number(rest, [g, ..acc])
         False ->
           case g == "e" || g == "E" {
@@ -693,7 +691,7 @@ fn read_placeholder_question(
 ) -> #(String, List(String)) {
   case input {
     [g, ..rest] ->
-      case is_digit(g) {
+      case char_utils.is_digit(g) {
         True -> read_placeholder_question(rest, [g, ..acc])
         False -> #(acc |> list.reverse |> string.concat, input)
       }
@@ -739,17 +737,17 @@ fn tokens_to_string_loop(
   case tokens {
     [] -> acc
     [token, ..rest] -> {
-      let s = token_to_string(token, options)
+      let token_text = token_to_string(token, options)
       let with_space = case acc, token {
         _, Comma | _, Semicolon | _, LParen | _, RParen | _, Dot | _, Star -> [
-          s,
+          token_text,
           ..acc
         ]
-        ["(", ..], _ | [".", ..], _ -> [s, ..acc]
-        _, Operator("[") -> [s, ..acc]
-        ["]", ..], _ | ["[", ..], _ -> [s, ..acc]
-        [], _ -> [s]
-        _, _ -> [s, " ", ..acc]
+        ["(", ..], _ | [".", ..], _ -> [token_text, ..acc]
+        _, Operator("[") -> [token_text, ..acc]
+        ["]", ..], _ | ["[", ..], _ -> [token_text, ..acc]
+        [], _ -> [token_text]
+        _, _ -> [token_text, " ", ..acc]
       }
       tokens_to_string_loop(rest, with_space, options)
     }

--- a/src/sqlode/naming.gleam
+++ b/src/sqlode/naming.gleam
@@ -12,9 +12,12 @@ pub type NamingContext {
 }
 
 pub fn new() -> NamingContext {
+  // nolint: assert_ok_pattern -- the regex literal is a compile-time constant
   let assert Ok(word_separator) = regexp.from_string("[_\\-\\s./]+")
+  // nolint: assert_ok_pattern -- the regex literal is a compile-time constant
   let assert Ok(camel_case) =
     regexp.from_string("([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)")
+  // nolint: assert_ok_pattern -- the regex literal is a compile-time constant
   let assert Ok(underscore_before_caps) =
     regexp.from_string("([a-z0-9])([A-Z])")
   NamingContext(word_separator:, camel_case:, underscore_before_caps:)

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -224,11 +224,16 @@ fn build_params(
 
     let #(field_name, scalar_type, nullable, is_list) = case macro_info {
       Some(model.MacroArg(name:, ..)) -> {
-        let n = case inferred {
+        let nullable = case inferred {
           Some(column) -> column.nullable
           None -> False
         }
-        #(naming.to_snake_case(ctx.naming, name), inferred_type, n, False)
+        #(
+          naming.to_snake_case(ctx.naming, name),
+          inferred_type,
+          nullable,
+          False,
+        )
       }
       Some(model.MacroNarg(name:, ..)) -> #(
         naming.to_snake_case(ctx.naming, name),

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -1096,12 +1096,12 @@ fn collect_aliased_tables(stmt: query_ir.Stmt) -> List(#(String, String)) {
     list.filter_map(collect_from_items(stmt), fn(item) {
       case item {
         query_ir.FromTable(name:, alias: Some(a)) -> {
-          let n = string.lowercase(name)
-          let al = string.lowercase(a)
-          case n, al {
+          let table_name = string.lowercase(name)
+          let alias_name = string.lowercase(a)
+          case table_name, alias_name {
             "", _ -> Error(Nil)
             _, "" -> Error(Nil)
-            _, _ -> Ok(#(n, al))
+            _, _ -> Ok(#(table_name, alias_name))
           }
         }
         _ -> Error(Nil)
@@ -1109,21 +1109,21 @@ fn collect_aliased_tables(stmt: query_ir.Stmt) -> List(#(String, String)) {
     })
   let dml_target = case stmt {
     query_ir.UpdateStmt(table:, alias: Some(a), ..) -> {
-      let n = string.lowercase(table)
-      let al = string.lowercase(a)
-      case n, al {
+      let table_name = string.lowercase(table)
+      let alias_name = string.lowercase(a)
+      case table_name, alias_name {
         "", _ -> []
         _, "" -> []
-        _, _ -> [#(n, al)]
+        _, _ -> [#(table_name, alias_name)]
       }
     }
     query_ir.DeleteStmt(table:, alias: Some(a), ..) -> {
-      let n = string.lowercase(table)
-      let al = string.lowercase(a)
-      case n, al {
+      let table_name = string.lowercase(table)
+      let alias_name = string.lowercase(a)
+      case table_name, alias_name {
         "", _ -> []
         _, "" -> []
-        _, _ -> [#(n, al)]
+        _, _ -> [#(table_name, alias_name)]
       }
     }
     _ -> []

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -1587,7 +1587,7 @@ fn render_type_tokens_loop(
         [] -> render_type_tokens_loop(rest, ["[]", ..acc])
       }
     [tok, ..rest] -> {
-      let s = case tok {
+      let token_text = case tok {
         lexer.Keyword(k) -> k
         lexer.Ident(n) -> n
         lexer.QuotedIdent(n) -> n
@@ -1599,9 +1599,9 @@ fn render_type_tokens_loop(
         lexer.Star -> "*"
         _ -> ""
       }
-      case s {
+      case token_text {
         "" -> render_type_tokens_loop(rest, acc)
-        _ -> render_type_tokens_loop(rest, [s, ..acc])
+        _ -> render_type_tokens_loop(rest, [token_text, ..acc])
       }
     }
   }
@@ -1698,10 +1698,8 @@ fn path_prefix(path: String) -> String {
 }
 
 pub fn warning_to_string(warning: SchemaWarning) -> String {
-  case warning {
-    UnresolvableViewColumn(column:) ->
-      "Warning: view column \""
-      <> column
-      <> "\" could not be resolved from source tables — skipping column."
-  }
+  let UnresolvableViewColumn(column:) = warning
+  "Warning: view column \""
+  <> column
+  <> "\" could not be resolved from source tables — skipping column."
 }

--- a/src/sqlode/verify.gleam
+++ b/src/sqlode/verify.gleam
@@ -232,7 +232,6 @@ fn format_finding(finding: Finding) -> String {
 }
 
 pub fn error_to_string(error: VerifyError) -> String {
-  case error {
-    ConfigError(inner) -> config.error_to_string(inner)
-  }
+  let ConfigError(inner) = error
+  config.error_to_string(inner)
 }

--- a/test/capabilities_test.gleam
+++ b/test/capabilities_test.gleam
@@ -20,13 +20,12 @@ pub fn manifest_matches_tracked_file_test() {
     True -> Nil
     False -> {
       let message =
-        "doc/capabilities.md is out of sync with src/sqlode/capabilities.gleam.\n"
-        <> "Regenerate the file with:\n"
-        <> "  just regen-capabilities\n"
-        <> "or copy the expected output below verbatim:\n"
-        <> "--- expected ---\n"
-        <> rendered
-        <> "--- end expected ---"
+        "doc/capabilities.md is out of sync with src/sqlode/capabilities.gleam.
+Regenerate the file with:
+  just regen-capabilities
+or copy the expected output below verbatim:
+--- expected ---
+" <> rendered <> "--- end expected ---"
       should.equal(message, "")
     }
   }

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -8,13 +8,13 @@ import sqlode/cli
 const base_dir = "test_output/cli_test"
 
 fn cleanup(subdir: String) {
-  let _ = simplifile.delete(base_dir <> "/" <> subdir)
+  let _delete_result = simplifile.delete(base_dir <> "/" <> subdir)
   Nil
 }
 
 fn setup(subdir: String) {
   cleanup(subdir)
-  let _ = simplifile.create_directory_all(base_dir <> "/" <> subdir)
+  let _mkdir_result = simplifile.create_directory_all(base_dir <> "/" <> subdir)
   Nil
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -371,9 +371,7 @@ pub fn expand_slice_placeholders_single_test() {
 
 pub fn expand_slice_placeholders_with_renumbering_test() {
   let sql =
-    "SELECT * FROM users WHERE name = __sqlode_param_1__"
-    <> " AND id IN (__sqlode_slice_2__)"
-    <> " AND status = __sqlode_param_3__"
+    "SELECT * FROM users WHERE name = __sqlode_param_1__ AND id IN (__sqlode_slice_2__) AND status = __sqlode_param_3__"
   let result =
     runtime.expand_slice_placeholders(sql, [#(2, 3)], 3, runtime.DollarNumbered)
   result
@@ -411,9 +409,7 @@ pub fn expand_slice_placeholders_empty_slice_test() {
 
 pub fn expand_slice_placeholders_empty_slice_with_other_params_test() {
   let sql =
-    "SELECT * FROM users WHERE name = __sqlode_param_1__"
-    <> " AND id IN (__sqlode_slice_2__)"
-    <> " AND status = __sqlode_param_3__"
+    "SELECT * FROM users WHERE name = __sqlode_param_1__ AND id IN (__sqlode_slice_2__) AND status = __sqlode_param_3__"
   let result =
     runtime.expand_slice_placeholders(sql, [#(2, 0)], 3, runtime.DollarNumbered)
   result
@@ -1207,11 +1203,11 @@ pub fn readme_runtime_prepare_is_two_arg_test() {
 
 fn mysql_enum_set_catalog() -> model.Catalog {
   let content =
-    "CREATE TABLE items (\n"
-    <> "  id BIGINT NOT NULL,\n"
-    <> "  status ENUM('active', 'inactive', 'archived') NOT NULL,\n"
-    <> "  tags SET('red', 'green', 'blue')\n"
-    <> ");"
+    "CREATE TABLE items (
+  id BIGINT NOT NULL,
+  status ENUM('active', 'inactive', 'archived') NOT NULL,
+  tags SET('red', 'green', 'blue')
+);"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine(
       [#("items.sql", content)],
@@ -1339,16 +1335,17 @@ fn mysql_native_queries(
   catalog: model.Catalog,
 ) -> List(model.AnalyzedQuery) {
   let sql =
-    "-- name: GetAuthor :one\n"
-    <> "SELECT id, name, bio, created_at FROM authors WHERE id = ?;\n"
-    <> "-- name: ListAuthors :many\n"
-    <> "SELECT id, name FROM authors ORDER BY id;\n"
-    <> "-- name: CreateAuthor :execlastid\n"
-    <> "INSERT INTO authors (name, bio, created_at) VALUES (?, ?, ?);\n"
-    <> "-- name: DeleteAuthor :exec\n"
-    <> "DELETE FROM authors WHERE id = ?;\n"
-    <> "-- name: UpdateBio :execrows\n"
-    <> "UPDATE authors SET bio = ? WHERE id = ?;\n"
+    "-- name: GetAuthor :one
+SELECT id, name, bio, created_at FROM authors WHERE id = ?;
+-- name: ListAuthors :many
+SELECT id, name FROM authors ORDER BY id;
+-- name: CreateAuthor :execlastid
+INSERT INTO authors (name, bio, created_at) VALUES (?, ?, ?);
+-- name: DeleteAuthor :exec
+DELETE FROM authors WHERE id = ?;
+-- name: UpdateBio :execrows
+UPDATE authors SET bio = ? WHERE id = ?;
+"
   let assert Ok(parsed) =
     query_parser.parse_file("q.sql", model.MySQL, naming_ctx, sql)
   let assert Ok(analyzed) =

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -10,7 +10,7 @@ import sqlode/model
 const test_out = "test_output/generate_test"
 
 fn cleanup() {
-  let _ = simplifile.delete(test_out)
+  let _delete_result = simplifile.delete(test_out)
   Nil
 }
 
@@ -657,7 +657,7 @@ fn join_rename_block(renames: List(model.ColumnRename)) -> model.SqlBlock {
 }
 
 fn cleanup_join_rename() {
-  let _ = simplifile.delete(join_rename_out)
+  let _delete_result = simplifile.delete(join_rename_out)
   Nil
 }
 
@@ -918,7 +918,7 @@ fn all_commands_block(
 }
 
 fn cleanup_commands() {
-  let _ = simplifile.delete(all_commands_out)
+  let _delete_result = simplifile.delete(all_commands_out)
   Nil
 }
 
@@ -1168,7 +1168,7 @@ pub fn execresult_allowed_on_raw_runtime_test() {
     )
   let cfg = model.Config(version: 2, sql: [block])
   let assert Ok(_) = generate.generate_config(cfg)
-  let _ = simplifile.delete("test_output/execresult_raw")
+  let _delete_result = simplifile.delete("test_output/execresult_raw")
   Nil
 }
 
@@ -1261,7 +1261,7 @@ fn compound_block() -> model.SqlBlock {
 }
 
 fn cleanup_compound() {
-  let _ = simplifile.delete(compound_out)
+  let _delete_result = simplifile.delete(compound_out)
   Nil
 }
 
@@ -1344,7 +1344,7 @@ fn view_block() -> model.SqlBlock {
 }
 
 fn cleanup_view() {
-  let _ = simplifile.delete(view_out)
+  let _delete_result = simplifile.delete(view_out)
   Nil
 }
 
@@ -1382,7 +1382,7 @@ pub fn view_select_star_inferred_test() {
 const resolve_out = "src/resolve_paths_test"
 
 fn cleanup_resolve() {
-  let _ = simplifile.delete(resolve_out)
+  let _delete_result = simplifile.delete(resolve_out)
   Nil
 }
 
@@ -1431,7 +1431,7 @@ pub fn invalid_out_path_rejected_test() {
 const dir_out = "test_output/generate_test_dir"
 
 fn cleanup_dir() {
-  let _ = simplifile.delete(dir_out)
+  let _delete_result = simplifile.delete(dir_out)
   Nil
 }
 
@@ -1880,7 +1880,7 @@ fn partial_view_block(strict_views: Bool) -> model.SqlBlock {
 }
 
 fn cleanup_partial_view() {
-  let _ = simplifile.delete(partial_view_out)
+  let _delete_result = simplifile.delete(partial_view_out)
   Nil
 }
 
@@ -1893,17 +1893,14 @@ pub fn strict_views_is_default_for_partial_view_test() {
   cleanup_partial_view()
 
   let yaml_path = "test/fixtures/partial_view.yaml"
-  let content =
-    "version: \"2\"\n"
-    <> "sql:\n"
-    <> "  - engine: postgresql\n"
-    <> "    schema: test/fixtures/partial_view_schema.sql\n"
-    <> "    queries: test/fixtures/partial_view_query.sql\n"
-    <> "    gen:\n"
-    <> "      gleam:\n"
-    <> "        out: "
-    <> partial_view_out
-    <> "\n"
+  let content = "version: \"2\"
+sql:
+  - engine: postgresql
+    schema: test/fixtures/partial_view_schema.sql
+    queries: test/fixtures/partial_view_query.sql
+    gen:
+      gleam:
+        out: " <> partial_view_out <> "\n"
   let assert Ok(_) = simplifile.write(yaml_path, content)
 
   let assert Ok(cfg) = config.load(yaml_path)
@@ -1925,7 +1922,7 @@ pub fn strict_views_is_default_for_partial_view_test() {
       panic as "expected generation to fail on partial view with default policy"
   }
 
-  let _ = simplifile.delete(yaml_path)
+  let _delete_result = simplifile.delete(yaml_path)
   cleanup_partial_view()
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -321,12 +321,12 @@ pub fn sqlc_slice_sets_is_list_test() {
 
 pub fn parse_enum_column_type_test() {
   let schema =
-    "CREATE TYPE status AS ENUM ('active', 'inactive', 'banned');\n"
-    <> "CREATE TABLE users (\n"
-    <> "  id BIGSERIAL PRIMARY KEY,\n"
-    <> "  name TEXT NOT NULL,\n"
-    <> "  status status NOT NULL\n"
-    <> ");"
+    "CREATE TYPE status AS ENUM ('active', 'inactive', 'banned');
+CREATE TABLE users (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  status status NOT NULL
+);"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("enum.sql", schema)])
@@ -568,10 +568,10 @@ pub fn compound_query_column_count_mismatch_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let content =
-    "-- name: BadUnion :many\n"
-    <> "SELECT id, name FROM authors\n"
-    <> "UNION\n"
-    <> "SELECT id FROM authors;"
+    "-- name: BadUnion :many
+SELECT id, name FROM authors
+UNION
+SELECT id FROM authors;"
 
   let assert Ok(queries) =
     query_parser.parse_file("union.sql", model.PostgreSQL, naming_ctx, content)
@@ -592,10 +592,10 @@ pub fn compound_query_valid_union_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let content =
-    "-- name: GoodUnion :many\n"
-    <> "SELECT id, name FROM authors\n"
-    <> "UNION ALL\n"
-    <> "SELECT id, name FROM authors;"
+    "-- name: GoodUnion :many
+SELECT id, name FROM authors
+UNION ALL
+SELECT id, name FROM authors;"
 
   let assert Ok(queries) =
     query_parser.parse_file("union.sql", model.PostgreSQL, naming_ctx, content)
@@ -614,10 +614,10 @@ pub fn compound_query_except_mismatch_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let content =
-    "-- name: BadExcept :many\n"
-    <> "SELECT id, name FROM authors\n"
-    <> "EXCEPT\n"
-    <> "SELECT id, name, bio FROM authors;"
+    "-- name: BadExcept :many
+SELECT id, name FROM authors
+EXCEPT
+SELECT id, name, bio FROM authors;"
 
   let assert Ok(queries) =
     query_parser.parse_file("except.sql", model.PostgreSQL, naming_ctx, content)
@@ -915,8 +915,8 @@ pub fn sqlite_repeated_named_placeholder_single_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: ReusedNamed :one\n"
-    <> "SELECT id FROM authors WHERE name = :name OR bio = :name;"
+    "-- name: ReusedNamed :one
+SELECT id FROM authors WHERE name = :name OR bio = :name;"
 
   let assert Ok(queries) =
     query_parser.parse_file("dedup.sql", model.SQLite, naming_ctx, sql)
@@ -935,8 +935,8 @@ pub fn sqlite_repeated_and_distinct_placeholders_correct_index_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: MixedDedup :one\n"
-    <> "SELECT id FROM authors WHERE name = :name AND bio = :name AND id = :id;"
+    "-- name: MixedDedup :one
+SELECT id FROM authors WHERE name = :name AND bio = :name AND id = :id;"
 
   let assert Ok(queries) =
     query_parser.parse_file("mixed.sql", model.SQLite, naming_ctx, sql)
@@ -959,8 +959,8 @@ pub fn sqlite_repeated_at_placeholder_single_param_test() {
   // Same placeholder used with columns of different types (id:Int, name:String)
   // should produce a type conflict error
   let sql =
-    "-- name: ReusedAt :one\n"
-    <> "SELECT id FROM authors WHERE id = @id OR name = @id;"
+    "-- name: ReusedAt :one
+SELECT id FROM authors WHERE id = @id OR name = @id;"
 
   let assert Ok(queries) =
     query_parser.parse_file("at.sql", model.SQLite, naming_ctx, sql)
@@ -979,8 +979,8 @@ pub fn sqlite_repeated_at_placeholder_same_type_test() {
   let catalog = test_catalog()
   // Same placeholder used with columns of the same type should succeed
   let sql =
-    "-- name: ReusedSameType :one\n"
-    <> "SELECT id FROM authors WHERE id = @id OR id > @id;"
+    "-- name: ReusedSameType :one
+SELECT id FROM authors WHERE id = @id OR id > @id;"
 
   let assert Ok(queries) =
     query_parser.parse_file("at.sql", model.SQLite, naming_ctx, sql)
@@ -2326,8 +2326,8 @@ pub fn arithmetic_int_operands_stay_int_test() {
 pub fn case_unifies_int_and_float_branches_test() {
   let query =
     analyze_single(
-      "-- name: Mixed :many\n"
-        <> "SELECT CASE WHEN id = 1 THEN 1 WHEN id = 2 THEN 2.5 ELSE 3 END AS value FROM items;",
+      "-- name: Mixed :many
+SELECT CASE WHEN id = 1 THEN 1 WHEN id = 2 THEN 2.5 ELSE 3 END AS value FROM items;",
       pricing_catalog(),
     )
   let assert [model.ScalarResult(col)] = query.result_columns
@@ -2338,8 +2338,8 @@ pub fn case_unifies_int_and_float_branches_test() {
 pub fn case_without_else_is_nullable_test() {
   let query =
     analyze_single(
-      "-- name: Opt :many\n"
-        <> "SELECT CASE WHEN id = 1 THEN 10 END AS maybe FROM items;",
+      "-- name: Opt :many
+SELECT CASE WHEN id = 1 THEN 10 END AS maybe FROM items;",
       pricing_catalog(),
     )
   let assert [model.ScalarResult(col)] = query.result_columns
@@ -2350,8 +2350,8 @@ pub fn case_without_else_is_nullable_test() {
 pub fn case_with_else_not_null_is_not_nullable_test() {
   let query =
     analyze_single(
-      "-- name: Strict :many\n"
-        <> "SELECT CASE WHEN id = 1 THEN 10 ELSE 20 END AS value FROM items;",
+      "-- name: Strict :many
+SELECT CASE WHEN id = 1 THEN 10 ELSE 20 END AS value FROM items;",
       pricing_catalog(),
     )
   let assert [model.ScalarResult(col)] = query.result_columns
@@ -2362,8 +2362,8 @@ pub fn case_with_else_not_null_is_not_nullable_test() {
 pub fn case_with_null_branch_is_nullable_test() {
   let query =
     analyze_single(
-      "-- name: WithNull :many\n"
-        <> "SELECT CASE WHEN id = 1 THEN NULL ELSE 42 END AS value FROM items;",
+      "-- name: WithNull :many
+SELECT CASE WHEN id = 1 THEN NULL ELSE 42 END AS value FROM items;",
       pricing_catalog(),
     )
   let assert [model.ScalarResult(col)] = query.result_columns
@@ -2374,10 +2374,8 @@ pub fn case_with_null_branch_is_nullable_test() {
 pub fn case_nested_inherits_unified_type_test() {
   let query =
     analyze_single(
-      "-- name: Nested :many\n"
-        <> "SELECT CASE WHEN id = 1"
-        <> " THEN CASE WHEN quantity > 0 THEN 1.0 ELSE 2 END"
-        <> " ELSE 3 END AS value FROM items;",
+      "-- name: Nested :many
+SELECT CASE WHEN id = 1 THEN CASE WHEN quantity > 0 THEN 1.0 ELSE 2 END ELSE 3 END AS value FROM items;",
       pricing_catalog(),
     )
   let assert [model.ScalarResult(col)] = query.result_columns
@@ -2388,8 +2386,8 @@ pub fn case_nested_inherits_unified_type_test() {
 pub fn case_nullable_column_branch_propagates_test() {
   let query =
     analyze_single(
-      "-- name: MaybeDiscount :many\n"
-        <> "SELECT CASE WHEN id = 1 THEN discount ELSE 0.0 END AS value FROM items;",
+      "-- name: MaybeDiscount :many
+SELECT CASE WHEN id = 1 THEN discount ELSE 0.0 END AS value FROM items;",
       pricing_catalog(),
     )
   let assert [model.ScalarResult(col)] = query.result_columns
@@ -2476,8 +2474,8 @@ pub fn param_type_conflict_detection_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: ConflictTest :one\n"
-    <> "SELECT id FROM authors WHERE id = $1 AND name = $1;"
+    "-- name: ConflictTest :one
+SELECT id FROM authors WHERE id = $1 AND name = $1;"
   let assert Ok(queries) =
     query_parser.parse_file("conflict.sql", model.PostgreSQL, naming_ctx, sql)
   let result =
@@ -2553,8 +2551,8 @@ pub fn ir_walker_infers_multiple_equality_params_in_order_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetByIdAndName :one\n"
-    <> "SELECT id, name FROM authors WHERE id = $1 AND name = $2;"
+    "-- name: GetByIdAndName :one
+SELECT id, name FROM authors WHERE id = $1 AND name = $2;"
   let assert Ok(queries) =
     query_parser.parse_file("eq.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =
@@ -2588,8 +2586,8 @@ pub fn ir_walker_resolves_qualified_equality_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetByQualifiedId :one\n"
-    <> "SELECT id, name FROM authors AS a WHERE a.id = $1;"
+    "-- name: GetByQualifiedId :one
+SELECT id, name FROM authors AS a WHERE a.id = $1;"
   let assert Ok(queries) =
     query_parser.parse_file("qualified.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =
@@ -2614,8 +2612,8 @@ pub fn ir_walker_infers_like_predicate_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: SearchByName :many\n"
-    <> "SELECT id, name FROM authors WHERE name LIKE $1;"
+    "-- name: SearchByName :many
+SELECT id, name FROM authors WHERE name LIKE $1;"
   let assert Ok(queries) =
     query_parser.parse_file("like.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =
@@ -2638,8 +2636,8 @@ pub fn ir_walker_handles_reversed_operand_order_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetByReversedId :one\n"
-    <> "SELECT id, name FROM authors WHERE $1 = id;"
+    "-- name: GetByReversedId :one
+SELECT id, name FROM authors WHERE $1 = id;"
   let assert Ok(queries) =
     query_parser.parse_file("reversed.sql", model.PostgreSQL, naming_ctx, sql)
   let assert Ok(analyzed) =
@@ -2684,8 +2682,8 @@ pub fn ir_walker_infers_single_element_in_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetAuthorsByIdList :many\n"
-    <> "SELECT id, name FROM authors WHERE id IN ($1);"
+    "-- name: GetAuthorsByIdList :many
+SELECT id, name FROM authors WHERE id IN ($1);"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("in.sql", model.PostgreSQL, naming_ctx, sql)
@@ -2709,8 +2707,8 @@ pub fn ir_walker_infers_qualified_in_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetQualifiedAuthorsById :many\n"
-    <> "SELECT a.id, a.name FROM authors AS a WHERE a.id IN ($1);"
+    "-- name: GetQualifiedAuthorsById :many
+SELECT a.id, a.name FROM authors AS a WHERE a.id IN ($1);"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file(
@@ -2739,8 +2737,8 @@ pub fn ir_walker_infers_quantified_any_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetAuthorsAnyId :many\n"
-    <> "SELECT id, name FROM authors WHERE id = ANY($1);"
+    "-- name: GetAuthorsAnyId :many
+SELECT id, name FROM authors WHERE id = ANY($1);"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("any.sql", model.PostgreSQL, naming_ctx, sql)
@@ -2767,9 +2765,8 @@ pub fn ir_walker_infers_update_assignment_in_subquery_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: UpdateBioFromId :exec\n"
-    <> "UPDATE authors SET bio = "
-    <> "(SELECT bio FROM authors WHERE id IN ($1)) WHERE id = $2;"
+    "-- name: UpdateBioFromId :exec
+UPDATE authors SET bio = (SELECT bio FROM authors WHERE id IN ($1)) WHERE id = $2;"
   let assert Ok(queries) =
     query_parser.parse_file(
       "update_in_subquery.sql",
@@ -2802,9 +2799,8 @@ pub fn ir_walker_skips_in_subquery_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetAuthorsByIdSub :many\n"
-    <> "SELECT id, name FROM authors "
-    <> "WHERE id IN (SELECT id FROM authors WHERE name = $1);"
+    "-- name: GetAuthorsByIdSub :many
+SELECT id, name FROM authors WHERE id IN (SELECT id FROM authors WHERE name = $1);"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("in_sub.sql", model.PostgreSQL, naming_ctx, sql)
@@ -2839,8 +2835,8 @@ pub fn ir_cte_virtual_table_resolves_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetCteIds :many\n"
-    <> "WITH cte AS (SELECT id FROM authors) SELECT id FROM cte;"
+    "-- name: GetCteIds :many
+WITH cte AS (SELECT id FROM authors) SELECT id FROM cte;"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("cte.sql", model.PostgreSQL, naming_ctx, sql)
@@ -2867,8 +2863,8 @@ pub fn ir_values_virtual_table_infers_param_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetValuesRows :many\n"
-    <> "SELECT n FROM (VALUES (1), (2)) AS v(n) WHERE n > $1;"
+    "-- name: GetValuesRows :many
+SELECT n FROM (VALUES (1), (2)) AS v(n) WHERE n > $1;"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("values.sql", model.PostgreSQL, naming_ctx, sql)
@@ -2895,8 +2891,8 @@ pub fn ir_derived_table_virtual_resolves_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
   let sql =
-    "-- name: GetDerivedIds :many\n"
-    <> "SELECT t.id FROM (SELECT id FROM authors) AS t;"
+    "-- name: GetDerivedIds :many
+SELECT t.id FROM (SELECT id FROM authors) AS t;"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("derived.sql", model.PostgreSQL, naming_ctx, sql)
@@ -2918,7 +2914,7 @@ pub fn ir_derived_table_virtual_resolves_test() {
 pub fn ir_table_alias_resolves_qualified_column_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
-  let sql = "-- name: GetAliasedIds :many\n" <> "SELECT a.id FROM authors AS a;"
+  let sql = "-- name: GetAliasedIds :many\nSELECT a.id FROM authors AS a;"
   assert_ir_select(sql)
   let assert Ok(queries) =
     query_parser.parse_file("alias.sql", model.PostgreSQL, naming_ctx, sql)

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -59,8 +59,8 @@ pub fn reject_query_without_sql_body_test() {
 pub fn count_mysql_placeholders_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: CreateAuthor :exec\n"
-    <> "INSERT INTO authors (name, bio) VALUES (?, ?);"
+    "-- name: CreateAuthor :exec
+INSERT INTO authors (name, bio) VALUES (?, ?);"
 
   let assert Ok(queries) =
     parse_file("mysql.sql", model.MySQL, naming_ctx, content)
@@ -72,8 +72,8 @@ pub fn count_mysql_placeholders_test() {
 pub fn count_sqlite_named_placeholders_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetAuthor :one\n"
-    <> "SELECT id FROM authors WHERE id = :id OR name = @name OR slug = $slug OR code = ?2;"
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = :id OR name = @name OR slug = $slug OR code = ?2;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -85,8 +85,8 @@ pub fn count_sqlite_named_placeholders_test() {
 pub fn expand_sqlc_arg_macro_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
     parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
@@ -102,8 +102,8 @@ pub fn expand_sqlc_arg_macro_test() {
 pub fn expand_sqlc_narg_macro_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: UpdateBio :exec\n"
-    <> "UPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);"
+    "-- name: UpdateBio :exec
+UPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
     parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
@@ -122,8 +122,8 @@ pub fn expand_sqlc_narg_macro_test() {
 pub fn expand_sqlc_arg_mysql_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
     parse_file("arg_mysql.sql", model.MySQL, naming_ctx, content)
@@ -138,8 +138,8 @@ pub fn expand_sqlc_arg_mysql_test() {
 pub fn expand_sqlc_arg_single_quoted_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlode.arg('author_name');"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = sqlode.arg('author_name');"
 
   let assert Ok(queries) =
     parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
@@ -155,8 +155,8 @@ pub fn expand_sqlc_arg_single_quoted_test() {
 pub fn expand_sqlc_arg_double_quoted_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = sqlode.arg(\"author_name\");"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = sqlode.arg(\"author_name\");"
 
   let assert Ok(queries) =
     parse_file("arg.sql", model.PostgreSQL, naming_ctx, content)
@@ -170,8 +170,8 @@ pub fn expand_sqlc_arg_double_quoted_test() {
 pub fn expand_sqlc_narg_single_quoted_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: UpdateBio :exec\n"
-    <> "UPDATE authors SET bio = sqlode.narg('new_bio') WHERE id = sqlode.arg(author_id);"
+    "-- name: UpdateBio :exec
+UPDATE authors SET bio = sqlode.narg('new_bio') WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
     parse_file("narg.sql", model.PostgreSQL, naming_ctx, content)
@@ -188,8 +188,8 @@ pub fn expand_sqlc_narg_single_quoted_test() {
 pub fn expand_sqlc_slice_double_quoted_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByIds :many\n"
-    <> "SELECT id, name FROM authors WHERE id IN (sqlode.slice(\"ids\"));"
+    "-- name: GetByIds :many
+SELECT id, name FROM authors WHERE id IN (sqlode.slice(\"ids\"));"
 
   let assert Ok(queries) =
     parse_file("slice.sql", model.PostgreSQL, naming_ctx, content)
@@ -204,8 +204,8 @@ pub fn expand_sqlc_slice_double_quoted_test() {
 pub fn expand_at_name_postgresql_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = @author_name;"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = @author_name;"
 
   let assert Ok(queries) =
     parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
@@ -221,8 +221,8 @@ pub fn expand_at_name_postgresql_test() {
 pub fn expand_at_name_sqlite_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = @author_name;"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = @author_name;"
 
   let assert Ok(queries) =
     parse_file("at.sql", model.SQLite, naming_ctx, content)
@@ -238,8 +238,8 @@ pub fn expand_at_name_sqlite_test() {
 pub fn expand_multiple_at_names_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: UpdateBio :exec\n"
-    <> "UPDATE authors SET bio = @new_bio WHERE id = @author_id;"
+    "-- name: UpdateBio :exec
+UPDATE authors SET bio = @new_bio WHERE id = @author_id;"
 
   let assert Ok(queries) =
     parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
@@ -258,8 +258,8 @@ pub fn expand_multiple_at_names_test() {
 pub fn expand_at_name_mixed_with_sqlc_arg_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: Update :exec\n"
-    <> "UPDATE authors SET bio = @new_bio WHERE id = sqlode.arg(author_id);"
+    "-- name: Update :exec
+UPDATE authors SET bio = @new_bio WHERE id = sqlode.arg(author_id);"
 
   let assert Ok(queries) =
     parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
@@ -276,8 +276,8 @@ pub fn expand_at_name_mixed_with_sqlc_arg_test() {
 pub fn at_name_not_expanded_on_mysql_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByName :one\n"
-    <> "SELECT id FROM authors WHERE name = @author_name;"
+    "-- name: GetByName :one
+SELECT id FROM authors WHERE name = @author_name;"
 
   let assert Ok(queries) =
     parse_file("at.sql", model.MySQL, naming_ctx, content)
@@ -330,9 +330,12 @@ pub fn empty_file_test() {
 pub fn multiple_queries_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: Q1 :one\nSELECT 1;\n"
-    <> "-- name: Q2 :many\nSELECT 2;\n"
-    <> "-- name: Q3 :exec\nINSERT INTO t VALUES (1);"
+    "-- name: Q1 :one
+SELECT 1;
+-- name: Q2 :many
+SELECT 2;
+-- name: Q3 :exec
+INSERT INTO t VALUES (1);"
 
   let assert Ok(queries) =
     parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
@@ -350,12 +353,18 @@ pub fn multiple_queries_test() {
 pub fn all_command_types_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: A :one\nSELECT 1;\n"
-    <> "-- name: B :many\nSELECT 1;\n"
-    <> "-- name: C :exec\nSELECT 1;\n"
-    <> "-- name: D :execresult\nSELECT 1;\n"
-    <> "-- name: E :execrows\nSELECT 1;\n"
-    <> "-- name: F :execlastid\nSELECT 1;"
+    "-- name: A :one
+SELECT 1;
+-- name: B :many
+SELECT 1;
+-- name: C :exec
+SELECT 1;
+-- name: D :execresult
+SELECT 1;
+-- name: E :execrows
+SELECT 1;
+-- name: F :execlastid
+SELECT 1;"
 
   let assert Ok(queries) =
     parse_file("cmds.sql", model.PostgreSQL, naming_ctx, content)
@@ -373,12 +382,12 @@ pub fn all_command_types_test() {
 pub fn multiline_sql_body_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetAuthor :one\n"
-    <> "SELECT id,\n"
-    <> "       name,\n"
-    <> "       bio\n"
-    <> "FROM authors\n"
-    <> "WHERE id = $1;"
+    "-- name: GetAuthor :one
+SELECT id,
+       name,
+       bio
+FROM authors
+WHERE id = $1;"
 
   let assert Ok(queries) =
     parse_file("multi.sql", model.PostgreSQL, naming_ctx, content)
@@ -394,10 +403,10 @@ pub fn multiline_sql_body_test() {
 pub fn ignore_placeholder_in_single_quoted_string_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetAuthorWithLiteral :one\n"
-    <> "SELECT id, name\n"
-    <> "FROM authors\n"
-    <> "WHERE note = '$2' OR id = $1;"
+    "-- name: GetAuthorWithLiteral :one
+SELECT id, name
+FROM authors
+WHERE note = '$2' OR id = $1;"
 
   let assert Ok(queries) =
     parse_file("lit.sql", model.PostgreSQL, naming_ctx, content)
@@ -410,10 +419,10 @@ pub fn ignore_placeholder_in_single_quoted_string_test() {
 pub fn ignore_placeholder_in_line_comment_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetById :one\n"
-    <> "SELECT id, name\n"
-    <> "FROM authors\n"
-    <> "WHERE id = $1; -- $2 is not used"
+    "-- name: GetById :one
+SELECT id, name
+FROM authors
+WHERE id = $1; -- $2 is not used"
 
   let assert Ok(queries) =
     parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
@@ -425,11 +434,11 @@ pub fn ignore_placeholder_in_line_comment_test() {
 pub fn ignore_placeholder_in_block_comment_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetById :one\n"
-    <> "SELECT id, name\n"
-    <> "FROM authors\n"
-    <> "/* WHERE bio = $2 */\n"
-    <> "WHERE id = $1;"
+    "-- name: GetById :one
+SELECT id, name
+FROM authors
+/* WHERE bio = $2 */
+WHERE id = $1;"
 
   let assert Ok(queries) =
     parse_file("cmt.sql", model.PostgreSQL, naming_ctx, content)
@@ -441,9 +450,9 @@ pub fn ignore_placeholder_in_block_comment_test() {
 pub fn ignore_at_name_in_string_literal_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByNote :one\n"
-    <> "SELECT id FROM authors\n"
-    <> "WHERE note = '@skip_me' AND id = @real_id;"
+    "-- name: GetByNote :one
+SELECT id FROM authors
+WHERE note = '@skip_me' AND id = @real_id;"
 
   let assert Ok(queries) =
     parse_file("at.sql", model.PostgreSQL, naming_ctx, content)
@@ -458,9 +467,9 @@ pub fn ignore_at_name_in_string_literal_test() {
 pub fn ignore_question_mark_in_string_mysql_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: GetByNote :one\n"
-    <> "SELECT id FROM authors\n"
-    <> "WHERE note = 'is this a ?' AND id = ?;"
+    "-- name: GetByNote :one
+SELECT id FROM authors
+WHERE note = 'is this a ?' AND id = ?;"
 
   let assert Ok(queries) = parse_file("q.sql", model.MySQL, naming_ctx, content)
   let assert [query] = queries
@@ -471,8 +480,8 @@ pub fn ignore_question_mark_in_string_mysql_test() {
 pub fn sqlite_repeated_colon_placeholder_dedup_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: ReusedNamed :one\n"
-    <> "SELECT id FROM authors WHERE id = :id OR parent_id = :id;"
+    "-- name: ReusedNamed :one
+SELECT id FROM authors WHERE id = :id OR parent_id = :id;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -484,8 +493,8 @@ pub fn sqlite_repeated_colon_placeholder_dedup_test() {
 pub fn sqlite_repeated_dollar_placeholder_dedup_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: ReusedDollar :one\n"
-    <> "SELECT id FROM authors WHERE id = $id OR parent_id = $id;"
+    "-- name: ReusedDollar :one
+SELECT id FROM authors WHERE id = $id OR parent_id = $id;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -497,8 +506,8 @@ pub fn sqlite_repeated_dollar_placeholder_dedup_test() {
 pub fn sqlite_repeated_at_placeholder_dedup_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: ReusedAt :one\n"
-    <> "SELECT id FROM authors WHERE id = @id OR parent_id = @id;"
+    "-- name: ReusedAt :one
+SELECT id FROM authors WHERE id = @id OR parent_id = @id;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -510,8 +519,8 @@ pub fn sqlite_repeated_at_placeholder_dedup_test() {
 pub fn sqlite_distinct_named_placeholders_not_deduped_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: DistinctNames :one\n"
-    <> "SELECT id FROM authors WHERE id = :id OR name = :name;"
+    "-- name: DistinctNames :one
+SELECT id FROM authors WHERE id = :id OR name = :name;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -523,8 +532,8 @@ pub fn sqlite_distinct_named_placeholders_not_deduped_test() {
 pub fn sqlite_colon_and_at_are_different_params_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: DifferentPrefix :one\n"
-    <> "SELECT id FROM authors WHERE id = :id OR parent_id = @id;"
+    "-- name: DifferentPrefix :one
+SELECT id FROM authors WHERE id = :id OR parent_id = @id;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -536,8 +545,8 @@ pub fn sqlite_colon_and_at_are_different_params_test() {
 pub fn sqlite_bare_question_marks_not_deduped_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: BareQuestions :exec\n"
-    <> "INSERT INTO authors (name, bio) VALUES (?, ?);"
+    "-- name: BareQuestions :exec
+INSERT INTO authors (name, bio) VALUES (?, ?);"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -549,8 +558,8 @@ pub fn sqlite_bare_question_marks_not_deduped_test() {
 pub fn sqlite_repeated_numbered_placeholder_dedup_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: ReusedNumbered :one\n"
-    <> "SELECT id FROM authors WHERE id = ?1 OR parent_id = ?1;"
+    "-- name: ReusedNumbered :one
+SELECT id FROM authors WHERE id = ?1 OR parent_id = ?1;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -562,8 +571,8 @@ pub fn sqlite_repeated_numbered_placeholder_dedup_test() {
 pub fn postgresql_plain_dollar_quoted_string_masks_placeholder_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: DollarPlain :one\n"
-    <> "SELECT $$literal $1 inside$$, id FROM authors WHERE id = $1;"
+    "-- name: DollarPlain :one
+SELECT $$literal $1 inside$$, id FROM authors WHERE id = $1;"
 
   let assert Ok(queries) =
     parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -575,8 +584,8 @@ pub fn postgresql_plain_dollar_quoted_string_masks_placeholder_test() {
 pub fn postgresql_tagged_dollar_quoted_string_masks_placeholder_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: DollarTag :one\n"
-    <> "SELECT $tag$literal $1 inside$tag$, id FROM authors WHERE id = $2;"
+    "-- name: DollarTag :one
+SELECT $tag$literal $1 inside$tag$, id FROM authors WHERE id = $2;"
 
   let assert Ok(queries) =
     parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -588,8 +597,8 @@ pub fn postgresql_tagged_dollar_quoted_string_masks_placeholder_test() {
 pub fn postgresql_dollar_quoted_does_not_affect_real_params_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: DollarMixed :one\n"
-    <> "SELECT $fn$body with $1 and $2$fn$, id FROM authors WHERE id = $1 AND name = $2;"
+    "-- name: DollarMixed :one
+SELECT $fn$body with $1 and $2$fn$, id FROM authors WHERE id = $1 AND name = $2;"
 
   let assert Ok(queries) =
     parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -601,7 +610,7 @@ pub fn postgresql_dollar_quoted_does_not_affect_real_params_test() {
 pub fn sqlite_dollar_not_treated_as_dollar_quoted_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: SqliteDollar :one\n" <> "SELECT id FROM authors WHERE id = $id;"
+    "-- name: SqliteDollar :one\nSELECT id FROM authors WHERE id = $id;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -613,8 +622,8 @@ pub fn sqlite_dollar_not_treated_as_dollar_quoted_test() {
 pub fn sqlc_arg_in_string_literal_ignored_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: MacroInString :one\n"
-    <> "SELECT id FROM authors WHERE note = 'sqlode.arg(fake)' AND id = sqlode.arg(real_id);"
+    "-- name: MacroInString :one
+SELECT id FROM authors WHERE note = 'sqlode.arg(fake)' AND id = sqlode.arg(real_id);"
 
   let assert Ok(queries) =
     parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -629,10 +638,10 @@ pub fn sqlc_arg_in_string_literal_ignored_test() {
 pub fn sqlc_narg_in_line_comment_ignored_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: MacroInComment :one\n"
-    <> "SELECT id FROM authors\n"
-    <> "-- WHERE name = sqlode.narg(ignored)\n"
-    <> "WHERE id = sqlode.arg(real_id);"
+    "-- name: MacroInComment :one
+SELECT id FROM authors
+-- WHERE name = sqlode.narg(ignored)
+WHERE id = sqlode.arg(real_id);"
 
   let assert Ok(queries) =
     parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -646,9 +655,9 @@ pub fn sqlc_narg_in_line_comment_ignored_test() {
 pub fn sqlc_slice_in_block_comment_ignored_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: MacroInBlock :many\n"
-    <> "SELECT id FROM authors\n"
-    <> "WHERE /* sqlode.slice(phantom) */ id IN (sqlode.slice(real_ids));"
+    "-- name: MacroInBlock :many
+SELECT id FROM authors
+WHERE /* sqlode.slice(phantom) */ id IN (sqlode.slice(real_ids));"
 
   let assert Ok(queries) =
     parse_file("pg.sql", model.PostgreSQL, naming_ctx, content)
@@ -680,12 +689,13 @@ pub fn error_to_string_coverage_test() {
 pub fn skip_annotation_skips_query_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- sqlode:skip\n"
-    <> "-- name: SkippedQuery :one\n"
-    <> "SELECT complex_stuff FROM somewhere;\n"
-    <> "\n"
-    <> "-- name: KeptQuery :many\n"
-    <> "SELECT id FROM authors;\n"
+    "-- sqlode:skip
+-- name: SkippedQuery :one
+SELECT complex_stuff FROM somewhere;
+
+-- name: KeptQuery :many
+SELECT id FROM authors;
+"
 
   let assert Ok(queries) =
     parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
@@ -699,13 +709,14 @@ pub fn skip_annotation_skips_query_test() {
 pub fn skip_annotation_all_queries_skipped_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- sqlode:skip\n"
-    <> "-- name: SkippedOne :one\n"
-    <> "SELECT 1;\n"
-    <> "\n"
-    <> "-- sqlode:skip\n"
-    <> "-- name: SkippedTwo :many\n"
-    <> "SELECT 2;\n"
+    "-- sqlode:skip
+-- name: SkippedOne :one
+SELECT 1;
+
+-- sqlode:skip
+-- name: SkippedTwo :many
+SELECT 2;
+"
 
   let assert Ok(queries) =
     parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
@@ -716,15 +727,16 @@ pub fn skip_annotation_all_queries_skipped_test() {
 pub fn skip_annotation_middle_query_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: First :one\n"
-    <> "SELECT 1;\n"
-    <> "\n"
-    <> "-- sqlode:skip\n"
-    <> "-- name: Second :one\n"
-    <> "SELECT 2;\n"
-    <> "\n"
-    <> "-- name: Third :many\n"
-    <> "SELECT 3;\n"
+    "-- name: First :one
+SELECT 1;
+
+-- sqlode:skip
+-- name: Second :one
+SELECT 2;
+
+-- name: Third :many
+SELECT 3;
+"
 
   let assert Ok(queries) =
     parse_file("test.sql", model.PostgreSQL, naming_ctx, content)
@@ -797,14 +809,15 @@ pub fn parse_block_annotation_no_inner_space_test() {
 pub fn parse_mixed_line_and_block_annotations_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- name: First :one\n"
-    <> "SELECT 1;\n"
-    <> "\n"
-    <> "/* name: Second :many */\n"
-    <> "SELECT 2;\n"
-    <> "\n"
-    <> "-- name: Third :exec\n"
-    <> "INSERT INTO t VALUES (1);\n"
+    "-- name: First :one
+SELECT 1;
+
+/* name: Second :many */
+SELECT 2;
+
+-- name: Third :exec
+INSERT INTO t VALUES (1);
+"
 
   let assert Ok(queries) =
     parse_file("mixed.sql", model.PostgreSQL, naming_ctx, content)
@@ -822,12 +835,12 @@ pub fn parse_mixed_line_and_block_annotations_test() {
 pub fn parse_block_annotation_multiline_body_test() {
   let naming_ctx = naming.new()
   let content =
-    "/* name: BigQuery :many */\n"
-    <> "SELECT id,\n"
-    <> "       name,\n"
-    <> "       bio\n"
-    <> "FROM authors\n"
-    <> "WHERE id = $1;"
+    "/* name: BigQuery :many */
+SELECT id,
+       name,
+       bio
+FROM authors
+WHERE id = $1;"
 
   let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
@@ -839,8 +852,8 @@ pub fn parse_block_annotation_multiline_body_test() {
 pub fn parse_block_annotation_with_macro_test() {
   let naming_ctx = naming.new()
   let content =
-    "/* name: Search :many */\n"
-    <> "SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
+    "/* name: Search :many */
+SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
 
   let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
@@ -852,10 +865,10 @@ pub fn parse_block_annotation_with_macro_test() {
 pub fn parse_block_annotation_body_with_regular_block_comment_test() {
   let naming_ctx = naming.new()
   let content =
-    "/* name: WithComment :one */\n"
-    <> "SELECT id\n"
-    <> "/* just a regular comment */\n"
-    <> "FROM authors WHERE id = $1;"
+    "/* name: WithComment :one */
+SELECT id
+/* just a regular comment */
+FROM authors WHERE id = $1;"
 
   let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
@@ -866,8 +879,7 @@ pub fn parse_block_annotation_body_with_regular_block_comment_test() {
 
 pub fn parse_block_comment_other_directive_ignored_test() {
   let naming_ctx = naming.new()
-  let content =
-    "-- name: Real :one\n" <> "/* other: bogus :many */\n" <> "SELECT 1;"
+  let content = "-- name: Real :one\n/* other: bogus :many */\nSELECT 1;"
 
   let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
@@ -898,7 +910,7 @@ pub fn parse_block_annotation_unclosed_ignored_test() {
 pub fn parse_block_annotation_multiline_not_annotation_test() {
   let naming_ctx = naming.new()
   // Annotation text split across lines is not supported.
-  let content = "/* name: Split\n" <> " :one */\n" <> "SELECT 1;"
+  let content = "/* name: Split\n :one */\nSELECT 1;"
 
   let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
@@ -939,12 +951,13 @@ pub fn parse_block_annotation_missing_sql_body_test() {
 pub fn skip_annotation_applies_to_block_annotation_test() {
   let naming_ctx = naming.new()
   let content =
-    "-- sqlode:skip\n"
-    <> "/* name: Skipped :one */\n"
-    <> "SELECT 1;\n"
-    <> "\n"
-    <> "-- name: Kept :many\n"
-    <> "SELECT 2;\n"
+    "-- sqlode:skip
+/* name: Skipped :one */
+SELECT 1;
+
+-- name: Kept :many
+SELECT 2;
+"
 
   let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -92,8 +92,7 @@ pub fn prepare_mixed_params_test() {
   let query =
     runtime.RawQuery(
       name: "GetByNameAndIds",
-      sql: "SELECT * FROM users WHERE name = __sqlode_param_1__"
-        <> " AND id IN (__sqlode_slice_2__)",
+      sql: "SELECT * FROM users WHERE name = __sqlode_param_1__ AND id IN (__sqlode_slice_2__)",
       command: runtime.QueryMany,
       param_count: 2,
       placeholder_style: runtime.DollarNumbered,
@@ -134,9 +133,7 @@ pub fn prepare_mysql_mixed_params_and_slice_test() {
   let query =
     runtime.RawQuery(
       name: "GetByNameAndIds",
-      sql: "SELECT * FROM users WHERE name = __sqlode_param_1__"
-        <> " AND id IN (__sqlode_slice_2__)"
-        <> " AND status = __sqlode_param_3__",
+      sql: "SELECT * FROM users WHERE name = __sqlode_param_1__ AND id IN (__sqlode_slice_2__) AND status = __sqlode_param_3__",
       command: runtime.QueryMany,
       param_count: 3,
       placeholder_style: runtime.QuestionPositional,
@@ -182,16 +179,12 @@ pub fn expand_slice_placeholders_preserves_string_literal_with_placeholder_text_
 
 pub fn expand_slice_placeholders_preserves_comment_with_placeholder_text_test() {
   let sql =
-    "SELECT id FROM t"
-    <> " /* $1 is the placeholder used below */"
-    <> " WHERE id = __sqlode_param_1__"
+    "SELECT id FROM t /* $1 is the placeholder used below */ WHERE id = __sqlode_param_1__"
   let result =
     runtime.expand_slice_placeholders(sql, [], 1, runtime.DollarNumbered)
   result
   |> should.equal(
-    "SELECT id FROM t"
-    <> " /* $1 is the placeholder used below */"
-    <> " WHERE id = $1",
+    "SELECT id FROM t /* $1 is the placeholder used below */ WHERE id = $1",
   )
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -93,10 +93,10 @@ pub fn schema_missing_parenthesis_test() {
 
 pub fn schema_if_not_exists_test() {
   let content =
-    "CREATE TABLE IF NOT EXISTS users (\n"
-    <> "  id BIGSERIAL PRIMARY KEY,\n"
-    <> "  name TEXT NOT NULL\n"
-    <> ");"
+    "CREATE TABLE IF NOT EXISTS users (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("ifne.sql", content)])
   let assert [table] = catalog.tables
@@ -106,10 +106,10 @@ pub fn schema_if_not_exists_test() {
 
 pub fn schema_quoted_table_name_test() {
   let content =
-    "CREATE TABLE \"MyTable\" (\n"
-    <> "  id BIGSERIAL PRIMARY KEY,\n"
-    <> "  name TEXT NOT NULL\n"
-    <> ");"
+    "CREATE TABLE \"MyTable\" (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("quoted.sql", content)])
   let assert [table] = catalog.tables
@@ -126,12 +126,12 @@ pub fn schema_multiple_files_test() {
 
 pub fn schema_table_with_constraints_test() {
   let content =
-    "CREATE TABLE orders (\n"
-    <> "  id BIGSERIAL PRIMARY KEY,\n"
-    <> "  user_id BIGINT NOT NULL,\n"
-    <> "  total NUMERIC(10,2) NOT NULL,\n"
-    <> "  FOREIGN KEY (user_id) REFERENCES users(id)\n"
-    <> ");"
+    "CREATE TABLE orders (
+  id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL,
+  total NUMERIC(10,2) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("fk.sql", content)])
   let assert [table] = catalog.tables
@@ -142,11 +142,11 @@ pub fn schema_table_with_constraints_test() {
 
 pub fn schema_enum_type_test() {
   let content =
-    "CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');\n"
-    <> "CREATE TABLE people (\n"
-    <> "  id BIGSERIAL PRIMARY KEY,\n"
-    <> "  current_mood mood NOT NULL\n"
-    <> ");"
+    "CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+CREATE TABLE people (
+  id BIGSERIAL PRIMARY KEY,
+  current_mood mood NOT NULL
+);"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("enum.sql", content)])
   let assert [enum] = catalog.enums
@@ -165,11 +165,11 @@ pub fn mysql_inline_enum_and_set_columns_test() {
   // the catalog and surfaces ENUM as `EnumType(name)` and SET as
   // first-class `SetType(name)` (no longer a StringType fallback).
   let content =
-    "CREATE TABLE items (\n"
-    <> "  id BIGINT NOT NULL,\n"
-    <> "  status ENUM('active', 'inactive', 'archived') NOT NULL,\n"
-    <> "  tags SET('red', 'green', 'blue')\n"
-    <> ");"
+    "CREATE TABLE items (
+  id BIGINT NOT NULL,
+  status ENUM('active', 'inactive', 'archived') NOT NULL,
+  tags SET('red', 'green', 'blue')
+);"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine(
       [#("items.sql", content)],
@@ -200,8 +200,8 @@ pub fn mysql_inline_enum_and_set_columns_test() {
 
 pub fn view_with_cast_expression_test() {
   let content =
-    "CREATE TABLE t (x TEXT NOT NULL, y TEXT NOT NULL);\n"
-    <> "CREATE VIEW v AS SELECT CAST(x AS TEXT) AS col_a, y AS col_b FROM t;"
+    "CREATE TABLE t (x TEXT NOT NULL, y TEXT NOT NULL);
+CREATE VIEW v AS SELECT CAST(x AS TEXT) AS col_a, y AS col_b FROM t;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("cast_view.sql", content)])
 
@@ -218,8 +218,8 @@ pub fn view_with_cast_expression_test() {
 
 pub fn view_basic_select_test() {
   let content =
-    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT);\n"
-    <> "CREATE VIEW active_users AS SELECT id, name FROM users;"
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT);
+CREATE VIEW active_users AS SELECT id, name FROM users;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("view.sql", content)])
 
@@ -232,8 +232,8 @@ pub fn view_basic_select_test() {
 
 pub fn view_with_alias_test() {
   let content =
-    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "CREATE VIEW user_names AS SELECT id, name AS display_name FROM users;"
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);
+CREATE VIEW user_names AS SELECT id, name AS display_name FROM users;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("view_alias.sql", content)])
 
@@ -250,8 +250,8 @@ pub fn view_with_alias_test() {
 
 pub fn view_star_test() {
   let content =
-    "CREATE TABLE items (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "CREATE VIEW all_items AS SELECT * FROM items;"
+    "CREATE TABLE items (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);
+CREATE VIEW all_items AS SELECT * FROM items;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("view_star.sql", content)])
 
@@ -262,8 +262,8 @@ pub fn view_star_test() {
 
 pub fn view_or_replace_test() {
   let content =
-    "CREATE TABLE t (id BIGSERIAL PRIMARY KEY, val TEXT NOT NULL);\n"
-    <> "CREATE OR REPLACE VIEW v AS SELECT id FROM t;"
+    "CREATE TABLE t (id BIGSERIAL PRIMARY KEY, val TEXT NOT NULL);
+CREATE OR REPLACE VIEW v AS SELECT id FROM t;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("or_replace.sql", content)])
 
@@ -316,10 +316,10 @@ pub fn parse_error_carries_source_path_test() {
 
 pub fn unrecognized_sql_type_returns_error_test() {
   let content =
-    "CREATE TABLE geo (\n"
-    <> "  id BIGSERIAL PRIMARY KEY,\n"
-    <> "  shape GEOMETRY NOT NULL\n"
-    <> ");"
+    "CREATE TABLE geo (
+  id BIGSERIAL PRIMARY KEY,
+  shape GEOMETRY NOT NULL
+);"
   let assert Error(error) = schema_parser.parse_files([#("geo.sql", content)])
   let msg = schema_parser.error_to_string(error)
   string.contains(msg, "geo") |> should.be_true()
@@ -390,8 +390,8 @@ ALTER TABLE users ADD CONSTRAINT unique_email UNIQUE (email);"
 
 pub fn view_with_count_expression_test() {
   let content =
-    "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "CREATE VIEW author_counts AS SELECT COUNT(*) AS total FROM authors;"
+    "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);
+CREATE VIEW author_counts AS SELECT COUNT(*) AS total FROM authors;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("count_view.sql", content)])
 
@@ -404,8 +404,8 @@ pub fn view_with_count_expression_test() {
 
 pub fn view_with_sum_expression_test() {
   let content =
-    "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, amount INTEGER NOT NULL);\n"
-    <> "CREATE VIEW order_totals AS SELECT SUM(amount) AS total_amount FROM orders;"
+    "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, amount INTEGER NOT NULL);
+CREATE VIEW order_totals AS SELECT SUM(amount) AS total_amount FROM orders;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("sum_view.sql", content)])
 
@@ -419,8 +419,8 @@ pub fn view_with_sum_expression_test() {
 
 pub fn view_with_avg_expression_test() {
   let content =
-    "CREATE TABLE products (id BIGSERIAL PRIMARY KEY, price REAL NOT NULL);\n"
-    <> "CREATE VIEW avg_prices AS SELECT AVG(price) AS avg_price FROM products;"
+    "CREATE TABLE products (id BIGSERIAL PRIMARY KEY, price REAL NOT NULL);
+CREATE VIEW avg_prices AS SELECT AVG(price) AS avg_price FROM products;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("avg_view.sql", content)])
 
@@ -433,8 +433,8 @@ pub fn view_with_avg_expression_test() {
 
 pub fn view_with_coalesce_expression_test() {
   let content =
-    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT);\n"
-    <> "CREATE VIEW user_display AS SELECT id, COALESCE(bio, 'N/A') AS bio_text FROM users;"
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT);
+CREATE VIEW user_display AS SELECT id, COALESCE(bio, 'N/A') AS bio_text FROM users;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("coalesce_view.sql", content)])
 
@@ -447,8 +447,8 @@ pub fn view_with_coalesce_expression_test() {
 
 pub fn view_with_literal_expression_test() {
   let content =
-    "CREATE TABLE t (id BIGSERIAL PRIMARY KEY);\n"
-    <> "CREATE VIEW v AS SELECT 42 AS magic, 'hello' AS greeting FROM t;"
+    "CREATE TABLE t (id BIGSERIAL PRIMARY KEY);
+CREATE VIEW v AS SELECT 42 AS magic, 'hello' AS greeting FROM t;"
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("literal_view.sql", content)])
 
@@ -463,12 +463,13 @@ pub fn view_with_literal_expression_test() {
 
 pub fn serial_types_are_implicitly_not_null_test() {
   let content =
-    "CREATE TABLE t (\n"
-    <> "  a SERIAL,\n"
-    <> "  b BIGSERIAL,\n"
-    <> "  c SMALLSERIAL,\n"
-    <> "  d INTEGER\n"
-    <> ");\n"
+    "CREATE TABLE t (
+  a SERIAL,
+  b BIGSERIAL,
+  c SMALLSERIAL,
+  d INTEGER
+);
+"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("serial.sql", content)])
@@ -486,9 +487,10 @@ pub fn serial_types_are_implicitly_not_null_test() {
 
 pub fn view_with_join_extracts_all_source_tables_test() {
   let content =
-    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, amount INTEGER NOT NULL);\n"
-    <> "CREATE VIEW user_orders AS SELECT u.name, o.amount FROM users u JOIN orders o ON u.id = o.user_id;\n"
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, amount INTEGER NOT NULL);
+CREATE VIEW user_orders AS SELECT u.name, o.amount FROM users u JOIN orders o ON u.id = o.user_id;
+"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("join_view.sql", content)])
@@ -508,9 +510,10 @@ pub fn view_with_join_extracts_all_source_tables_test() {
 
 pub fn view_with_left_join_test() {
   let content =
-    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "CREATE TABLE profiles (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, bio TEXT);\n"
-    <> "CREATE VIEW user_profiles AS SELECT u.name, p.bio FROM users u LEFT JOIN profiles p ON u.id = p.user_id;\n"
+    "CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);
+CREATE TABLE profiles (id BIGSERIAL PRIMARY KEY, user_id INTEGER NOT NULL, bio TEXT);
+CREATE VIEW user_profiles AS SELECT u.name, p.bio FROM users u LEFT JOIN profiles p ON u.id = p.user_id;
+"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("left_join.sql", content)])
@@ -523,9 +526,10 @@ pub fn view_with_left_join_test() {
 
 pub fn view_star_with_join_test() {
   let content =
-    "CREATE TABLE t1 (a INTEGER NOT NULL, b TEXT NOT NULL);\n"
-    <> "CREATE TABLE t2 (c INTEGER NOT NULL, d TEXT NOT NULL);\n"
-    <> "CREATE VIEW v AS SELECT * FROM t1 JOIN t2 ON t1.a = t2.c;\n"
+    "CREATE TABLE t1 (a INTEGER NOT NULL, b TEXT NOT NULL);
+CREATE TABLE t2 (c INTEGER NOT NULL, d TEXT NOT NULL);
+CREATE VIEW v AS SELECT * FROM t1 JOIN t2 ON t1.a = t2.c;
+"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files([#("star_join.sql", content)])
@@ -677,8 +681,8 @@ pub fn partition_by_clause_does_not_break_table_test() {
 
 pub fn drop_table_removes_table_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "DROP TABLE users;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+DROP TABLE users;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   list.length(catalog.tables) |> should.equal(0)
 }
@@ -691,9 +695,9 @@ pub fn drop_table_if_exists_nonexistent_test() {
 
 pub fn drop_view_removes_view_test() {
   let sql =
-    "CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "CREATE VIEW author_list AS SELECT id, name FROM authors;\n"
-    <> "DROP VIEW author_list;"
+    "CREATE TABLE authors (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+CREATE VIEW author_list AS SELECT id, name FROM authors;
+DROP VIEW author_list;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   list.length(catalog.tables) |> should.equal(1)
   let assert [table] = catalog.tables
@@ -702,16 +706,16 @@ pub fn drop_view_removes_view_test() {
 
 pub fn drop_type_removes_enum_test() {
   let sql =
-    "CREATE TYPE status AS ENUM ('active', 'inactive');\n"
-    <> "DROP TYPE status;"
+    "CREATE TYPE status AS ENUM ('active', 'inactive');
+DROP TYPE status;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   list.length(catalog.enums) |> should.equal(0)
 }
 
 pub fn alter_table_drop_column_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "ALTER TABLE users DROP COLUMN name;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+ALTER TABLE users DROP COLUMN name;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   list.length(table.columns) |> should.equal(1)
@@ -721,8 +725,8 @@ pub fn alter_table_drop_column_test() {
 
 pub fn alter_table_if_exists_drop_column_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "ALTER TABLE IF EXISTS users DROP COLUMN name;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+ALTER TABLE IF EXISTS users DROP COLUMN name;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   list.length(table.columns) |> should.equal(1)
@@ -730,8 +734,8 @@ pub fn alter_table_if_exists_drop_column_test() {
 
 pub fn alter_table_rename_column_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "ALTER TABLE users RENAME COLUMN name TO full_name;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+ALTER TABLE users RENAME COLUMN name TO full_name;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   let assert [_, col2] = table.columns
@@ -740,8 +744,8 @@ pub fn alter_table_rename_column_test() {
 
 pub fn alter_table_rename_to_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY);\n"
-    <> "ALTER TABLE users RENAME TO accounts;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users RENAME TO accounts;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   table.name |> should.equal("accounts")
@@ -749,8 +753,8 @@ pub fn alter_table_rename_to_test() {
 
 pub fn alter_table_set_not_null_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, created_at TIMESTAMP);\n"
-    <> "ALTER TABLE users ALTER COLUMN created_at SET NOT NULL;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, created_at TIMESTAMP);
+ALTER TABLE users ALTER COLUMN created_at SET NOT NULL;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   let assert [_, col2] = table.columns
@@ -760,8 +764,8 @@ pub fn alter_table_set_not_null_test() {
 
 pub fn alter_table_drop_not_null_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);\n"
-    <> "ALTER TABLE users ALTER COLUMN name DROP NOT NULL;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+ALTER TABLE users ALTER COLUMN name DROP NOT NULL;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   let assert [_, col2] = table.columns
@@ -771,8 +775,8 @@ pub fn alter_table_drop_not_null_test() {
 
 pub fn alter_table_alter_column_type_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, score INTEGER NOT NULL);\n"
-    <> "ALTER TABLE users ALTER COLUMN score TYPE TEXT;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, score INTEGER NOT NULL);
+ALTER TABLE users ALTER COLUMN score TYPE TEXT;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   let assert [_, col2] = table.columns
@@ -782,8 +786,8 @@ pub fn alter_table_alter_column_type_test() {
 
 pub fn alter_table_drop_constraint_stays_silent_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL);\n"
-    <> "ALTER TABLE users DROP CONSTRAINT unique_email;"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL);
+ALTER TABLE users DROP CONSTRAINT unique_email;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   list.length(table.columns) |> should.equal(2)
@@ -791,16 +795,15 @@ pub fn alter_table_drop_constraint_stays_silent_test() {
 
 pub fn comment_on_stays_silent_test() {
   let sql =
-    "CREATE TABLE users (id INTEGER PRIMARY KEY);\n"
-    <> "COMMENT ON TABLE users IS 'account records';"
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+COMMENT ON TABLE users IS 'account records';"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   table.name |> should.equal("users")
 }
 
 pub fn transaction_control_stays_silent_test() {
-  let sql =
-    "BEGIN;\n" <> "CREATE TABLE users (id INTEGER PRIMARY KEY);\n" <> "COMMIT;"
+  let sql = "BEGIN;\nCREATE TABLE users (id INTEGER PRIMARY KEY);\nCOMMIT;"
   let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
   let assert [table] = catalog.tables
   table.name |> should.equal("users")
@@ -869,12 +872,12 @@ pub fn mysql_snapshot_matches_migration_history_test() {
 
 pub fn mysql_alter_modify_changes_column_type_test() {
   let create =
-    "CREATE TABLE `events` (\n"
-    <> "  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,\n"
-    <> "  `payload` TEXT NULL,\n"
-    <> "  PRIMARY KEY (`id`)\n"
-    <> ");\n"
-    <> "ALTER TABLE `events` MODIFY COLUMN `payload` JSON NOT NULL;"
+    "CREATE TABLE `events` (
+  `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `payload` TEXT NULL,
+  PRIMARY KEY (`id`)
+);
+ALTER TABLE `events` MODIFY COLUMN `payload` JSON NOT NULL;"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine(
@@ -891,12 +894,12 @@ pub fn mysql_alter_modify_changes_column_type_test() {
 
 pub fn mysql_alter_change_renames_and_retypes_column_test() {
   let create =
-    "CREATE TABLE `notes` (\n"
-    <> "  `id` BIGINT NOT NULL,\n"
-    <> "  `body` TEXT NOT NULL,\n"
-    <> "  PRIMARY KEY (`id`)\n"
-    <> ");\n"
-    <> "ALTER TABLE `notes` CHANGE COLUMN `body` `content` LONGTEXT NULL;"
+    "CREATE TABLE `notes` (
+  `id` BIGINT NOT NULL,
+  `body` TEXT NOT NULL,
+  PRIMARY KEY (`id`)
+);
+ALTER TABLE `notes` CHANGE COLUMN `body` `content` LONGTEXT NULL;"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine([#("notes.sql", create)], model.MySQL)
@@ -915,11 +918,11 @@ pub fn mysql_alter_modify_decimal_uses_lossless_contract_test() {
   // a MODIFY changing a column to DECIMAL must produce DecimalType,
   // not the legacy FloatType collapse.
   let sql =
-    "CREATE TABLE `prices` (\n"
-    <> "  `id` BIGINT NOT NULL,\n"
-    <> "  `amount` INT NOT NULL\n"
-    <> ");\n"
-    <> "ALTER TABLE `prices` MODIFY COLUMN `amount` DECIMAL(20,6) NOT NULL;"
+    "CREATE TABLE `prices` (
+  `id` BIGINT NOT NULL,
+  `amount` INT NOT NULL
+);
+ALTER TABLE `prices` MODIFY COLUMN `amount` DECIMAL(20,6) NOT NULL;"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine([#("prices.sql", sql)], model.MySQL)
@@ -933,8 +936,8 @@ pub fn mysql_create_view_with_backticks_test() {
   // Backtick-quoted identifiers in CREATE VIEW must round-trip
   // through the parser (#419 acceptance criteria).
   let sql =
-    "CREATE TABLE `posts` (`id` BIGINT NOT NULL, `title` VARCHAR(255) NOT NULL);\n"
-    <> "CREATE VIEW `post_titles` AS SELECT `id`, `title` FROM `posts`;"
+    "CREATE TABLE `posts` (`id` BIGINT NOT NULL, `title` VARCHAR(255) NOT NULL);
+CREATE VIEW `post_titles` AS SELECT `id`, `title` FROM `posts`;"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine([#("posts.sql", sql)], model.MySQL)
@@ -951,12 +954,11 @@ pub fn mysql_create_table_strips_auto_increment_and_charset_noise_test() {
   // after the column type in real MySQL DDL. They must not bleed
   // into the type text and must not produce phantom columns.
   let sql =
-    "CREATE TABLE `posts` (\n"
-    <> "  `id` BIGINT NOT NULL AUTO_INCREMENT,\n"
-    <> "  `title` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
-    <> " NOT NULL COMMENT 'post title',\n"
-    <> "  PRIMARY KEY (`id`)\n"
-    <> ");"
+    "CREATE TABLE `posts` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `title` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'post title',
+  PRIMARY KEY (`id`)
+);"
 
   let assert Ok(#(catalog, _)) =
     schema_parser.parse_files_with_engine([#("posts.sql", sql)], model.MySQL)

--- a/test/writer_test.gleam
+++ b/test/writer_test.gleam
@@ -7,7 +7,7 @@ import sqlode/writer
 const test_dir = "test_output/writer_test"
 
 fn cleanup() {
-  let _ = simplifile.delete(test_dir)
+  let _delete_result = simplifile.delete(test_dir)
   Nil
 }
 


### PR DESCRIPTION
## Summary

Brings [glinter](https://github.com/pairshaped/glinter) into the project as a dev dependency, configures it under `[tools.glinter]` in `gleam.toml` with `warnings_as_errors = true`, and runs it from both `just lint` (added) / `just all` (prepended ahead of `gleam test`) and a new CI step `Lint (glinter, warnings as errors)`.

## What changed

- **gleam.toml** — adds `glinter` dev dep + `[tools.glinter]` config with `include = [\"src/\", \"test/\"]` and `warnings_as_errors = true`. A handful of rules are off with strong inline justification (label_possible, prefer_guard_clause, stringly_typed_error, error_context_lost, thrown_away_error, deep_nesting / function_complexity / module_complexity, unused_exports). For tests: assert_ok_pattern, avoid_panic, missing_type_annotation, short_variable_name, unused_exports are off because of gleeunit conventions.
- **All other glinter findings fixed**:
  - 180+ `unnecessary_string_concatenation` rewritten as multi-line literals (mostly SQL fixtures).
  - `discarded_result` → named `_create_dir_result` / `_delete_result` bindings.
  - `unqualified_import` → qualified `char_utils.is_*`.
  - `short_variable_name` renamed (`s` → `token_text`, `n` → `table_name` / `nullable`).
  - `redundant_case` → `let Variant(..)` destructuring.
  - One inline `// nolint: assert_ok_pattern` for the compile-time regex literals in `naming.new()`.
  - `main` in `src/sqlode.gleam` gets `-> Nil`.
- **justfile** — new `lint` task; `all` runs glinter before tests.
- **.github/workflows/ci.yml** — new `Lint` step between Build and Unit tests.

## Test plan

- [x] `gleam run -m glinter` — \"No issues found.\"
- [x] `gleam test` — 911 passed, no failures
- [x] `gleam check` / `gleam build --warnings-as-errors` — clean
- [x] `gleam format --check src/ test/` — clean
- [ ] CI runs the new lint step