### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-21
+
+### Added
+
+- **First-class Docker distribution path** (#438). `Dockerfile`,
+  `scripts/smoke_docker.sh`, and `.github/workflows/docker.yml` now
+  build, smoke-test, and publish a container image for sqlode. Users
+  can run the CLI via `ghcr.io/nao1215/sqlode` without installing
+  Erlang/OTP on the host, and tagged releases publish semver image
+  tags in addition to the escript artifact.
+- **Tutorial-first SQLite onboarding** (#437).
+  `doc/tutorials/getting-started-sqlite.md` now walks through install,
+  `sqlode init`, `sqlode generate`, and a minimal `sqlight` runtime
+  example end to end. The new `examples/sqlite-basic/` project is the
+  runnable counterpart, and `spec/example_spec.sh` keeps the tutorial
+  commands from drifting by asserting the generated modules exist.
+
+### Changed
+
+- **README install/reference cleanup**. The top-level README now points
+  readers to the SQLite tutorial and runnable example first, documents
+  the Docker install path alongside the existing release artifacts, and
+  removes decorative callouts in favor of tighter reference prose.
+
+### Fixed
+
+- **`sqlode init --engine=mysql --runtime=native` now works** (#436).
+  The stale CLI validation guard that still rejected MySQL native mode
+  after v0.5.0 support shipped has been removed. Both Gleam tests and
+  ShellSpec coverage now pin the generated config and starter schema
+  for the MySQL native path.
+
 ## [0.5.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest init --engine=sqli
 docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
 ```
 
-The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.5.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
+The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.6.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
 
 ### Initialize config
 

--- a/examples/sqlite-basic/gleam.toml
+++ b/examples/sqlite-basic/gleam.toml
@@ -7,7 +7,7 @@ target = "erlang"
 [dependencies]
 gleam_stdlib = ">= 0.40.0 and < 2.0.0"
 sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = ">= 0.5.0 and < 1.0.0"
+sqlode = ">= 0.6.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.5.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.5.0"
+version = "0.6.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.5.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.6.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.5.0"
+pub const version = "0.6.0"

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -1195,10 +1195,13 @@ pub fn readme_runtime_prepare_is_two_arg_test() {
   string.contains(readme, "let #(sql, values) = runtime.prepare(")
   |> should.be_true()
 
+  // Keep this resilient to README line-wrapping changes while still pinning
+  // the second argument to the generated params record.
+  string.contains(readme, "runtime.prepare(q, params.")
+  |> should.be_true()
+
   // Fail fast if anyone regresses the example back to a 3-arg call with the
   // placeholder prefix string ("$" or "?").
-  string.contains(readme, "runtime.prepare(\n  q,\n  params.")
-  |> should.be_true()
   string.contains(readme, "\"$\",  // \"$\" for PostgreSQL")
   |> should.be_false()
 }


### PR DESCRIPTION
## Summary
Prepare the v0.6.0 release metadata and changelog.

## Changes
- bump the package and CLI version to 0.6.0
- add the 0.6.0 changelog entry and refresh release-facing examples
- relax the README runtime snapshot test so CI matches the current docs formatting

## Design Decisions
- keep the release notes scoped to commits since v0.5.0
- update the README and example dependency ranges to the new published version

## Limitations
- local ShellSpec compile cases still require networked Hex access in this sandbox, so final validation is deferred to GitHub Actions CI
