### PR TITLE
fix(codegen): reject normalized query-name collisions

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -39,6 +39,11 @@ pub type GenerateError {
     schema_paths: List(String),
   )
   DuplicateQueryName(name: String, paths: List(String))
+  NormalizedQueryNameCollision(
+    function_name: String,
+    names: List(String),
+    paths: List(String),
+  )
   UnsupportedAnnotation(query_name: String, command: String, detail: String)
   InvalidOutPath(path: String)
   WriteError(writer.WriteError)
@@ -487,6 +492,8 @@ fn wrap_validation_error(err: query_validation.ValidationError) -> GenerateError
   case err {
     query_validation.DuplicateName(name:, paths:) ->
       DuplicateQueryName(name:, paths:)
+    query_validation.NormalizedNameCollision(function_name:, names:, paths:) ->
+      NormalizedQueryNameCollision(function_name:, names:, paths:)
     query_validation.UnsupportedAnnotation(query_name:, command:, detail:) ->
       UnsupportedAnnotation(query_name:, command:, detail:)
     query_validation.UnsupportedArrayForEngine(query_name:, engine:) ->
@@ -862,6 +869,12 @@ pub fn error_to_string(error: GenerateError) -> String {
     DuplicateQueryName(name:, paths:) ->
       query_validation.error_to_string(query_validation.DuplicateName(
         name:,
+        paths:,
+      ))
+    NormalizedQueryNameCollision(function_name:, names:, paths:) ->
+      query_validation.error_to_string(query_validation.NormalizedNameCollision(
+        function_name:,
+        names:,
         paths:,
       ))
     UnsupportedAnnotation(query_name:, command:, detail:) ->

--- a/src/sqlode/query_validation.gleam
+++ b/src/sqlode/query_validation.gleam
@@ -20,31 +20,54 @@ import sqlode/runtime
 /// stays identical across commands.
 pub type ValidationError {
   DuplicateName(name: String, paths: List(String))
+  NormalizedNameCollision(
+    function_name: String,
+    names: List(String),
+    paths: List(String),
+  )
   UnsupportedAnnotation(query_name: String, command: String, detail: String)
   UnsupportedArrayForEngine(query_name: String, engine: String)
 }
 
 /// Reject two tokenized queries that declare the same annotation
-/// name. Left unchecked, the generator would emit colliding
-/// function, decoder, and row-type identifiers downstream.
+/// name, or whose names normalize to the same Gleam identifier
+/// (the snake_case `function_name` that queries/params/decoders
+/// are derived from). Either shape would leave the generator
+/// emitting duplicate declarations and fail the Gleam compile.
+/// Literal duplicates are reported first so operators see the
+/// simpler diagnostic when both cases hit at once.
 pub fn validate_no_duplicate_names(
   queries: List(query_ir.TokenizedQuery),
 ) -> Result(Nil, ValidationError) {
-  let grouped =
-    list.group(queries, fn(q) { q.base.name })
-    |> dict.to_list
-    |> list.filter(fn(entry) { list.length(entry.1) > 1 })
-
-  case grouped {
-    [] -> Ok(Nil)
-    [#(name, dupes), ..] -> {
+  case find_duplicate_group(queries, fn(q) { q.base.name }) {
+    Ok(#(name, dupes)) -> {
       let paths =
         dupes
         |> list.map(fn(q) { q.base.source_path })
         |> list.unique
       Error(DuplicateName(name:, paths:))
     }
+    Error(Nil) ->
+      case find_duplicate_group(queries, fn(q) { q.base.function_name }) {
+        Ok(#(function_name, colliding)) -> {
+          let names =
+            colliding |> list.map(fn(q) { q.base.name }) |> list.unique
+          let paths =
+            colliding |> list.map(fn(q) { q.base.source_path }) |> list.unique
+          Error(NormalizedNameCollision(function_name:, names:, paths:))
+        }
+        Error(Nil) -> Ok(Nil)
+      }
   }
+}
+
+fn find_duplicate_group(
+  queries: List(query_ir.TokenizedQuery),
+  key: fn(query_ir.TokenizedQuery) -> String,
+) -> Result(#(String, List(query_ir.TokenizedQuery)), Nil) {
+  list.group(queries, key)
+  |> dict.to_list
+  |> list.find(fn(entry) { list.length(entry.1) > 1 })
 }
 
 /// Reject annotations that are not yet supported by any codegen
@@ -140,6 +163,14 @@ pub fn error_to_string(error: ValidationError) -> String {
       <> name
       <> "\" found in: "
       <> string.join(paths, ", ")
+    NormalizedNameCollision(function_name:, names:, paths:) ->
+      "query names "
+      <> quote_join(names)
+      <> " all normalize to the generated identifier \""
+      <> function_name
+      <> "\" (found in: "
+      <> string.join(paths, ", ")
+      <> "). Rename one of them so the derived function, params, row, and decoder identifiers are unique."
     UnsupportedAnnotation(query_name:, command:, detail:) ->
       "Query " <> query_name <> " uses " <> command <> ": " <> detail
     UnsupportedArrayForEngine(query_name:, engine:) ->
@@ -149,4 +180,10 @@ pub fn error_to_string(error: ValidationError) -> String {
       <> engine
       <> "\". Arrays are only supported with PostgreSQL"
   }
+}
+
+fn quote_join(names: List(String)) -> String {
+  names
+  |> list.map(fn(n) { "\"" <> n <> "\"" })
+  |> string.join(", ")
 }

--- a/test/fixtures/normalized_collision_query.sql
+++ b/test/fixtures/normalized_collision_query.sql
@@ -1,0 +1,9 @@
+-- Two distinct annotation names that both normalize to the
+-- snake_case identifier `get_user`, which would produce
+-- duplicate declarations for get_user / GetUserRow / GetUserParams /
+-- prepare_get_user / get_user_decoder if generation proceeded.
+-- name: GetUser :one
+SELECT id, name FROM authors WHERE id = $1;
+
+-- name: get_user :one
+SELECT id, name FROM authors WHERE name = $1;

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -1645,6 +1645,43 @@ pub fn reject_duplicate_query_names_test() {
   |> should.be_true
 }
 
+pub fn reject_normalized_name_collision_across_cases_test() {
+  // `GetUser` and `get_user` have distinct annotation text but
+  // share the same snake_case `function_name`, which would leave
+  // the generator emitting duplicate `get_user` functions,
+  // `prepare_get_user` helpers, and `GetUser*` types. Generation
+  // must stop before writing files and the error must identify
+  // both conflicting names so operators can rename one of them.
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/normalized_collision_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  let cfg = model.Config(version: 2, sql: [block])
+  let assert Error(error) = generate.generate_config(cfg)
+
+  let message = generate.error_to_string(error)
+  string.contains(message, "normalize to the generated identifier")
+  |> should.be_true
+  string.contains(message, "get_user") |> should.be_true
+  string.contains(message, "GetUser") |> should.be_true
+}
+
 // --- emit_sql_as_comment / emit_exact_table_names coverage ---
 
 pub fn emit_sql_as_comment_includes_sql_in_output_test() {

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -254,6 +254,28 @@ pub fn verify_rejects_duplicate_query_names_test() {
   string.contains(finding.detail, "GetAuthor") |> should.be_true()
 }
 
+pub fn verify_rejects_normalized_name_collision_test() {
+  // Different annotation names that normalize to the same
+  // snake_case `function_name` would produce duplicate Gleam
+  // declarations. `generate` (and therefore `verify`) must
+  // reject the config before it can reach the codegen stage.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/normalized_collision_query.sql",
+        "src/verify_normalized_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "normalize to the generated identifier")
+  |> should.be_true()
+  string.contains(finding.detail, "get_user") |> should.be_true()
+  string.contains(finding.detail, "GetUser") |> should.be_true()
+}
+
 pub fn verify_rejects_unsupported_batch_annotation_test() {
   // :batchmany is not supported by any codegen path. `generate`
   // rejects it; `verify` must surface the same finding so CI


### PR DESCRIPTION
## Summary

`generate` only rejected duplicate query names by the original
annotation text, so two queries whose names normalized to the same
Gleam identifier (e.g. `GetUser` and `get_user` both becoming the
snake_case `get_user`) would pass validation and emit duplicate
function, helper, decoder, and row-type declarations. Generation
now fails before writing files whenever the derived
`function_name` collides across queries.

## Changes

- `src/sqlode/query_validation.gleam`: add a `NormalizedNameCollision` variant alongside `DuplicateName`; `validate_no_duplicate_names` now checks `q.base.name` first, then falls back to grouping by `q.base.function_name` so distinct annotation names that normalize to the same generated identifier surface as their own diagnostic. Shared `error_to_string` lists all conflicting names and source paths.
- `src/sqlode/generate.gleam`: add a matching `NormalizedQueryNameCollision` variant to `GenerateError`, wire it through `wrap_validation_error`, and delegate the rendered message back to `query_validation.error_to_string` so verify and generate stay byte-identical.
- `test/fixtures/normalized_collision_query.sql`: new fixture exercising `GetUser` + `get_user` against the shared authors schema.
- `test/generate_test.gleam`, `test/verify_test.gleam`: regression tests locking in the new rejection from both CLI entry points.

## Design Decisions

PascalCase-derived identifiers (`<Name>Params`, `<Name>Row`) share
the same word-splitting logic as the snake_case `function_name`,
so a collision on `function_name` implies a collision on every
other derived identifier. Checking `function_name` alone is
therefore sufficient to catch every case the issue enumerates,
and keeps the error message focused on the one underlying cause.

Literal annotation duplicates (`DuplicateName`) are reported
before normalized collisions (`NormalizedNameCollision`) so
operators see the simpler diagnostic when both conditions trigger
at once.

Closes #443