### PR TITLE
docs: add tutorial-first quickstart and runnable sqlite-basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Supported engines (raw + native): PostgreSQL (`pog`), MySQL 8.0
 engine/runtime support matrix and per-engine query-annotation
 details.
 
+**New to sqlode?** Work through the
+[SQLite quickstart tutorial](doc/tutorials/getting-started-sqlite.md)
+for a five-minute, end-to-end walkthrough, or copy the runnable
+[`examples/sqlite-basic/`](examples/sqlite-basic/) project. The rest
+of this README stays reference-oriented.
+
 ## Getting started
 
 ### Install

--- a/doc/tutorials/getting-started-sqlite.md
+++ b/doc/tutorials/getting-started-sqlite.md
@@ -1,0 +1,146 @@
+# Getting started with sqlode and SQLite
+
+This tutorial walks you from an empty directory to a typed,
+compile-checked SQLite data layer in about five minutes. It targets
+the `sqlight` native runtime so the generated adapter opens a real
+SQLite connection; no schema changes in a separate migration tool are
+required.
+
+A ready-made version of every file in this tutorial lives under
+[`examples/sqlite-basic/`](../../examples/sqlite-basic/). You can copy
+that directory and skip ahead to [Run the generator](#3-run-the-generator)
+if you prefer.
+
+## Prerequisites
+
+- Erlang/OTP 27 or later with `escript` on `PATH`
+- Gleam 1.10 or later
+- A POSIX shell (Linux, macOS, or WSL)
+
+## 1. Install sqlode
+
+The fastest path is the published release escript:
+
+```console
+curl -fsSL https://raw.githubusercontent.com/nao1215/sqlode/main/scripts/install.sh | sh
+```
+
+The installer writes `sqlode` to `$HOME/.local/bin/sqlode`. Make sure
+that directory is on your `PATH`.
+
+If you prefer to invoke sqlode through your project's deps instead,
+you can replace every `sqlode` command below with
+`gleam run -m sqlode --`.
+
+## 2. Scaffold a project
+
+```console
+gleam new hello_sqlode
+cd hello_sqlode
+gleam add sqlight
+gleam add sqlode
+sqlode init --engine=sqlite --runtime=native
+```
+
+`sqlode init` creates:
+
+- `sqlode.yaml` — generator config pointed at `db/schema.sql` and
+  `db/query.sql`
+- `db/schema.sql` — a starter `authors` table
+- `db/query.sql` — `GetAuthor`, `ListAuthors`, and `CreateAuthor`
+  queries
+
+Open `db/schema.sql` and `db/query.sql` to see what a minimal sqlode
+project looks like. You can edit these freely — the next step
+regenerates the Gleam code.
+
+## 3. Run the generator
+
+```console
+sqlode generate
+```
+
+This writes four modules under `src/db/`:
+
+| File                    | What it holds                                    |
+| ----------------------- | ------------------------------------------------ |
+| `params.gleam`          | Typed parameter records (one per query)          |
+| `models.gleam`          | Row structs for `:one` / `:many` results         |
+| `queries.gleam`         | Query descriptors and `prepare_*` helpers        |
+| `sqlight_adapter.gleam` | High-level functions that run the queries on a `sqlight.Connection` |
+
+Every regeneration is idempotent — rerun it whenever you touch
+`db/schema.sql` or `db/query.sql`.
+
+## 4. Use the adapter
+
+Replace `src/hello_sqlode.gleam` with:
+
+```gleam
+import db/params
+import db/sqlight_adapter
+import gleam/io
+import gleam/option
+import sqlight
+
+pub fn main() {
+  let assert Ok(db) = sqlight.open(":memory:")
+
+  let assert Ok(_) =
+    sqlight.exec(
+      "CREATE TABLE authors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        bio TEXT
+      );",
+      db,
+    )
+
+  let assert Ok(_) =
+    sqlight_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Alice", bio: option.Some("A bio")),
+    )
+
+  let assert Ok(option.Some(author)) =
+    sqlight_adapter.get_author(db, params.GetAuthorParams(id: 1))
+  io.println("Loaded author: " <> author.name)
+}
+```
+
+Then run:
+
+```console
+gleam run
+```
+
+Expected output:
+
+```
+Loaded author: Alice
+```
+
+## 5. Iterate
+
+Any time you edit SQL:
+
+1. Update `db/schema.sql` or `db/query.sql`.
+2. Run `sqlode generate`.
+3. The Gleam compiler tells you about every call site that now has
+   the wrong parameter or return shape — that is the whole point.
+
+To keep your CI in sync, run `sqlode verify` as a fast preflight:
+
+```console
+sqlode verify
+```
+
+## Where to look next
+
+- [`examples/sqlite-basic/`](../../examples/sqlite-basic/) — the
+  finished version of this tutorial, used by the repository's smoke
+  test so this walkthrough stays current.
+- [`doc/capabilities.md`](../capabilities.md) — full engine/runtime
+  support matrix.
+- [`README.md`](../../README.md) — the reference-oriented entry
+  point once you have finished the tutorial.

--- a/examples/sqlite-basic/.gitignore
+++ b/examples/sqlite-basic/.gitignore
@@ -1,0 +1,6 @@
+build/
+src/db/
+manifest.toml
+*.beam
+*.ez
+erl_crash.dump

--- a/examples/sqlite-basic/README.md
+++ b/examples/sqlite-basic/README.md
@@ -1,0 +1,35 @@
+# sqlite-basic
+
+A minimal runnable sqlode example that targets SQLite with the
+native `sqlight` adapter.
+
+The full walkthrough lives in
+[`doc/tutorials/getting-started-sqlite.md`](../../doc/tutorials/getting-started-sqlite.md).
+
+## Layout
+
+```
+examples/sqlite-basic/
+├── sqlode.yaml          # engine=sqlite, runtime=native, out=src/db
+├── db/
+│   ├── schema.sql       # authors table
+│   └── query.sql        # GetAuthor / ListAuthors / CreateAuthor / DeleteAuthor
+├── src/
+│   └── sqlite_basic.gleam
+└── test/
+    └── sqlite_basic_test.gleam
+```
+
+`src/db/` is intentionally absent from the repository. Running
+`sqlode generate` in this directory writes
+`params.gleam`, `models.gleam`, `queries.gleam`, and
+`sqlight_adapter.gleam` under `src/db/`, which the test module imports.
+
+## Run
+
+```console
+cd examples/sqlite-basic
+gleam deps download
+sqlode generate --config=sqlode.yaml   # or: gleam run -m sqlode -- generate
+gleam test
+```

--- a/examples/sqlite-basic/db/query.sql
+++ b/examples/sqlite-basic/db/query.sql
@@ -1,0 +1,11 @@
+-- name: GetAuthor :one
+SELECT id, name, bio FROM authors WHERE id = ?1;
+
+-- name: ListAuthors :many
+SELECT id, name, bio FROM authors ORDER BY name;
+
+-- name: CreateAuthor :exec
+INSERT INTO authors (name, bio) VALUES (?1, ?2);
+
+-- name: DeleteAuthor :exec
+DELETE FROM authors WHERE id = ?1;

--- a/examples/sqlite-basic/db/schema.sql
+++ b/examples/sqlite-basic/db/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE authors (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  bio TEXT
+);

--- a/examples/sqlite-basic/gleam.toml
+++ b/examples/sqlite-basic/gleam.toml
@@ -1,0 +1,13 @@
+name = "sqlite_basic"
+version = "0.1.0"
+description = "Minimal runnable sqlode example for SQLite + sqlight native runtime."
+
+target = "erlang"
+
+[dependencies]
+gleam_stdlib = ">= 0.40.0 and < 2.0.0"
+sqlight = ">= 1.0.0 and < 2.0.0"
+sqlode = ">= 0.5.0 and < 1.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.5.0 and < 2.0.0"

--- a/examples/sqlite-basic/sqlode.yaml
+++ b/examples/sqlite-basic/sqlode.yaml
@@ -1,0 +1,9 @@
+version: "2"
+sql:
+  - schema: "db/schema.sql"
+    queries: "db/query.sql"
+    engine: "sqlite"
+    gen:
+      gleam:
+        out: "src/db"
+        runtime: "native"

--- a/examples/sqlite-basic/src/sqlite_basic.gleam
+++ b/examples/sqlite-basic/src/sqlite_basic.gleam
@@ -1,0 +1,20 @@
+//// Minimal runnable example for sqlode + SQLite.
+////
+//// Before building this project, generate the typed Gleam wrappers:
+////
+////   sqlode generate --config=sqlode.yaml
+////
+//// The command writes `src/db/{params,models,queries,sqlight_adapter}.gleam`.
+//// With those modules in place, `gleam test` runs the end-to-end flow from
+//// `test/sqlite_basic_test.gleam`.
+////
+//// See `doc/tutorials/getting-started-sqlite.md` in the sqlode repository
+//// for the full walkthrough.
+
+import gleam/io
+
+pub fn main() {
+  io.println(
+    "sqlite-basic example. Run `sqlode generate` to produce src/db/*, then `gleam test`.",
+  )
+}

--- a/examples/sqlite-basic/test/sqlite_basic_test.gleam
+++ b/examples/sqlite-basic/test/sqlite_basic_test.gleam
@@ -1,0 +1,67 @@
+//// End-to-end test against a real in-memory SQLite database.
+////
+//// Requires `sqlode generate` to have been run first so that the
+//// generated modules under `src/db/` exist.
+
+import db/params
+import db/sqlight_adapter
+import gleam/option
+import gleeunit
+import sqlight
+
+pub fn main() {
+  gleeunit.main()
+}
+
+fn open_with_schema() -> sqlight.Connection {
+  let assert Ok(db) = sqlight.open(":memory:")
+  let assert Ok(_) =
+    sqlight.exec(
+      "CREATE TABLE authors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        bio TEXT
+      );",
+      db,
+    )
+  db
+}
+
+pub fn create_and_get_author_test() {
+  let db = open_with_schema()
+
+  let assert Ok(_) =
+    sqlight_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Alice", bio: option.Some("A bio")),
+    )
+
+  let assert Ok(option.Some(author)) =
+    sqlight_adapter.get_author(db, params.GetAuthorParams(id: 1))
+  let assert True = author.id == 1
+  let assert True = author.name == "Alice"
+  let assert True = author.bio == option.Some("A bio")
+
+  Nil
+}
+
+pub fn list_authors_is_ordered_by_name_test() {
+  let db = open_with_schema()
+
+  let assert Ok(_) =
+    sqlight_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Bob", bio: option.None),
+    )
+  let assert Ok(_) =
+    sqlight_adapter.create_author(
+      db,
+      params.CreateAuthorParams(name: "Alice", bio: option.None),
+    )
+
+  let assert Ok([first, second]) = sqlight_adapter.list_authors(db)
+  let assert True = first.name == "Alice"
+  let assert True = second.name == "Bob"
+
+  Nil
+}

--- a/spec/example_spec.sh
+++ b/spec/example_spec.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+Describe 'examples/sqlite-basic'
+  Include "$SHELLSPEC_SPECDIR/spec_helper.sh"
+
+  EXAMPLE_DIR="$PROJECT_ROOT/examples/sqlite-basic"
+  GENERATED_DIR="$EXAMPLE_DIR/src/db"
+
+  clean_generated() {
+    rm -rf "$GENERATED_DIR"
+  }
+
+  Describe 'tutorial freshness'
+    Before 'clean_generated'
+    After 'clean_generated'
+
+    It 'regenerates params, models, queries, and the sqlight adapter'
+      When run generate --config="$EXAMPLE_DIR/sqlode.yaml"
+      The status should be success
+      The output should include 'Successfully generated'
+      The path "$GENERATED_DIR/params.gleam" should be file
+      The path "$GENERATED_DIR/models.gleam" should be file
+      The path "$GENERATED_DIR/queries.gleam" should be file
+      The path "$GENERATED_DIR/sqlight_adapter.gleam" should be file
+      The contents of file "$GENERATED_DIR/params.gleam" should include 'GetAuthorParams(id: Int)'
+      The contents of file "$GENERATED_DIR/params.gleam" should include 'CreateAuthorParams(name: String'
+      The contents of file "$GENERATED_DIR/sqlight_adapter.gleam" should include 'pub fn get_author('
+      The contents of file "$GENERATED_DIR/sqlight_adapter.gleam" should include 'pub fn list_authors('
+      The contents of file "$GENERATED_DIR/sqlight_adapter.gleam" should include 'pub fn create_author('
+      The contents of file "$GENERATED_DIR/sqlight_adapter.gleam" should include 'pub fn delete_author('
+    End
+  End
+End


### PR DESCRIPTION
## Summary

Fix the missing tutorial-first onboarding path called out in Issue #434. Reference material alone does not convert evaluation traffic, so this PR adds a short guided walkthrough plus a runnable example that the smoke test keeps honest.

## Changes

- `doc/tutorials/getting-started-sqlite.md` — five-minute SQLite + sqlight native walkthrough covering install, `sqlode init`, schema/query editing, `sqlode generate`, and a minimal `gleam run` snippet using the generated adapter.
- `examples/sqlite-basic/` — standalone Gleam project that mirrors the tutorial: `sqlode.yaml`, `db/schema.sql`, `db/query.sql`, `gleam.toml`, `src/sqlite_basic.gleam`, and `test/sqlite_basic_test.gleam`. Generated code under `src/db/` is intentionally `.gitignore`d so the regeneration step stays meaningful and the example never drifts into stale generated artefacts.
- `spec/example_spec.sh` — shellspec smoke test that runs `sqlode generate` against the example's config and asserts the four expected modules (`params`, `models`, `queries`, `sqlight_adapter`) are produced with the expected public symbols.
- `README.md` — add a "New to sqlode?" callout right after the intro that links the tutorial and the example. The rest of the README stays reference-oriented.

## Design Decisions

- The example keeps generated code out of the repository. The smoke test is the single source of truth for what the generator should produce for the tutorial's inputs. This avoids the hidden-merge-conflict failure mode of committed generated code.
- The tutorial points at the `examples/sqlite-basic/` directory as a shortcut for users who want to skip typing; the smoke test is the mechanism that keeps that pointer accurate.
- `CONTRIBUTING.md`'s guideline that user-facing docs stay reference-oriented is respected — the narrative lives in `doc/tutorials/`, not in `README.md`.

## Verification

- `gleam format --check src/ test/`
- `gleam check`
- `gleam build --warnings-as-errors`
- `gleam run -m glinter`
- `gleam test` (919 passed, no failures)
- `shellspec` (24 examples including the new `examples/sqlite-basic tutorial freshness` case, 0 failures)

Closes #434