### PR TITLE
fix(cli): allow mysql native runtime in sqlode init

### DIFF
--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -28,6 +28,16 @@ Describe 'sqlode CLI'
       The status should be failure
       The output should include 'already exists'
     End
+
+    It 'scaffolds mysql + native runtime'
+      When run init_cmd --output="$TEST_OUTPUT_DIR/sqlode.yaml" --engine=mysql --runtime=native
+      The status should be success
+      The output should include 'Created'
+      The path "$TEST_OUTPUT_DIR/sqlode.yaml" should be file
+      The contents of file "$TEST_OUTPUT_DIR/sqlode.yaml" should include 'engine: "mysql"'
+      The contents of file "$TEST_OUTPUT_DIR/sqlode.yaml" should include 'runtime: "native"'
+      The contents of file "$TEST_OUTPUT_DIR/db/schema.sql" should include 'BIGINT AUTO_INCREMENT PRIMARY KEY'
+    End
   End
 
   Describe 'generate command'

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -323,15 +323,6 @@ fn validate_init_flags(engine: String, runtime: String) -> Result(Nil, String) {
         )
     }
   })
-  |> result.try(fn(_) {
-    case engine, runtime {
-      "mysql", "native" ->
-        Error(
-          "MySQL does not support runtime: \"native\" because no Gleam MySQL driver is available; use runtime: \"raw\"",
-        )
-      _, _ -> Ok(Nil)
-    }
-  })
 }
 
 fn config_template(engine: String, runtime: String) -> String {

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -201,3 +201,30 @@ pub fn init_mysql_engine_generates_mysql_schema_test() {
 
   cleanup("mysql_engine")
 }
+
+pub fn init_mysql_native_runtime_test() {
+  setup("mysql_native")
+  let dir = base_dir <> "/mysql_native"
+  let config_path = dir <> "/sqlode.yaml"
+
+  cli.app()
+  |> glint.execute([
+    "init",
+    "--output=" <> config_path,
+    "--engine=mysql",
+    "--runtime=native",
+  ])
+  |> result.is_ok
+  |> should.be_true
+
+  let assert Ok(config) = simplifile.read(config_path)
+  config |> string.contains("engine: \"mysql\"") |> should.be_true
+  config |> string.contains("runtime: \"native\"") |> should.be_true
+
+  let assert Ok(schema) = simplifile.read(dir <> "/db/schema.sql")
+  schema
+  |> string.contains("BIGINT AUTO_INCREMENT PRIMARY KEY")
+  |> should.be_true
+
+  cleanup("mysql_native")
+}


### PR DESCRIPTION
## Summary

`sqlode init --engine=mysql --runtime=native` is rejected even though MySQL native support shipped in v0.5.0. This removes the stale validation guard so the documented first-run path works.

## Changes

- `src/sqlode/cli.gleam`: drop the `("mysql", "native")` guard inside `validate_init_flags`. The `config_template`, `starter_schema`, and `starter_query` helpers are already runtime-agnostic for MySQL, so no further adjustments are needed.
- `test/cli_test.gleam`: add `init_mysql_native_runtime_test`, asserting the generated `sqlode.yaml` records `engine: "mysql"` / `runtime: "native"` and that the starter schema emits MySQL DDL.
- `spec/cli_spec.sh`: add a shellspec case that runs `sqlode init --engine=mysql --runtime=native` and inspects the generated config plus schema.

## Design Decisions

- The fix is limited to removing the guard — all existing MySQL scaffolding already matched the supported MySQL native path (shork-based codegen in `sqlode/codegen/adapter.gleam`).
- Gleam test + shellspec coverage mirror the existing mysql / sqlite-native pair to keep the matrix consistent.

## Verification

- `gleam format --check src/ test/`
- `gleam check`
- `gleam build --warnings-as-errors`
- `gleam run -m glinter`
- `gleam test` (919 passed)
- `shellspec` (23 examples, 0 failures)

Closes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MySQL engine now supports the native runtime option in the init command.

* **Tests**
  * Added test coverage validating MySQL initialization with native runtime.
  * Verifies sqlode.yaml configuration includes correct engine and runtime settings.
  * Confirms generated MySQL schema SQL contains expected BIGINT AUTO_INCREMENT PRIMARY KEY.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->