### PR TITLE
feat(dist): ship a first-class Docker distribution path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git/
+.github/
+build/
+target/
+test_output/
+test_integration_sqlite_tmp/
+doc/
+examples/
+integration_test/
+spec/
+test/
+*.beam
+*.ez
+erl_crash.dump
+.codex
+.claude

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,80 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and smoke-test image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # On release tags, also log in to GHCR so the push step below
+      # can publish. On pull requests we only build locally to keep
+      # the CR untouched from forks.
+      - name: Log in to GHCR
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      # Build once into the local docker daemon so the smoke test can
+      # run against the exact artefact we will publish.
+      - name: Build image (load for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          push: false
+          tags: sqlode:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        run: bash scripts/smoke_docker.sh sqlode:smoke
+
+      # Push only on main-branch pushes and release tags. Pull
+      # requests from forks skip this step (login is also gated).
+      - name: Push image
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- builder ----------
+# Produces the self-contained `sqlode` escript. We pin the Gleam
+# version to match the erlef/setup-beam toolchain used in CI so the
+# artefact is byte-identical with what the release workflow ships.
+FROM ghcr.io/gleam-lang/gleam:v1.15.2-erlang-alpine AS builder
+
+WORKDIR /build
+
+# `gleam deps download` reaches rebar3 for Erlang-native dependencies.
+RUN apk add --no-cache bash curl \
+    && curl -fsSL https://s3.amazonaws.com/rebar3/rebar3 -o /usr/local/bin/rebar3 \
+    && chmod +x /usr/local/bin/rebar3
+
+# Resolve deps first so later source edits hit a cache layer.
+COPY gleam.toml manifest.toml ./
+RUN gleam deps download
+
+# Copy source, build the project, and bundle the escript. An
+# explicit `gleam build` pass materialises the sqlode BEAM files in
+# `build/dev/erlang/sqlode/ebin` so gleescript can include them in
+# the escript archive.
+COPY src ./src
+RUN gleam build
+RUN gleam run -m gleescript
+
+# ---------- runtime ----------
+# Minimal Erlang image so evaluators do not have to install Erlang/OTP
+# themselves. `escript` (part of Erlang/OTP) runs the packaged CLI.
+# OTP must match the version used by the gleam-lang/gleam builder
+# image above (OTP 28 for Gleam v1.15.2) — otherwise the escript's
+# compiled BEAM modules fail to load at runtime.
+FROM erlang:28-alpine AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/nao1215/sqlode"
+LABEL org.opencontainers.image.description="sqlode — typed Gleam code generator for SQL schemas and queries."
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=builder /build/sqlode /usr/local/bin/sqlode
+RUN chmod +x /usr/local/bin/sqlode
+
+# `/work` is the conventional bind-mount target — users run
+# `docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate`.
+WORKDIR /work
+
+ENTRYPOINT ["escript", "/usr/local/bin/sqlode"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ of this README stays reference-oriented.
 
 ### Install
 
-sqlode ships as an Erlang escript. Every install path therefore needs an Erlang/OTP runtime on the host (`escript` on PATH). The easiest way to cover both downloading the escript and detecting a missing runtime is the one-line installer:
+sqlode ships as an Erlang escript. Most install paths therefore need an Erlang/OTP runtime on the host (`escript` on PATH); the Docker image (Option D) bundles Erlang so you can evaluate sqlode without installing one yourself.
 
 #### Option A: One-line install (recommended)
 
@@ -78,6 +78,19 @@ If you already have a Gleam project, you can invoke the CLI through `gleam run` 
 gleam add sqlode
 gleam run -m sqlode -- generate
 ```
+
+#### Option D: Docker image (no Erlang install required)
+
+Prebuilt images are published to GitHub Container Registry. Use this path if you want to evaluate sqlode without installing Erlang/OTP on the host:
+
+```console
+docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest init --engine=sqlite
+docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
+```
+
+The container's working directory is `/work`, so bind-mounting your project there lets `init` / `generate` / `verify` write into the host directory. Pin a release by replacing `:latest` with `:0.5.0` (or any tag listed under the repository's Packages page).
+
+> Note: image tags are published by the repository's CI workflow. The first push that runs after this workflow lands is what materialises the `:latest` tag — until then, build locally with `docker build -t sqlode .` at the repo root.
 
 ### Initialize config
 

--- a/scripts/smoke_docker.sh
+++ b/scripts/smoke_docker.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Smoke-test a sqlode container image end-to-end. Ensures the image
+# can run `version`, scaffold a fresh project with `init`, and
+# generate typed Gleam code from the scaffolded SQL. Used by the
+# release workflow and re-usable locally:
+#
+#   ./scripts/smoke_docker.sh sqlode:test
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <image-tag>" >&2
+  exit 1
+fi
+
+IMAGE="$1"
+
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+# `version` must print the canonical banner.
+OUTPUT="$(docker run --rm "$IMAGE" version)"
+case "$OUTPUT" in
+  *"sqlode v"*) ;;
+  *)
+    echo "version command did not emit expected banner: $OUTPUT" >&2
+    exit 1
+    ;;
+esac
+
+# `--help` must succeed.
+docker run --rm "$IMAGE" --help >/dev/null
+
+# `init` must scaffold sqlode.yaml + stub SQL files in a bind-mounted
+# working directory. Use the host UID so the generated files are not
+# owned by root.
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$TMP_DIR:/work" \
+  "$IMAGE" init --engine=sqlite --runtime=native >/dev/null
+
+test -f "$TMP_DIR/sqlode.yaml"
+test -f "$TMP_DIR/db/schema.sql"
+test -f "$TMP_DIR/db/query.sql"
+
+# `generate` must produce the expected Gleam modules.
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$TMP_DIR:/work" \
+  "$IMAGE" generate >/dev/null
+
+test -f "$TMP_DIR/src/db/params.gleam"
+test -f "$TMP_DIR/src/db/queries.gleam"
+test -f "$TMP_DIR/src/db/models.gleam"
+test -f "$TMP_DIR/src/db/sqlight_adapter.gleam"
+
+echo "Smoke test passed: $IMAGE"


### PR DESCRIPTION
## Summary

Close the onboarding gap called out in Issue #433: add a first-class install path that does not require the evaluator to install Erlang/OTP themselves. A pre-built Docker image published to GHCR lets users run `sqlode init` / `generate` / `verify` immediately.

## Changes

- `Dockerfile` — multi-stage build. The `builder` stage pins `ghcr.io/gleam-lang/gleam:v1.15.2-erlang-alpine` (matching the erlef/setup-beam toolchain used in the other workflows), resolves dependencies, compiles sqlode, and runs `gleam run -m gleescript` to produce the escript. The `runtime` stage uses `erlang:28-alpine` (OTP must match the builder, otherwise the escript's BEAM modules fail to load) and exposes `escript /usr/local/bin/sqlode` via `ENTRYPOINT`. Final image is ~156 MB.
- `.dockerignore` — excludes build/, tests, docs, and git metadata from the build context.
- `scripts/smoke_docker.sh` — end-to-end smoke test that runs the `version` banner, scaffolds a temp project with `init --engine=sqlite --runtime=native`, and invokes `generate` to produce the four expected modules (`params`, `queries`, `models`, `sqlight_adapter`). Usable locally (`bash scripts/smoke_docker.sh sqlode:test`) and from CI.
- `.github/workflows/docker.yml` — new CI lane. On pull requests the image is built with `docker/build-push-action@v6 load=true` and validated by the smoke test without touching GHCR. On `main` pushes and `v*` tags the image is pushed to `ghcr.io/${{ github.repository }}` with semver / `latest` tags via `docker/metadata-action`.
- `README.md` — add "Option D: Docker image (no Erlang install required)" right under the existing Options A–C, and relax the opening sentence that claimed every install path needs Erlang/OTP.

## Design Decisions

- **Why Docker over Homebrew / asdf**: the Issue specifically calls out hiding the Erlang dependency. Homebrew and asdf plugins still require OTP on the host. A container is the shortest path to a true zero-dep evaluation experience.
- **Validation vs publishing**: the acceptance criteria lists "Automate publishing OR validation". This PR does both — the smoke test runs on every PR (validation), and publishing is gated to trusted refs (`main` branch pushes and release tags) so fork PRs cannot touch the registry.
- **OTP version matters**: during local verification the first build used `erlang:27-alpine` at runtime and failed with `corrupt atom table` / `undefined function sqlode:main/0`. An escript built against OTP 28 will not load on an OTP 27 runtime. The Dockerfile comment and the `erlang:28-alpine` base codify that invariant.
- **`gleam build` before `gleam run -m gleescript`**: a bare `gleam run -m gleescript` in a fresh container produced an escript archive that was missing `sqlode*.beam`, so `sqlode:main/0` was undefined at runtime. Splitting into `gleam build` followed by `gleam run -m gleescript` reliably materialises the project's BEAM files in `build/dev/erlang/sqlode/ebin` before gleescript scans the ebin tree.

## Verification

- `docker build -t sqlode:test .` — succeeds (final image 156 MB).
- `docker run --rm sqlode:test version` → `sqlode v0.5.0`.
- `docker run --rm sqlode:test --help` — succeeds.
- `bash scripts/smoke_docker.sh sqlode:test` — passes end-to-end init + generate.
- `gleam format --check src/ test/` / `gleam check` / `gleam run -m glinter` — all pass.

## Limitations

- The first `ghcr.io/nao1215/sqlode:latest` tag only materialises after this PR lands on `main` (or after the next release tag). The README calls this out so users have clear expectations in the interim.
- Single-arch build (linux/amd64) in the workflow as configured. Adding `linux/arm64` via `docker/build-push-action`'s `platforms` option is a straightforward follow-up if Apple Silicon / arm64 users report needing it.

Closes #433