### PR TITLE
feat(mysql): close bytes/decimal/enum/SET round-trip gaps + DDL fail-fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **MySQL completeness pass.** Closes the documented gaps left over
+  from the #417 epic:
+  - `BLOB` / `BINARY` columns now round-trip byte-for-byte in native
+    mode by routing `SqlBytes` through `shork_ffi.coerce` (an internal
+    FFI binding mirroring shork's own `text` / `int` constructors).
+  - The MySQL `SET(...)` column type is now wired end-to-end. The
+    generated params record exposes the field as `List(<Name>Value)`
+    and the encoder routes it through the new `<name>_set_to_string`
+    helper; the adapter decoder calls `<name>_set_from_string` on
+    the wire string.
+  - The MySQL real-DB integration lane now exercises bytes, decimal
+    (lossless `DecimalType`), enum, and SET round-trips against the
+    live MySQL service.
+  - MySQL schema files containing DDL sqlode does not (yet) model
+    fail with a new `UnsupportedMysqlDdl` parse error rather than
+    silently dropping the statement on the floor (Issue #419
+    fail-fast acceptance).
+  - `:execresult` rejection on `runtime: "native"` is now pinned by
+    a MySQL-specific test (positive: same query in `runtime: "raw"`
+    generates without complaint).
+
+### Added
+
 - **End-to-end MySQL support** (#417 epic; #418, #419, #420, #421,
   #422, #423). MySQL is now a first-class engine in both `raw` and
   `native` runtime modes. The native MySQL adapter targets the

--- a/README.md
+++ b/README.md
@@ -294,12 +294,10 @@ do not need to know the MySQL wire protocol.
 > **Out of scope (today):** MariaDB is not separately validated; the
 > `mysql` engine targets MySQL 8.0 specifically. `:execresult` is
 > rejected for every native target — use `:exec`, `:execrows`, or
-> `:execlastid` instead. `BLOB` / `BINARY` columns are encoded as
-> NULL by the generated MySQL adapter because shork's public `Value`
-> type does not yet expose a bytes constructor — schemas with bytes
-> columns parse and generate cleanly, but the native round-trip is
-> a documented gap until shork (or our adapter) gains a bytes
-> encoder.
+> `:execlastid` instead. `BLOB` / `BINARY` columns are encoded
+> byte-for-byte by routing through `shork_ffi.coerce` — the same
+> identity FFI shork's other value constructors use under the hood
+> — so the native round-trip works without a shork API extension.
 
 ```yaml
 gen:

--- a/integration_test/fixtures/mysql_real_test.gleam
+++ b/integration_test/fixtures/mysql_real_test.gleam
@@ -9,13 +9,6 @@
 //// tests stay independent of each other and the initial DB state.
 ////
 //// MYSQL_URL format: mysql://user:pass@host:port/database
-////
-//// Known limitation: shork's public Value type does not (yet) expose
-//// a bytes constructor, so BLOB columns are encoded as NULL by the
-//// generated `value_to_shork` helper. The round-trip-bytes scenario
-//// from Issue #418 is currently a documented gap rather than a
-//// passing test; rerun this lane with bytes support once shork (or
-//// our adapter) gains a bytes encoder.
 
 import db/models
 import db/mysql_adapter
@@ -44,7 +37,6 @@ pub fn main() {
 }
 
 fn parse_mysql_url(url: String) -> shork.Config {
-  // Minimal mysql:// URL parser: mysql://user:pass@host:port/database
   let stripped = case string.starts_with(url, "mysql://") {
     True -> string.drop_start(url, 8)
     False -> url
@@ -79,13 +71,21 @@ fn connect_or_fail() -> shork.Connection {
 }
 
 fn reset_authors(db: shork.Connection) -> Nil {
-  // Match shork's own test fixture pattern: no `returning` decoder
-  // for DDL — Query(Nil) plus a discarded result is enough.
-  let _ =
-    shork.query("DROP TABLE IF EXISTS authors") |> shork.execute(db)
+  let _ = shork.query("DROP TABLE IF EXISTS authors") |> shork.execute(db)
   let _ =
     shork.query(
-      "CREATE TABLE authors (id BIGINT AUTO_INCREMENT PRIMARY KEY, email VARCHAR(255) NOT NULL UNIQUE, display_name VARCHAR(255) NOT NULL, bio TEXT NULL, is_active BOOLEAN NOT NULL DEFAULT TRUE, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+      "CREATE TABLE authors (
+        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+        email VARCHAR(255) NOT NULL UNIQUE,
+        display_name VARCHAR(255) NOT NULL,
+        bio TEXT NULL,
+        is_active BOOLEAN NOT NULL DEFAULT TRUE,
+        avatar BLOB NULL,
+        balance DECIMAL(20,6) NOT NULL DEFAULT '0.000000',
+        status ENUM('draft','published','archived') NOT NULL DEFAULT 'draft',
+        tags SET('red','green','blue') NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )",
     )
     |> shork.execute(db)
   Nil
@@ -97,17 +97,28 @@ fn with_db(run: fn(shork.Connection) -> Nil) -> Nil {
   run(db)
 }
 
+fn default_create_params(
+  email: String,
+  display_name: String,
+) -> params.CreateAuthorParams {
+  params.CreateAuthorParams(
+    email:,
+    display_name:,
+    bio: option.None,
+    is_active: True,
+    avatar: option.None,
+    balance: "0.000000",
+    status: models.Draft,
+    tags: option.None,
+  )
+}
+
 pub fn create_returns_positive_last_insert_id_test() {
   use db <- with_db
   let assert Ok(id) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "alice@example.com",
-        display_name: "Alice",
-        bio: option.Some("a bio"),
-        is_active: True,
-      ),
+      default_create_params("alice@example.com", "Alice"),
     )
   { id > 0 } |> should.be_true()
 }
@@ -117,12 +128,7 @@ pub fn get_author_round_trips_inserted_row_test() {
   let assert Ok(id) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "bob@example.com",
-        display_name: "Bob",
-        bio: option.None,
-        is_active: True,
-      ),
+      default_create_params("bob@example.com", "Bob"),
     )
   let assert Ok(option.Some(author)) =
     mysql_adapter.get_author(db, params.GetAuthorParams(id:))
@@ -138,22 +144,12 @@ pub fn list_authors_returns_deterministic_order_test() {
   let assert Ok(_) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "first@example.com",
-        display_name: "First",
-        bio: option.None,
-        is_active: True,
-      ),
+      default_create_params("first@example.com", "First"),
     )
   let assert Ok(_) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "second@example.com",
-        display_name: "Second",
-        bio: option.None,
-        is_active: True,
-      ),
+      default_create_params("second@example.com", "Second"),
     )
   let assert Ok(authors) = mysql_adapter.list_authors(db)
   list.length(authors) |> should.equal(2)
@@ -166,12 +162,7 @@ pub fn update_bio_reports_one_changed_row_test() {
   let assert Ok(id) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "carol@example.com",
-        display_name: "Carol",
-        bio: option.None,
-        is_active: True,
-      ),
+      default_create_params("carol@example.com", "Carol"),
     )
   let assert Ok(rows) =
     mysql_adapter.update_author_bio(
@@ -190,12 +181,7 @@ pub fn delete_author_removes_row_test() {
   let assert Ok(id) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "dave@example.com",
-        display_name: "Dave",
-        bio: option.None,
-        is_active: True,
-      ),
+      default_create_params("dave@example.com", "Dave"),
     )
   let assert Ok(Nil) =
     mysql_adapter.delete_author(db, params.DeleteAuthorParams(id:))
@@ -209,27 +195,108 @@ pub fn upsert_author_updates_existing_row_test() {
   let assert Ok(_) =
     mysql_adapter.create_author(
       db,
-      params.CreateAuthorParams(
-        email: "eve@example.com",
-        display_name: "Eve",
-        bio: option.Some("old"),
-        is_active: True,
-      ),
+      default_create_params("eve@example.com", "Eve"),
     )
-  // Same email triggers ON DUPLICATE KEY UPDATE.
-  let assert Ok(_) =
-    mysql_adapter.upsert_author(
-      db,
-      params.UpsertAuthorParams(
-        email: "eve@example.com",
-        display_name: "Eve Updated",
-        bio: option.Some("new"),
-        is_active: True,
-      ),
-    )
+  let updated = params.UpsertAuthorParams(
+    email: "eve@example.com",
+    display_name: "Eve Updated",
+    bio: option.Some("new"),
+    is_active: True,
+    avatar: option.None,
+    balance: "0.000000",
+    status: models.Draft,
+    tags: option.None,
+  )
+  let assert Ok(_) = mysql_adapter.upsert_author(db, updated)
 
   let assert Ok(authors) = mysql_adapter.list_authors(db)
   list.length(authors) |> should.equal(1)
   let assert [author] = authors
   author.display_name |> should.equal("Eve Updated")
+}
+
+// Issue #418 / #422 round-trip coverage for the previously-documented
+// gaps: bytes (BLOB), decimal (DECIMAL(20,6) lossless contract),
+// ENUM, and MySQL SET.
+
+pub fn bytes_avatar_round_trips_byte_for_byte_test() {
+  use db <- with_db
+  let avatar = <<0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0xFF>>
+  let create =
+    params.CreateAuthorParams(
+      email: "frank@example.com",
+      display_name: "Frank",
+      bio: option.None,
+      is_active: True,
+      avatar: option.Some(avatar),
+      balance: "0.000000",
+      status: models.Draft,
+      tags: option.None,
+    )
+  let assert Ok(id) = mysql_adapter.create_author(db, create)
+  let assert Ok(option.Some(author)) =
+    mysql_adapter.get_author(db, params.GetAuthorParams(id:))
+  author.avatar |> should.equal(option.Some(avatar))
+}
+
+pub fn decimal_balance_round_trips_lossless_test() {
+  use db <- with_db
+  let balance = "12345678901234.567890"
+  let create =
+    params.CreateAuthorParams(
+      email: "grace@example.com",
+      display_name: "Grace",
+      bio: option.None,
+      is_active: True,
+      avatar: option.None,
+      balance: balance,
+      status: models.Draft,
+      tags: option.None,
+    )
+  let assert Ok(id) = mysql_adapter.create_author(db, create)
+  let assert Ok(option.Some(author)) =
+    mysql_adapter.get_author(db, params.GetAuthorParams(id:))
+  // MySQL stores DECIMAL exactly to the schema's precision/scale, so
+  // the value we wrote and the value we read should be identical
+  // strings — that is the whole point of `DecimalType` over Float.
+  author.balance |> should.equal(balance)
+}
+
+pub fn enum_status_round_trips_through_helpers_test() {
+  use db <- with_db
+  let create =
+    params.CreateAuthorParams(
+      email: "harry@example.com",
+      display_name: "Harry",
+      bio: option.None,
+      is_active: True,
+      avatar: option.None,
+      balance: "0.000000",
+      status: models.Published,
+      tags: option.None,
+    )
+  let assert Ok(id) = mysql_adapter.create_author(db, create)
+  let assert Ok(option.Some(author)) =
+    mysql_adapter.get_author(db, params.GetAuthorParams(id:))
+  author.status |> should.equal(models.Published)
+}
+
+pub fn set_tags_round_trips_through_helpers_test() {
+  use db <- with_db
+  let tags = [models.Red, models.Green]
+  let create =
+    params.CreateAuthorParams(
+      email: "ivy@example.com",
+      display_name: "Ivy",
+      bio: option.None,
+      is_active: True,
+      avatar: option.None,
+      balance: "0.000000",
+      status: models.Draft,
+      tags: option.Some(tags),
+    )
+  let assert Ok(id) = mysql_adapter.create_author(db, create)
+  let assert Ok(option.Some(author)) =
+    mysql_adapter.get_author(db, params.GetAuthorParams(id:))
+  author.tags |> should.equal(option.Some(tags))
 }

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -190,20 +190,26 @@ fn shork_adapter_config() -> AdapterConfig {
 }
 
 /// Encode a `runtime.Value` into a `shork.Value`. shork's public
-/// `Value` type does not (yet) expose a bytes/blob constructor, so
-/// `SqlBytes` falls back to `shork.null()` — bytes columns in native
-/// MySQL mode round-trip as NULL until the driver grows a bytes
-/// helper. SqlArray likewise resolves to NULL because MySQL has no
-/// first-class array type.
+/// `Value` type currently exposes constructors for bool / int / float
+/// / text / null / calendar but not for bytes — so we add a private
+/// `bit_array_to_shork` FFI binding that calls into `shork_ffi.coerce`
+/// (the same underlying identity FFI that `shork.text` and friends
+/// dispatch through) and pass `BitArray` parameters through unchanged.
+/// The Erlang `mysql` library underneath stores them as `BLOB` /
+/// `BINARY` byte-for-byte. `SqlArray` still resolves to NULL because
+/// MySQL has no first-class array type.
 ///
 /// `SqlBool` is encoded as `shork.int(1 | 0)` rather than
-/// `shork.bool(...)`. The Erlang `mysql` library underneath shork
-/// expects integers 1/0 on the wire for `TINYINT(1)` / `BOOLEAN`
-/// columns; passing the Gleam `True` / `False` atoms verbatim (which
-/// is what `shork.bool` does — it is a `coerce` identity FFI) trips
-/// `mysql:query/4` with `badarg` during parameter binding.
+/// `shork.bool(...)`. The Erlang `mysql` library expects integers 1/0
+/// on the wire for `TINYINT(1)` / `BOOLEAN` columns; passing the
+/// Gleam `True` / `False` atoms verbatim (which is what `shork.bool`
+/// does — it is a `coerce` identity FFI) trips `mysql:query/4` with
+/// `badarg` during parameter binding.
 fn shork_value_to_driver_helper() -> String {
-  "fn value_to_shork(value: runtime.Value) -> shork.Value {
+  "@external(erlang, \"shork_ffi\", \"coerce\")
+fn bit_array_to_shork(value: BitArray) -> shork.Value
+
+fn value_to_shork(value: runtime.Value) -> shork.Value {
   case value {
     runtime.SqlNull -> shork.null()
     runtime.SqlString(v) -> shork.text(v)
@@ -211,7 +217,7 @@ fn shork_value_to_driver_helper() -> String {
     runtime.SqlFloat(v) -> shork.float(v)
     runtime.SqlBool(True) -> shork.int(1)
     runtime.SqlBool(False) -> shork.int(0)
-    runtime.SqlBytes(_) -> shork.null()
+    runtime.SqlBytes(v) -> bit_array_to_shork(v)
     runtime.SqlArray(_) -> shork.null()
   }
 }"
@@ -461,6 +467,15 @@ fn render_base_decoder(
       <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(s, \"valid "
       <> enum_name
       <> " value\") } })"
+    // SetType: comma-joined wire string → `List(<Name>Value)` via the
+    // `<name>_set_from_string` helper. Empty string maps to `[]`,
+    // unknown member names fail the row decoder with a useful default.
+    model.SetType(set_name) ->
+      "decode.then(decode.string, fn(s) { case models."
+      <> type_mapping.set_from_string_fn(set_name)
+      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure([], \"valid "
+      <> set_name
+      <> " set\") } })"
     _ ->
       case
         type_mapping == model.StrongMapping

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -461,21 +461,8 @@ fn render_base_decoder(
   type_mapping: model.TypeMapping,
 ) -> String {
   case scalar_type {
-    model.EnumType(enum_name) ->
-      "decode.then(decode.string, fn(s) { case models."
-      <> type_mapping.enum_from_string_fn(enum_name)
-      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(s, \"valid "
-      <> enum_name
-      <> " value\") } })"
-    // SetType: comma-joined wire string → `List(<Name>Value)` via the
-    // `<name>_set_from_string` helper. Empty string maps to `[]`,
-    // unknown member names fail the row decoder with a useful default.
-    model.SetType(set_name) ->
-      "decode.then(decode.string, fn(s) { case models."
-      <> type_mapping.set_from_string_fn(set_name)
-      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure([], \"valid "
-      <> set_name
-      <> " set\") } })"
+    model.EnumType(_) | model.SetType(_) ->
+      common.render_enum_or_set_decoder(scalar_type, config.decoder_function)
     _ ->
       case
         type_mapping == model.StrongMapping

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -25,10 +25,17 @@ pub fn render_enum_or_set_decoder(
   fallback: fn(model.ScalarType) -> String,
 ) -> String {
   case scalar_type {
+    // `decode.failure` requires a zero value of the target decoder's
+    // output type, not `String`. For ENUMs we call the generated
+    // `<name>_default()` helper (the first declared variant); for SETs
+    // `[]` is a natural empty fallback and Gleam infers the element
+    // type from the Ok branch.
     model.EnumType(enum_name) ->
       "decode.then(decode.string, fn(s) { case models."
       <> type_mapping.enum_from_string_fn(enum_name)
-      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(s, \"valid "
+      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(models."
+      <> type_mapping.enum_default_fn(enum_name)
+      <> "(), \"valid "
       <> enum_name
       <> " value\") } })"
     model.SetType(set_name) ->

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -39,9 +39,9 @@ pub fn queries_have_enums(queries: List(model.AnalyzedQuery)) -> Bool {
           ..,
         ))
         | model.ScalarResult(model.ResultColumn(
-          scalar_type: model.SetType(_),
-          ..,
-        )) -> True
+            scalar_type: model.SetType(_),
+            ..,
+          )) -> True
         _ -> False
       }
     })

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -4,6 +4,7 @@ import gleam/result
 import gleam/string
 import sqlode/codegen/builder
 import sqlode/model
+import sqlode/type_mapping
 
 pub fn has_slices(params: List(model.QueryParam)) -> Bool {
   list.any(params, fn(p) { p.is_list })
@@ -11,6 +12,56 @@ pub fn has_slices(params: List(model.QueryParam)) -> Bool {
 
 pub fn queries_have_slices(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) { has_slices(query.params) })
+}
+
+/// Wrap the base decoder for `EnumType` and `SetType` columns so the
+/// decoded value reaches the consuming record as the generated sum
+/// type (or list of sum-type values for SET) rather than the raw
+/// wire string. `fallback` is the decoder to use for every other
+/// scalar type (adapter-specific in the caller — e.g. pog's
+/// `decode.bool` vs sqlight's int-to-bool adapter).
+pub fn render_enum_or_set_decoder(
+  scalar_type: model.ScalarType,
+  fallback: fn(model.ScalarType) -> String,
+) -> String {
+  case scalar_type {
+    model.EnumType(enum_name) ->
+      "decode.then(decode.string, fn(s) { case models."
+      <> type_mapping.enum_from_string_fn(enum_name)
+      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(s, \"valid "
+      <> enum_name
+      <> " value\") } })"
+    model.SetType(set_name) ->
+      "decode.then(decode.string, fn(s) { case models."
+      <> type_mapping.set_from_string_fn(set_name)
+      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure([], \"valid "
+      <> set_name
+      <> " set\") } })"
+    _ -> fallback(scalar_type)
+  }
+}
+
+/// Render a param / record field's Gleam type for generated modules
+/// that are NOT `models.gleam` itself (currently `params.gleam` and
+/// `queries.gleam`). They reach the generated `EnumType` / `SetType`
+/// definitions through a plain `import db/models`, so every external
+/// reference must be qualified with `models.` — the bare names only
+/// work inside `models.gleam` where the types are declared.
+/// `ArrayType` recurses so arrays of enum / set stay qualified.
+pub fn qualified_field_type(
+  scalar_type: model.ScalarType,
+  type_mapping_mode: model.TypeMapping,
+) -> String {
+  case scalar_type {
+    model.EnumType(_) ->
+      "models."
+      <> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
+    model.SetType(name) ->
+      "List(models." <> type_mapping.set_value_type_name(name) <> ")"
+    model.ArrayType(element) ->
+      "List(" <> qualified_field_type(element, type_mapping_mode) <> ")"
+    _ -> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
+  }
 }
 
 pub fn queries_have_enum_params(queries: List(model.AnalyzedQuery)) -> Bool {

--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -17,7 +17,7 @@ pub fn queries_have_enum_params(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
     list.any(query.params, fn(param) {
       case param.scalar_type {
-        model.EnumType(_) -> True
+        model.EnumType(_) | model.SetType(_) -> True
         _ -> False
       }
     })
@@ -28,7 +28,7 @@ pub fn queries_have_enums(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
     list.any(query.params, fn(param) {
       case param.scalar_type {
-        model.EnumType(_) -> True
+        model.EnumType(_) | model.SetType(_) -> True
         _ -> False
       }
     })
@@ -36,6 +36,10 @@ pub fn queries_have_enums(queries: List(model.AnalyzedQuery)) -> Bool {
       case col {
         model.ScalarResult(model.ResultColumn(
           scalar_type: model.EnumType(_),
+          ..,
+        ))
+        | model.ScalarResult(model.ResultColumn(
+          scalar_type: model.SetType(_),
           ..,
         )) -> True
         _ -> False

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -126,6 +126,12 @@ fn render_enum_type(enum_def: model.EnumDef) -> String {
   let type_name = type_mapping.enum_type_name(enum_def.name)
   let to_string_fn = type_mapping.enum_to_string_fn(enum_def.name)
   let from_string_fn = type_mapping.enum_from_string_fn(enum_def.name)
+  let default_fn = type_mapping.enum_default_fn(enum_def.name)
+
+  let first_variant = case enum_def.values {
+    [first, ..] -> type_mapping.enum_value_name(first)
+    [] -> type_name
+  }
 
   let constructors =
     builder.lines(list.map(enum_def.values, type_mapping.enum_value_name))
@@ -173,6 +179,15 @@ fn render_enum_type(enum_def: model.EnumDef) -> String {
       "    _ -> Error(\"Unknown " <> enum_def.name <> " value: \" <> value)",
     ),
     builder.line("  }"),
+    builder.line("}"),
+    builder.blank(),
+    // `<name>_default()` is the first variant in declaration order.
+    // Used as the `decode.failure` fallback for generated decoders —
+    // `decode.failure` requires a zero of the target type, and hard-
+    // coding the first variant keeps the generated code
+    // type-checked without the caller needing to pick one at runtime.
+    builder.line("pub fn " <> default_fn <> "() -> " <> type_name <> " {"),
+    builder.line("  " <> first_variant),
     builder.line("}"),
   ])
   |> builder.render

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -155,8 +155,7 @@ fn param_fields(
 ) -> List(String) {
   params
   |> list.map(fn(param) {
-    let base_type =
-      type_mapping.scalar_type_to_gleam_type(param.scalar_type, type_mapping)
+    let base_type = qualified_param_type(param.scalar_type, type_mapping)
     let typed = case param.is_list {
       True -> "List(" <> base_type <> ")"
       False ->
@@ -167,6 +166,30 @@ fn param_fields(
     }
     param.field_name <> ": " <> typed
   })
+}
+
+/// Render a param field's Gleam type, prefixing generated enum / set
+/// types with `models.` so params.gleam — which lives in a different
+/// module from the generated `models.gleam` — reaches them through the
+/// plain `import db/models` header. `models.gleam` itself uses
+/// unqualified names because the types are defined in that same
+/// module, so only callers in other generated modules need the
+/// qualifier. `ArrayType` recurses so nested enum/set references
+/// inside an array are also qualified.
+fn qualified_param_type(
+  scalar_type: model.ScalarType,
+  type_mapping_mode: model.TypeMapping,
+) -> String {
+  case scalar_type {
+    model.EnumType(_) ->
+      "models."
+      <> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
+    model.SetType(name) ->
+      "List(models." <> type_mapping.set_value_type_name(name) <> ")"
+    model.ArrayType(element) ->
+      "List(" <> qualified_param_type(element, type_mapping_mode) <> ")"
+    _ -> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
+  }
 }
 
 fn param_accessors(

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -155,7 +155,7 @@ fn param_fields(
 ) -> List(String) {
   params
   |> list.map(fn(param) {
-    let base_type = qualified_param_type(param.scalar_type, type_mapping)
+    let base_type = common.qualified_field_type(param.scalar_type, type_mapping)
     let typed = case param.is_list {
       True -> "List(" <> base_type <> ")"
       False ->
@@ -166,30 +166,6 @@ fn param_fields(
     }
     param.field_name <> ": " <> typed
   })
-}
-
-/// Render a param field's Gleam type, prefixing generated enum / set
-/// types with `models.` so params.gleam — which lives in a different
-/// module from the generated `models.gleam` — reaches them through the
-/// plain `import db/models` header. `models.gleam` itself uses
-/// unqualified names because the types are defined in that same
-/// module, so only callers in other generated modules need the
-/// qualifier. `ArrayType` recurses so nested enum/set references
-/// inside an array are also qualified.
-fn qualified_param_type(
-  scalar_type: model.ScalarType,
-  type_mapping_mode: model.TypeMapping,
-) -> String {
-  case scalar_type {
-    model.EnumType(_) ->
-      "models."
-      <> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
-    model.SetType(name) ->
-      "List(models." <> type_mapping.set_value_type_name(name) <> ")"
-    model.ArrayType(element) ->
-      "List(" <> qualified_param_type(element, type_mapping_mode) <> ")"
-    _ -> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
-  }
 }
 
 fn param_accessors(

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -205,6 +205,15 @@ fn plan_encoding(
       let to_str = "models." <> type_mapping.enum_to_string_fn(name)
       EnumEncode(runtime_fn:, to_string_fn: to_str)
     }
+    // SetType reuses the EnumEncode shape: project the
+    // `List(<Name>Value)` field through `<name>_set_to_string` (the
+    // helper emitted by `codegen/models.gleam`) before handing the
+    // resulting comma-joined `String` to `runtime.string`.
+    model.SetType(name) -> {
+      let runtime_fn = type_mapping.scalar_type_to_runtime_function(scalar_type)
+      let to_str = "models." <> type_mapping.set_to_string_fn(name)
+      EnumEncode(runtime_fn:, to_string_fn: to_str)
+    }
     model.ArrayType(element) -> {
       let inner = plan_encoding(element, type_mapping_mode)
       ArrayEncode(element_encoder: inner)

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -288,8 +288,7 @@ fn param_arg_type(
   param: model.QueryParam,
   type_mapping: model.TypeMapping,
 ) -> String {
-  let base =
-    type_mapping.scalar_type_to_gleam_type(param.scalar_type, type_mapping)
+  let base = common.qualified_field_type(param.scalar_type, type_mapping)
   case param.is_list {
     True -> "List(" <> base <> ")"
     False ->
@@ -334,7 +333,11 @@ fn render_decoder_function(
           ..,
         )) -> {
           let field_name = naming.to_snake_case(naming_ctx, name)
-          let base = type_mapping.scalar_type_to_decoder(engine, scalar_type)
+          let base =
+            common.render_enum_or_set_decoder(
+              scalar_type,
+              type_mapping.scalar_type_to_decoder(engine, _),
+            )
           let decoder = case nullable {
             True -> "decode.optional(" <> base <> ")"
             False -> base
@@ -366,7 +369,10 @@ fn render_decoder_function(
               let #(i, ls) = inner_acc
               let field_name = naming.to_snake_case(naming_ctx, c.name)
               let base =
-                type_mapping.scalar_type_to_decoder(engine, c.scalar_type)
+                common.render_enum_or_set_decoder(
+                  c.scalar_type,
+                  type_mapping.scalar_type_to_decoder(engine, _),
+                )
               let decoder = case c.nullable {
                 True -> "decode.optional(" <> base <> ")"
                 False -> base

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -10,6 +10,12 @@ import sqlode/query_analyzer/token_utils
 pub type ParseError {
   InvalidCreateTable(path: String, detail: String)
   InvalidColumn(path: String, table: String, detail: String)
+  /// Issue #419: emitted when a MySQL schema file contains a DDL
+  /// statement sqlode does not yet understand, instead of silently
+  /// dropping it on the floor. The detail names the leading
+  /// keywords of the offending statement so the user can tell at a
+  /// glance which line triggered the failure.
+  UnsupportedMysqlDdl(path: String, detail: String)
 }
 
 pub type SchemaWarning {
@@ -673,9 +679,10 @@ fn parse_statement_tokens(
       }
     }
     False ->
-      case classify_unknown_statement(tokens) {
+      case classify_unknown_statement(tokens, engine) {
         DestructiveDDL(action) -> Ok(DDLApplied(action:))
         SilentlyIgnored -> Ok(Ignored)
+        UnsupportedMysql(detail:) -> Error(UnsupportedMysqlDdl(path:, detail:))
       }
   }
 }
@@ -683,6 +690,10 @@ fn parse_statement_tokens(
 type UnknownStatementKind {
   DestructiveDDL(DDLAction)
   SilentlyIgnored
+  /// Issue #419: surfaced when a MySQL schema file contains a DDL
+  /// shape sqlode does not yet model. The detail is a short summary
+  /// (the leading keywords) used directly in the user-facing error.
+  UnsupportedMysql(detail: String)
 }
 
 type DDLAction {
@@ -730,7 +741,10 @@ type DDLAction {
 /// like `rename`, `savepoint`, and `comment` arrive as `Ident` tokens, so
 /// we normalise the first few tokens of the statement to lowercase strings
 /// before matching, treating Keyword and Ident uniformly.
-fn classify_unknown_statement(tokens: List(lexer.Token)) -> UnknownStatementKind {
+fn classify_unknown_statement(
+  tokens: List(lexer.Token),
+  engine: model.Engine,
+) -> UnknownStatementKind {
   let words = tokens |> list.take(8) |> list.map(token_keyword_text)
   case words {
     ["create", "index", ..] -> SilentlyIgnored
@@ -750,7 +764,18 @@ fn classify_unknown_statement(tokens: List(lexer.Token)) -> UnknownStatementKind
 
     ["alter", "table", ..] -> classify_alter_table_from_tokens(tokens)
 
-    _ -> SilentlyIgnored
+    _ ->
+      case engine {
+        // Issue #419: MySQL schema files that contain DDL we do not
+        // (yet) understand now surface an actionable error instead
+        // of being silently dropped on the floor. PostgreSQL /
+        // SQLite keep the legacy permissive behaviour — extending
+        // the fail-fast policy to every engine is out of scope for
+        // the MySQL completeness work.
+        model.MySQL ->
+          UnsupportedMysql(detail: summarise_unknown_mysql_statement(words))
+        model.PostgreSQL | model.SQLite -> SilentlyIgnored
+      }
   }
 }
 
@@ -1108,6 +1133,26 @@ fn apply_ddl_action(
       }),
       enums,
     )
+  }
+}
+
+/// Render the leading words of a statement back into a short summary
+/// suitable for the user-facing `UnsupportedMysqlDdl` detail. We only
+/// take the first three non-empty words so a `RENAME TABLE a TO b ...`
+/// reads as `RENAME TABLE a` rather than the entire token stream.
+fn summarise_unknown_mysql_statement(words: List(String)) -> String {
+  let summary =
+    words
+    |> list.filter(fn(word) { word != "" })
+    |> list.take(3)
+    |> list.map(string.uppercase)
+    |> string.join(" ")
+  case summary {
+    "" -> "(empty statement)"
+    _ ->
+      summary
+      <> " ... — sqlode does not (yet) understand this statement; file"
+      <> " an issue or pre-process the schema to remove it."
   }
 }
 
@@ -1687,6 +1732,8 @@ pub fn error_to_string(error: ParseError) -> String {
       <> table
       <> ": "
       <> detail
+    UnsupportedMysqlDdl(path:, detail:) ->
+      path_prefix(path) <> "Unsupported MySQL DDL statement: " <> detail
   }
 }
 

--- a/src/sqlode/type_mapping.gleam
+++ b/src/sqlode/type_mapping.gleam
@@ -283,6 +283,14 @@ pub fn enum_from_string_fn(name: String) -> String {
   string.lowercase(name) <> "_from_string"
 }
 
+/// Name of the helper that returns the enum's first variant as a
+/// `zero`-style fallback. Used by generated adapter / queries
+/// decoders where `decode.failure(zero, msg)` needs a concrete value
+/// of the target type.
+pub fn enum_default_fn(name: String) -> String {
+  string.lowercase(name) <> "_default"
+}
+
 // --- Set naming utilities ---
 
 /// Gleam type name for a single value of a MySQL `SET` column. The

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -666,7 +666,11 @@ pub fn render_enum_decoder_uses_decode_then_test() {
   |> should.be_true()
   string.contains(rendered, "decode.success(v)")
   |> should.be_true()
-  string.contains(rendered, "decode.failure(s")
+  // Error branch must pass a typed zero (the generated
+  // `<name>_default()` helper), not the raw decoded string, so the
+  // case expression type-checks as `Decoder(<EnumType>)` rather than
+  // `Decoder(String)`.
+  string.contains(rendered, "decode.failure(models.status_default()")
   |> should.be_true()
 
   // Should NOT use decode.map for enum decoding

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -1320,6 +1320,101 @@ pub fn render_mysql_native_adapter_decodes_affected_rows_for_execrows_test() {
   string.contains(rendered, "decode.field(1, decode.int)") |> should.be_true()
 }
 
+pub fn render_mysql_native_adapter_passes_bytes_through_shork_ffi_test() {
+  // SqlBytes encoding goes through `shork_ffi.coerce` directly so
+  // BLOB / BINARY parameters reach mysql:query/4 byte-for-byte —
+  // closes the previously-documented bytes round-trip gap from #418.
+  let naming_ctx = naming.new()
+  let catalog = mysql_native_catalog()
+  let queries = mysql_native_queries(naming_ctx, catalog)
+  let block = mysql_native_block()
+  let rendered = adapter.render(naming_ctx, block, queries, dict.new())
+
+  string.contains(rendered, "@external(erlang, \"shork_ffi\", \"coerce\")")
+  |> should.be_true()
+  string.contains(
+    rendered,
+    "fn bit_array_to_shork(value: BitArray) -> shork.Value",
+  )
+  |> should.be_true()
+  string.contains(rendered, "runtime.SqlBytes(v) -> bit_array_to_shork(v)")
+  |> should.be_true()
+}
+
+pub fn render_mysql_set_param_uses_set_to_string_helper_test() {
+  // SET params are encoded via the generated `<name>_set_to_string`
+  // helper before being handed to `runtime.string`; the column type
+  // in the params record stays `List(<Name>Value)`.
+  let naming_ctx = naming.new()
+  let assert Ok(schema_content) =
+    simplifile.read("test/fixtures/mysql_real_schema.sql")
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files_with_engine(
+      [#("test/fixtures/mysql_real_schema.sql", schema_content)],
+      model.MySQL,
+    )
+  let assert Ok(query_content) =
+    simplifile.read("test/fixtures/mysql_real_query.sql")
+  let assert Ok(parsed) =
+    query_parser.parse_file(
+      "test/fixtures/mysql_real_query.sql",
+      model.MySQL,
+      naming_ctx,
+      query_content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, parsed)
+
+  let params_rendered =
+    params.render(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+      "sqlode/runtime",
+    )
+  // The params record exposes the SET column as `List(<Name>Value)`
+  // and the encoder routes it through `<name>_set_to_string` before
+  // calling `runtime.string`.
+  string.contains(params_rendered, "tags: Option(List(AuthorsTagsValue))")
+  |> should.be_true()
+  string.contains(params_rendered, "models.authors_tags_set_to_string")
+  |> should.be_true()
+}
+
+pub fn render_mysql_set_decoder_uses_set_from_string_helper_test() {
+  let naming_ctx = naming.new()
+  let assert Ok(schema_content) =
+    simplifile.read("test/fixtures/mysql_real_schema.sql")
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files_with_engine(
+      [#("test/fixtures/mysql_real_schema.sql", schema_content)],
+      model.MySQL,
+    )
+  let assert Ok(query_content) =
+    simplifile.read("test/fixtures/mysql_real_query.sql")
+  let assert Ok(parsed) =
+    query_parser.parse_file(
+      "test/fixtures/mysql_real_query.sql",
+      model.MySQL,
+      naming_ctx,
+      query_content,
+    )
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.MySQL, catalog, naming_ctx, parsed)
+
+  let block = mysql_native_block()
+  let block =
+    model.SqlBlock(
+      ..block,
+      schema: ["test/fixtures/mysql_real_schema.sql"],
+      queries: ["test/fixtures/mysql_real_query.sql"],
+    )
+  let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
+  string.contains(rendered, "models.authors_tags_set_from_string")
+  |> should.be_true()
+}
+
 fn mysql_native_catalog() -> model.Catalog {
   let assert Ok(content) = simplifile.read("test/fixtures/mysql_schema.sql")
   let assert Ok(#(catalog, _)) =

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -1376,7 +1376,10 @@ pub fn render_mysql_set_param_uses_set_to_string_helper_test() {
   // The params record exposes the SET column as `List(<Name>Value)`
   // and the encoder routes it through `<name>_set_to_string` before
   // calling `runtime.string`.
-  string.contains(params_rendered, "tags: Option(List(AuthorsTagsValue))")
+  string.contains(
+    params_rendered,
+    "tags: Option(List(models.AuthorsTagsValue))",
+  )
   |> should.be_true()
   string.contains(params_rendered, "models.authors_tags_set_to_string")
   |> should.be_true()

--- a/test/fixtures/mysql_execresult_query.sql
+++ b/test/fixtures/mysql_execresult_query.sql
@@ -1,0 +1,2 @@
+-- name: UpdateAuthorName :execresult
+UPDATE authors SET name = ? WHERE id = ?;

--- a/test/fixtures/mysql_real_query.sql
+++ b/test/fixtures/mysql_real_query.sql
@@ -1,9 +1,9 @@
 -- name: CreateAuthor :execlastid
-INSERT INTO authors (email, display_name, bio, is_active)
-VALUES (?, ?, ?, ?);
+INSERT INTO authors (email, display_name, bio, is_active, avatar, balance, status, tags)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetAuthor :one
-SELECT id, email, display_name, bio, is_active
+SELECT id, email, display_name, bio, is_active, avatar, balance, status, tags
 FROM authors
 WHERE id = ?;
 
@@ -22,8 +22,8 @@ DELETE FROM authors
 WHERE id = ?;
 
 -- name: UpsertAuthor :execrows
-INSERT INTO authors (email, display_name, bio, is_active)
-VALUES (?, ?, ?, ?)
+INSERT INTO authors (email, display_name, bio, is_active, avatar, balance, status, tags)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
   display_name = VALUES(display_name),
   bio = VALUES(bio);

--- a/test/fixtures/mysql_real_schema.sql
+++ b/test/fixtures/mysql_real_schema.sql
@@ -4,5 +4,9 @@ CREATE TABLE authors (
   display_name VARCHAR(255) NOT NULL,
   bio TEXT NULL,
   is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  avatar BLOB NULL,
+  balance DECIMAL(20,6) NOT NULL DEFAULT '0.000000',
+  status ENUM('draft','published','archived') NOT NULL DEFAULT 'draft',
+  tags SET('red','green','blue') NULL,
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1146,6 +1146,64 @@ pub fn execresult_rejected_on_native_runtime_test() {
   }
 }
 
+pub fn execresult_rejected_on_mysql_native_runtime_test() {
+  // Issue #418: `:execresult` is rejected for every native target,
+  // and MySQL is no exception. The shared `validate_native_annotations`
+  // pass refuses generation before any MySQL-specific code runs.
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.MySQL,
+      schema: ["test/fixtures/mysql_schema.sql"],
+      queries: ["test/fixtures/mysql_execresult_query.sql"],
+      gleam: model.GleamOutput(
+        out: "test_output/mysql_execresult_reject",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let cfg = model.Config(version: 2, sql: [block])
+  case generate.generate_config(cfg) {
+    Error(generate.UnsupportedAnnotation(command: ":execresult", ..)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn execresult_allowed_on_mysql_raw_runtime_test() {
+  // The corresponding positive case: in raw mode the same query
+  // generates without complaint, mirroring the SQLite + PostgreSQL
+  // raw-mode contract.
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.MySQL,
+      schema: ["test/fixtures/mysql_schema.sql"],
+      queries: ["test/fixtures/mysql_execresult_query.sql"],
+      gleam: model.GleamOutput(
+        out: "test_output/mysql_execresult_raw",
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let _delete_result = simplifile.delete("test_output/mysql_execresult_raw")
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Ok(_) = generate.generate_config(cfg)
+}
+
 pub fn execresult_allowed_on_raw_runtime_test() {
   let block =
     model.SqlBlock(

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -949,6 +949,38 @@ CREATE VIEW `post_titles` AS SELECT `id`, `title` FROM `posts`;"
   column_names |> should.equal(["id", "title"])
 }
 
+pub fn mysql_unsupported_ddl_fails_fast_test() {
+  // Issue #419: MySQL schema files containing DDL sqlode does not
+  // model must surface an actionable error rather than silently
+  // dropping the statement on the floor.
+  let sql =
+    "CREATE TABLE `events` (`id` BIGINT NOT NULL, PRIMARY KEY (`id`));
+RENAME TABLE `events` TO `events_archive`;"
+
+  let assert Error(error) =
+    schema_parser.parse_files_with_engine([#("events.sql", sql)], model.MySQL)
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "events.sql") |> should.be_true()
+  string.contains(msg, "Unsupported MySQL DDL") |> should.be_true()
+  string.contains(msg, "RENAME TABLE") |> should.be_true()
+}
+
+pub fn mysql_unknown_statement_for_postgresql_stays_silent_test() {
+  // The fail-fast policy is scoped to MySQL — PostgreSQL keeps the
+  // legacy permissive behaviour so existing schemas with adjacent
+  // unrecognised DDL (e.g. plpgsql function bodies) do not break.
+  let sql =
+    "CREATE TABLE events (id BIGINT NOT NULL, PRIMARY KEY (id));
+GRANT SELECT ON events TO some_role;"
+
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files_with_engine(
+      [#("events.sql", sql)],
+      model.PostgreSQL,
+    )
+  list.length(catalog.tables) |> should.equal(1)
+}
+
 pub fn mysql_create_table_strips_auto_increment_and_charset_noise_test() {
   // AUTO_INCREMENT, CHARACTER SET, COLLATE, and COMMENT all appear
   // after the column type in real MySQL DDL. They must not bleed


### PR DESCRIPTION
## Summary

Closes the five MySQL-completeness gaps the #417 epic explicitly left as future work.

| Gap | Issue | Where |
| --- | --- | --- |
| Bytes round-trip in native mode | #418 | private \`bit_array_to_shork\` FFI in \`codegen/adapter.gleam\` + integration test |
| Decimal lossless round-trip in live DB | #422 | integration fixture + new \`decimal_balance_round_trips_lossless_test\` |
| Enum + SET round-trip in live DB | #420 / #422 | params + adapter codegen for \`SetType\`, plus two new live-DB tests |
| Unsupported MySQL DDL fail-fast | #419 | new \`UnsupportedMysqlDdl\` \`ParseError\` variant + 2 unit tests |
| Native \`:execresult\` MySQL-specific test | #418 | new positive (raw) + negative (native) MySQL tests in \`generate_test\` |

The README's \"BLOB columns are encoded as NULL\" caveat is removed and the CHANGELOG \`Unreleased\` section gets a summary.

## Implementation notes

* shork's value constructors are all \`@external(erlang, \"shork_ffi\", \"coerce\")\` identity FFIs. Adding our own \`@external\` binding for \`bit_array_to_shork(BitArray) -> shork.Value\` is enough to make BLOB columns reach mysql:query/4 byte-for-byte without touching the upstream library.
* Params codegen grows a \`SetType\` arm that reuses the existing \`EnumEncode\` shape but routes through \`<name>_set_to_string\` so \`List(<Name>Value)\` fields encode as the comma-joined wire string MySQL expects. Adapter decoder mirrors it via \`<name>_set_from_string\`.
* DDL fail-fast is scoped to MySQL on purpose; PostgreSQL / SQLite schemas often have adjacent unrecognised DDL (GRANT, plpgsql bodies) we'd rather pass through.

## Test plan

- [x] \`gleam check\` / \`gleam build --warnings-as-errors\` — clean
- [x] \`gleam run -m glinter\` — \"No issues found.\" (config from #429)
- [x] \`gleam test\` — 918 passed, no failures (was 911 before)
- [x] \`gleam format --check src/ test/\` — clean
- [ ] CI: \`case_mysql_real\` exercises bytes / decimal / enum / SET against the live MySQL service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MySQL docs and README to reflect improved BLOB/BINARY handling and native-mode behavior.

* **New Features**
  * BLOB/BINARY columns now round-trip byte-for-byte in MySQL native mode.
  * SET columns supported end-to-end; ENUM and DECIMAL preserve values losslessly.
  * Schema parsing for MySQL now fails fast with a clear error for unsupported DDL.

* **Tests**
  * Added integration and generation tests covering bytes, DECIMAL, ENUM, SET, and MySQL DDL/runtime behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->