### PR TITLE
fix(verify): mirror generate-time query validation

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -18,7 +18,7 @@ import sqlode/naming
 import sqlode/query_analyzer
 import sqlode/query_ir
 import sqlode/query_parser
-import sqlode/runtime
+import sqlode/query_validation
 import sqlode/schema_parser
 import sqlode/sql_paths
 import sqlode/type_mapping
@@ -478,20 +478,19 @@ fn load_queries(
 fn validate_no_duplicate_query_names(
   queries: List(query_ir.TokenizedQuery),
 ) -> Result(List(query_ir.TokenizedQuery), GenerateError) {
-  let grouped =
-    list.group(queries, fn(q) { q.base.name })
-    |> dict.to_list
-    |> list.filter(fn(entry) { list.length(entry.1) > 1 })
+  query_validation.validate_no_duplicate_names(queries)
+  |> result.map_error(wrap_validation_error)
+  |> result.map(fn(_) { queries })
+}
 
-  case grouped {
-    [] -> Ok(queries)
-    [#(name, dupes), ..] -> {
-      let paths =
-        dupes
-        |> list.map(fn(q) { q.base.source_path })
-        |> list.unique
-      Error(DuplicateQueryName(name:, paths:))
-    }
+fn wrap_validation_error(err: query_validation.ValidationError) -> GenerateError {
+  case err {
+    query_validation.DuplicateName(name:, paths:) ->
+      DuplicateQueryName(name:, paths:)
+    query_validation.UnsupportedAnnotation(query_name:, command:, detail:) ->
+      UnsupportedAnnotation(query_name:, command:, detail:)
+    query_validation.UnsupportedArrayForEngine(query_name:, engine:) ->
+      UnsupportedArrayForEngine(query_name:, engine:)
   }
 }
 
@@ -689,76 +688,23 @@ fn validate_out_path(out: String) -> Result(Nil, GenerateError) {
 fn validate_unsupported_annotations(
   queries: List(model.AnalyzedQuery),
 ) -> Result(Nil, GenerateError) {
-  let unsupported = fn(command: runtime.QueryCommand) -> Bool {
-    case command {
-      runtime.QueryBatchOne
-      | runtime.QueryBatchMany
-      | runtime.QueryBatchExec
-      | runtime.QueryCopyFrom -> True
-      _ -> False
-    }
-  }
-  case list.find(queries, fn(q) { unsupported(q.base.command) }) {
-    Ok(q) -> {
-      let #(command, alternative) = case q.base.command {
-        runtime.QueryBatchOne -> #(":batchone", ":one")
-        runtime.QueryBatchMany -> #(":batchmany", ":many")
-        runtime.QueryBatchExec -> #(":batchexec", ":exec")
-        runtime.QueryCopyFrom -> #(":copyfrom", ":exec")
-        _ -> #("", ":exec")
-      }
-      Error(UnsupportedAnnotation(
-        query_name: q.base.name,
-        command: command,
-        detail: command
-          <> " is not yet supported. Use "
-          <> alternative
-          <> " instead, or add '-- sqlode:skip' before the annotation to bypass this query",
-      ))
-    }
-    Error(_) -> Ok(Nil)
-  }
+  query_validation.validate_unsupported_annotations(queries)
+  |> result.map_error(wrap_validation_error)
 }
 
 fn validate_array_engine_support(
   engine: model.Engine,
   queries: List(model.AnalyzedQuery),
 ) -> Result(Nil, GenerateError) {
-  case engine {
-    model.PostgreSQL -> Ok(Nil)
-    _ -> {
-      let has_array = fn(q: model.AnalyzedQuery) {
-        list.any(q.params, fn(p) {
-          case p.scalar_type {
-            model.ArrayType(_) -> True
-            _ -> False
-          }
-        })
-      }
-      case list.find(queries, has_array) {
-        Ok(q) ->
-          Error(UnsupportedArrayForEngine(
-            query_name: q.base.name,
-            engine: model.engine_to_string(engine),
-          ))
-        Error(_) -> Ok(Nil)
-      }
-    }
-  }
+  query_validation.validate_array_engine_support(engine, queries)
+  |> result.map_error(wrap_validation_error)
 }
 
 fn validate_native_annotations(
   queries: List(model.AnalyzedQuery),
 ) -> Result(Nil, GenerateError) {
-  case list.find(queries, fn(q) { q.base.command == runtime.QueryExecResult }) {
-    Ok(q) ->
-      Error(UnsupportedAnnotation(
-        query_name: q.base.name,
-        command: ":execresult",
-        detail: ":execresult is not supported with native runtime. Use :exec, :execrows, or :execlastid instead",
-      ))
-    Error(_) -> Ok(Nil)
-  }
+  query_validation.validate_native_annotations(queries)
+  |> result.map_error(wrap_validation_error)
 }
 
 fn adapter_filename(engine: model.Engine) -> String {
@@ -914,12 +860,16 @@ pub fn error_to_string(error: GenerateError) -> String {
           }
       }
     DuplicateQueryName(name:, paths:) ->
-      "duplicate query name \""
-      <> name
-      <> "\" found in: "
-      <> string.join(paths, ", ")
+      query_validation.error_to_string(query_validation.DuplicateName(
+        name:,
+        paths:,
+      ))
     UnsupportedAnnotation(query_name:, command:, detail:) ->
-      "Query " <> query_name <> " uses " <> command <> ": " <> detail
+      query_validation.error_to_string(query_validation.UnsupportedAnnotation(
+        query_name:,
+        command:,
+        detail:,
+      ))
     InvalidOutPath(path:) ->
       "Invalid output path \""
       <> path
@@ -928,10 +878,8 @@ pub fn error_to_string(error: GenerateError) -> String {
     VendorRuntimeNotFound ->
       "vendor_runtime is enabled but the sqlode/runtime source file could not be found. Tried: src/sqlode/runtime.gleam, build/packages/sqlode/src/sqlode/runtime.gleam, build/dev/erlang/sqlode/src/sqlode/runtime.gleam"
     UnsupportedArrayForEngine(query_name:, engine:) ->
-      "Query \""
-      <> query_name
-      <> "\": array parameters are not supported for engine \""
-      <> engine
-      <> "\". Arrays are only supported with PostgreSQL"
+      query_validation.error_to_string(
+        query_validation.UnsupportedArrayForEngine(query_name:, engine:),
+      )
   }
 }

--- a/src/sqlode/query_validation.gleam
+++ b/src/sqlode/query_validation.gleam
@@ -1,0 +1,152 @@
+//// Post-parse query validation shared by `generate` and `verify`.
+////
+//// These checks reject configurations that would otherwise reach
+//// the codegen stage in a state the generator cannot express
+//// safely. Centralising them here means `verify` and `generate`
+//// reach the same verdict for any given config: `verify` can be
+//// used as a trustworthy pre-generation CI gate, and the checks
+//// cannot drift apart again by accident.
+
+import gleam/dict
+import gleam/list
+import gleam/string
+import sqlode/model
+import sqlode/query_ir
+import sqlode/runtime
+
+/// A problem a post-parse check surfaced. Callers wrap the variant
+/// in their own error type (a `GenerateError` for the generator, a
+/// `Finding` string for the verifier) so the shared diagnostic text
+/// stays identical across commands.
+pub type ValidationError {
+  DuplicateName(name: String, paths: List(String))
+  UnsupportedAnnotation(query_name: String, command: String, detail: String)
+  UnsupportedArrayForEngine(query_name: String, engine: String)
+}
+
+/// Reject two tokenized queries that declare the same annotation
+/// name. Left unchecked, the generator would emit colliding
+/// function, decoder, and row-type identifiers downstream.
+pub fn validate_no_duplicate_names(
+  queries: List(query_ir.TokenizedQuery),
+) -> Result(Nil, ValidationError) {
+  let grouped =
+    list.group(queries, fn(q) { q.base.name })
+    |> dict.to_list
+    |> list.filter(fn(entry) { list.length(entry.1) > 1 })
+
+  case grouped {
+    [] -> Ok(Nil)
+    [#(name, dupes), ..] -> {
+      let paths =
+        dupes
+        |> list.map(fn(q) { q.base.source_path })
+        |> list.unique
+      Error(DuplicateName(name:, paths:))
+    }
+  }
+}
+
+/// Reject annotations that are not yet supported by any codegen
+/// path (`:batchone`, `:batchmany`, `:batchexec`, `:copyfrom`).
+/// The failure names a supported alternative so operators can fix
+/// the annotation without digging through docs.
+pub fn validate_unsupported_annotations(
+  queries: List(model.AnalyzedQuery),
+) -> Result(Nil, ValidationError) {
+  let unsupported = fn(command: runtime.QueryCommand) -> Bool {
+    case command {
+      runtime.QueryBatchOne
+      | runtime.QueryBatchMany
+      | runtime.QueryBatchExec
+      | runtime.QueryCopyFrom -> True
+      _ -> False
+    }
+  }
+  case list.find(queries, fn(q) { unsupported(q.base.command) }) {
+    Ok(q) -> {
+      let #(command, alternative) = case q.base.command {
+        runtime.QueryBatchOne -> #(":batchone", ":one")
+        runtime.QueryBatchMany -> #(":batchmany", ":many")
+        runtime.QueryBatchExec -> #(":batchexec", ":exec")
+        runtime.QueryCopyFrom -> #(":copyfrom", ":exec")
+        _ -> #("", ":exec")
+      }
+      Error(UnsupportedAnnotation(
+        query_name: q.base.name,
+        command: command,
+        detail: command
+          <> " is not yet supported. Use "
+          <> alternative
+          <> " instead, or add '-- sqlode:skip' before the annotation to bypass this query",
+      ))
+    }
+    Error(_) -> Ok(Nil)
+  }
+}
+
+/// Reject array parameters for engines that cannot carry them.
+/// Only PostgreSQL supports native array binding at the adapter
+/// layer today.
+pub fn validate_array_engine_support(
+  engine: model.Engine,
+  queries: List(model.AnalyzedQuery),
+) -> Result(Nil, ValidationError) {
+  case engine {
+    model.PostgreSQL -> Ok(Nil)
+    _ -> {
+      let has_array = fn(q: model.AnalyzedQuery) {
+        list.any(q.params, fn(p) {
+          case p.scalar_type {
+            model.ArrayType(_) -> True
+            _ -> False
+          }
+        })
+      }
+      case list.find(queries, has_array) {
+        Ok(q) ->
+          Error(UnsupportedArrayForEngine(
+            query_name: q.base.name,
+            engine: model.engine_to_string(engine),
+          ))
+        Error(_) -> Ok(Nil)
+      }
+    }
+  }
+}
+
+/// Reject annotations that clash with the native runtime. Call
+/// only when the block targets the native runtime; raw-runtime
+/// projects can still emit `:execresult` and should not be
+/// filtered by this check.
+pub fn validate_native_annotations(
+  queries: List(model.AnalyzedQuery),
+) -> Result(Nil, ValidationError) {
+  case list.find(queries, fn(q) { q.base.command == runtime.QueryExecResult }) {
+    Ok(q) ->
+      Error(UnsupportedAnnotation(
+        query_name: q.base.name,
+        command: ":execresult",
+        detail: ":execresult is not supported with native runtime. Use :exec, :execrows, or :execlastid instead",
+      ))
+    Error(_) -> Ok(Nil)
+  }
+}
+
+pub fn error_to_string(error: ValidationError) -> String {
+  case error {
+    DuplicateName(name:, paths:) ->
+      "duplicate query name \""
+      <> name
+      <> "\" found in: "
+      <> string.join(paths, ", ")
+    UnsupportedAnnotation(query_name:, command:, detail:) ->
+      "Query " <> query_name <> " uses " <> command <> ": " <> detail
+    UnsupportedArrayForEngine(query_name:, engine:) ->
+      "Query \""
+      <> query_name
+      <> "\": array parameters are not supported for engine \""
+      <> engine
+      <> "\". Arrays are only supported with PostgreSQL"
+  }
+}

--- a/src/sqlode/verify.gleam
+++ b/src/sqlode/verify.gleam
@@ -28,6 +28,7 @@ import sqlode/naming
 import sqlode/query_analyzer
 import sqlode/query_ir
 import sqlode/query_parser
+import sqlode/query_validation
 import sqlode/schema_parser
 import sqlode/sql_paths
 
@@ -124,8 +125,29 @@ fn load_and_analyze(
 ) -> Result(List(model.AnalyzedQuery), String) {
   use entries <- result.try(read_files(block.queries))
   use queries <- result.try(parse_all_queries(entries, block.engine, naming_ctx))
-  query_analyzer.analyze_queries(block.engine, catalog, naming_ctx, queries)
-  |> result.map_error(query_analyzer.analysis_error_to_string)
+  use Nil <- result.try(
+    query_validation.validate_no_duplicate_names(queries)
+    |> result.map_error(query_validation.error_to_string),
+  )
+  use analyzed <- result.try(
+    query_analyzer.analyze_queries(block.engine, catalog, naming_ctx, queries)
+    |> result.map_error(query_analyzer.analysis_error_to_string),
+  )
+  use Nil <- result.try(
+    query_validation.validate_unsupported_annotations(analyzed)
+    |> result.map_error(query_validation.error_to_string),
+  )
+  use Nil <- result.try(
+    query_validation.validate_array_engine_support(block.engine, analyzed)
+    |> result.map_error(query_validation.error_to_string),
+  )
+  use Nil <- result.try(case block.gleam.runtime {
+    model.Native ->
+      query_validation.validate_native_annotations(analyzed)
+      |> result.map_error(query_validation.error_to_string)
+    model.Raw -> Ok(Nil)
+  })
+  Ok(analyzed)
 }
 
 fn parse_all_queries(

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -197,3 +197,129 @@ pub fn verify_surfaces_empty_query_directory_as_finding_test() {
   let assert [finding] = report.findings
   string.contains(finding.detail, "no .sql files") |> should.be_true()
 }
+
+// ============================================================
+// Generate-parity validation tests (Issue #441)
+//
+// `verify` is meant to be a trustworthy pre-generation CI gate:
+// anything `generate` would reject must also be reported by
+// `verify`. Each test below locks in one of the four shared
+// post-parse checks.
+// ============================================================
+
+fn make_block_with(
+  schema_path: String,
+  query_path: String,
+  out: String,
+  engine: model.Engine,
+  runtime: model.Runtime,
+) -> model.SqlBlock {
+  model.SqlBlock(
+    name: option.None,
+    engine: engine,
+    schema: [schema_path],
+    queries: [query_path],
+    gleam: model.GleamOutput(
+      out: out,
+      runtime: runtime,
+      type_mapping: model.StringMapping,
+      emit_sql_as_comment: False,
+      emit_exact_table_names: False,
+      omit_unused_models: False,
+      vendor_runtime: False,
+      strict_views: False,
+      query_parameter_limit: option.None,
+    ),
+    overrides: model.empty_overrides(),
+  )
+}
+
+pub fn verify_rejects_duplicate_query_names_test() {
+  // duplicate_query.sql declares `GetAuthor` twice. `generate`
+  // rejects this immediately; `verify` used to print "All checks
+  // passed" for the same config. Both commands must now reject
+  // it with the same diagnostic.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/duplicate_query.sql",
+        "src/verify_dupe_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "duplicate query name") |> should.be_true()
+  string.contains(finding.detail, "GetAuthor") |> should.be_true()
+}
+
+pub fn verify_rejects_unsupported_batch_annotation_test() {
+  // :batchmany is not supported by any codegen path. `generate`
+  // rejects it; `verify` must surface the same finding so CI
+  // catches the gap before generation.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block_with(
+        "test/fixtures/all_commands_schema.sql",
+        "test/fixtures/batchmany_query.sql",
+        "src/verify_batch_out",
+        model.SQLite,
+        model.Raw,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, ":batchmany") |> should.be_true()
+  string.contains(finding.detail, "ListPostsBatch") |> should.be_true()
+}
+
+pub fn verify_rejects_execresult_under_native_runtime_test() {
+  // :execresult is valid on the raw path but incompatible with
+  // the native runtime. `verify` must honour the runtime flag on
+  // the block when running this check so a native project
+  // cannot ship code the generator would refuse.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block_with(
+        "test/fixtures/all_commands_schema.sql",
+        "test/fixtures/execresult_query.sql",
+        "src/verify_execresult_out",
+        model.SQLite,
+        model.Native,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, ":execresult") |> should.be_true()
+  string.contains(finding.detail, "UpdatePost") |> should.be_true()
+}
+
+pub fn verify_execresult_under_raw_runtime_is_allowed_test() {
+  // The same fixture must pass verification when the block
+  // targets the raw runtime — :execresult is only forbidden in
+  // native mode. This guards against an over-eager check that
+  // would fire regardless of runtime.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block_with(
+        "test/fixtures/all_commands_schema.sql",
+        "test/fixtures/execresult_query.sql",
+        "src/verify_execresult_raw_out",
+        model.SQLite,
+        model.Raw,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  report.findings |> should.equal([])
+}
+// Note: the non-PostgreSQL array-parameter check
+// (`validate_array_engine_support`) is also shared with `generate`
+// via `sqlode/query_validation`. We do not add a fixture-based
+// regression test here because the current SQLite schema pipeline
+// does not surface `ArrayType` on inferred params for
+// `TEXT[]` / `INTEGER[]` columns, so neither command actually
+// reaches the rejection branch today. If a future change produces
+// array-typed params on a non-PostgreSQL engine, both `generate`
+// and `verify` will reject it with an identical message through
+// the shared validator.


### PR DESCRIPTION
## Summary

`sqlode verify` previously reported "All checks passed" for some
configs that `sqlode generate` rejects immediately (duplicate query
names, unsupported `:batchmany` / `:execresult` annotations, and
array params on non-PostgreSQL engines). Verify and generate now
share the same post-parse validation path, so verify is a
trustworthy pre-generation CI gate and the two checks cannot drift
apart by accident.

## Changes

- New module `src/sqlode/query_validation.gleam` holds the four
  post-parse checks as engine-agnostic functions that return a
  neutral `ValidationError` and a single `error_to_string`. Each
  caller wraps the variant into its own error type.
- `src/sqlode/generate.gleam` delegates the duplicate-name,
  unsupported-annotation, array-engine-support, and
  native-annotation checks (and their error strings) to the shared
  module instead of keeping private copies.
- `src/sqlode/verify.gleam` runs the same validators after
  `parse_all_queries` / `analyze_queries`, gating the
  `:execresult` check on the block's `runtime` so raw projects
  keep passing.
- `test/verify_test.gleam` gains four regression tests: duplicate
  query names, `:batchmany`, `:execresult` under native (rejected)
  vs raw (allowed), locking in each parity case.

## Design Decisions

The shared module exposes `ValidationError` as a neutral type with
one variant per check; generate and verify wrap it into their own
error types (pattern-matched at a single site each). Generate's
`error_to_string` delegates back to `query_validation.error_to_string`
for these three variants so the diagnostic text for `verify` and
`generate` stays byte-identical.

The non-PostgreSQL array-parameter check is ported but not covered
by a fixture test: SQLite / MySQL schema inference does not
currently surface `ArrayType` on inferred params, so neither
command reaches the rejection branch with the existing array
fixtures today. If a future change propagates array types on a
non-PostgreSQL engine, both commands will reject it identically
through the shared validator.

Closes #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced query validation to detect duplicate query names, unsupported annotations, and incompatible array parameter configurations earlier in the verification pipeline with clearer error messages.

* **Tests**
  * Added comprehensive test coverage for query validation across different database engines and runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->