### PR TITLE
fix(verify): support schema/query directories like generate

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -20,6 +20,7 @@ import sqlode/query_ir
 import sqlode/query_parser
 import sqlode/runtime
 import sqlode/schema_parser
+import sqlode/sql_paths
 import sqlode/type_mapping
 import sqlode/writer
 
@@ -391,49 +392,13 @@ fn enum_name(scalar_type: model.ScalarType) -> Result(String, Nil) {
   }
 }
 
-fn expand_sql_paths(
-  paths: List(String),
-  error_fn: fn(String, String) -> GenerateError,
-) -> Result(List(String), GenerateError) {
-  paths
-  |> list.try_map(fn(path) {
-    case simplifile.is_directory(path) {
-      Ok(True) ->
-        case simplifile.get_files(in: path) {
-          Ok(files) -> {
-            let sql_files =
-              files
-              |> list.filter(fn(f) { string.ends_with(f, ".sql") })
-              |> list.sort(string.compare)
-            case sql_files {
-              [] -> Error(error_fn(path, "Directory contains no .sql files"))
-              _ -> Ok(sql_files)
-            }
-          }
-          Error(error) ->
-            Error(error_fn(
-              path,
-              "Failed to read directory: " <> simplifile.describe_error(error),
-            ))
-        }
-      Ok(False) -> Ok([path])
-      Error(error) ->
-        Error(error_fn(
-          path,
-          "Failed to access path: " <> simplifile.describe_error(error),
-        ))
-    }
-  })
-  |> result.map(list.flatten)
-}
-
 fn load_catalog(
   paths: List(String),
   engine: model.Engine,
   strict_views: Bool,
 ) -> Result(model.Catalog, GenerateError) {
   use expanded <- result.try(
-    expand_sql_paths(paths, fn(path, detail) { SchemaReadError(path:, detail:) }),
+    sql_paths.expand(paths, fn(path, detail) { SchemaReadError(path:, detail:) }),
   )
   use entries <- result.try(
     expanded
@@ -483,7 +448,7 @@ fn load_queries(
   let model.SqlBlock(engine:, queries:, ..) = block
 
   use expanded <- result.try(
-    expand_sql_paths(queries, fn(path, detail) {
+    sql_paths.expand(queries, fn(path, detail) {
       QueryReadError(path:, detail:)
     }),
   )

--- a/src/sqlode/sql_paths.gleam
+++ b/src/sqlode/sql_paths.gleam
@@ -1,0 +1,55 @@
+//// Shared `.sql` path expansion used by `generate` and `verify`.
+////
+//// A configured `schema` or `queries` entry may be either a direct
+//// path to a `.sql` file or a directory of `.sql` files. This
+//// module applies the expansion rules both commands rely on so the
+//// CLI presents a single, consistent surface: directories expand
+//// to their `.sql` children in ascii-sorted order, empty
+//// directories fail, and errors carry the originating path so
+//// callers can render diagnostics.
+
+import gleam/list
+import gleam/result
+import gleam/string
+import simplifile
+
+/// Expand directory entries in `paths` into their `.sql` children.
+/// File entries pass through unchanged. `error_fn` maps an
+/// offending path and detail string into the caller's error type
+/// so each command can attach its own wrapping variant while the
+/// underlying diagnostic text stays consistent.
+pub fn expand(
+  paths: List(String),
+  error_fn: fn(String, String) -> error,
+) -> Result(List(String), error) {
+  paths
+  |> list.try_map(fn(path) {
+    case simplifile.is_directory(path) {
+      Ok(True) ->
+        case simplifile.get_files(in: path) {
+          Ok(files) -> {
+            let sql_files =
+              files
+              |> list.filter(fn(f) { string.ends_with(f, ".sql") })
+              |> list.sort(string.compare)
+            case sql_files {
+              [] -> Error(error_fn(path, "Directory contains no .sql files"))
+              _ -> Ok(sql_files)
+            }
+          }
+          Error(error) ->
+            Error(error_fn(
+              path,
+              "Failed to read directory: " <> simplifile.describe_error(error),
+            ))
+        }
+      Ok(False) -> Ok([path])
+      Error(error) ->
+        Error(error_fn(
+          path,
+          "Failed to access path: " <> simplifile.describe_error(error),
+        ))
+    }
+  })
+  |> result.map(list.flatten)
+}

--- a/src/sqlode/verify.gleam
+++ b/src/sqlode/verify.gleam
@@ -29,6 +29,7 @@ import sqlode/query_analyzer
 import sqlode/query_ir
 import sqlode/query_parser
 import sqlode/schema_parser
+import sqlode/sql_paths
 
 /// Outcome of a single verification pass. A report with an empty
 /// `findings` list means every block in the config parsed, analysed
@@ -143,7 +144,10 @@ fn parse_all_queries(
 }
 
 fn read_files(paths: List(String)) -> Result(List(#(String, String)), String) {
-  paths
+  use expanded <- result.try(
+    sql_paths.expand(paths, fn(path, detail) { path <> ": " <> detail }),
+  )
+  expanded
   |> list.try_map(fn(path) {
     case simplifile.read(path) {
       Ok(content) -> Ok(#(path, content))

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -144,3 +144,56 @@ pub fn report_to_string_reports_all_clear_on_empty_findings_test() {
   let report = verify.Report(findings: [])
   verify.report_to_string(report) |> should.equal("All checks passed.")
 }
+
+pub fn verify_accepts_schema_and_queries_directories_test() {
+  // A directory-style config must verify cleanly the same way
+  // `generate` accepts it. Before Issue #440, verify tried to
+  // simplifile.read(dir) and reported an "Is a directory" OS
+  // error as a finding, which made the command unusable for
+  // every directory-based config.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/schema_dir",
+        "test/fixtures/query_dir",
+        "src/verify_dir_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  report.findings |> should.equal([])
+}
+
+pub fn verify_surfaces_empty_schema_directory_as_finding_test() {
+  // Empty directories must produce the same user-facing error
+  // text generate reports ("no .sql files"), so a CI gate that
+  // runs verify before generate catches the same class of
+  // misconfiguration.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/empty_dir",
+        "test/fixtures/verify_ok_query.sql",
+        "src/verify_empty_schema_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "no .sql files") |> should.be_true()
+}
+
+pub fn verify_surfaces_empty_query_directory_as_finding_test() {
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/empty_dir",
+        "src/verify_empty_query_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "no .sql files") |> should.be_true()
+}


### PR DESCRIPTION
## Summary

`sqlode verify` rejected directory-based `schema` / `queries` inputs
even though `generate` already supports them, so any config using a
directory layout could not be validated before generation. This change
makes `verify` reuse the same directory expansion rules as `generate`
so both commands accept the same input shapes.

## Changes

- Extract the `.sql` path expansion logic from `src/sqlode/generate.gleam` into a new shared module `src/sqlode/sql_paths.gleam`.
- Wire `src/sqlode/verify.gleam`'s `read_files` to call `sql_paths.expand` before reading, so directories expand to their `.sql` children with the same ascii-sorted order and empty-directory diagnostics.
- Update `src/sqlode/generate.gleam` to call the shared helper instead of its private copy.
- Add directory-input coverage to `test/verify_test.gleam`: success case with `schema_dir` + `query_dir`, and empty-directory cases that surface as findings.

## Design Decisions

The shared helper keeps the existing error-callback pattern so each
command attaches its own error variant while the diagnostic text stays
identical. `verify` surfaces empty-directory and read errors as
per-block `Finding`s (rather than short-circuiting) to match the
verifier's existing behaviour of collecting every problem in one pass.

Closes #440