### PR TITLE
ci(release): run glinter in the tag build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
 
 jobs:
+  # The build job's quality gate must stay aligned with CI
+  # (`.github/workflows/ci.yml`) and `just all`. Any step added to
+  # those contracts should be added here too so tag-driven releases
+  # cannot ship a commit the PR lane would have rejected.
   build:
     name: Build and verify
     runs-on: ubuntu-latest
@@ -41,6 +45,9 @@ jobs:
 
       - name: Build (warnings as errors)
         run: gleam build --warnings-as-errors
+
+      - name: Lint (glinter, warnings as errors)
+        run: gleam run -m glinter
 
       - name: Unit tests
         run: gleam test


### PR DESCRIPTION
## Summary

The tag-driven release workflow did not run glinter even though the
main CI workflow and `just all` both treat it as part of the required
quality bar. This means a direct tag push could publish Hex and
GitHub release artifacts from a commit that would have failed the
declared lint gate. This change aligns the release job with CI so
the published path is at least as strict as the PR lane.

## Changes

- `.github/workflows/release.yml`: add a `Lint (glinter, warnings as errors)` step to the `build` job, matching the name, command, and position used in `ci.yml` (between the `Build (warnings as errors)` step and `Unit tests`).
- Add a short comment above the `build:` job spelling out the parity contract with `ci.yml` and `just all` so future quality-gate additions are less likely to drift across workflows.

## Design Decisions

The new step mirrors `ci.yml` exactly (same name, same command,
same position) rather than introducing a shared workflow fragment.
With just one duplicate step, a reusable workflow / composite
action would add more indirection than it saves; the inline
comment instead points future contributors at the contract they
need to keep in sync.

Closes #442