### PR TITLE
fix(schema): handle ADD COLUMN IF NOT EXISTS safely

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -633,15 +633,29 @@ fn extract_alter_table_parts(
       lexer.Keyword("add"),
       lexer.Keyword("column"),
       ..rest
-    ] -> #(extract_ident(name_tok), rest)
+    ] -> #(extract_ident(name_tok), strip_if_not_exists(rest))
     [
       lexer.Keyword("alter"),
       lexer.Keyword("table"),
       name_tok,
       lexer.Keyword("add"),
       ..rest
-    ] -> #(extract_ident(name_tok), rest)
+    ] -> #(extract_ident(name_tok), strip_if_not_exists(rest))
     _ -> #("", [])
+  }
+}
+
+/// Skip a leading `IF NOT EXISTS` idempotency modifier on an
+/// ADD COLUMN clause. Without this, the parser would treat `if`
+/// as the column name and fail with a misleading
+/// "missing type for column if" error. The column definition
+/// itself is unchanged by the modifier, so dropping the three
+/// keywords is enough.
+fn strip_if_not_exists(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [lexer.Keyword("if"), lexer.Keyword("not"), lexer.Keyword("exists"), ..rest] ->
+      rest
+    _ -> tokens
   }
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -388,6 +388,39 @@ ALTER TABLE users ADD CONSTRAINT unique_email UNIQUE (email);"
   list.length(table.columns) |> should.equal(2)
 }
 
+pub fn alter_table_add_column_if_not_exists_test() {
+  // Before Issue #448, sqlode treated `if` as the column name and
+  // rejected the common PostgreSQL migration idiom
+  // `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ... ` with a
+  // "missing type for column if" error. The idempotency modifier
+  // is a no-op at parse time: the column should still be added
+  // to the catalog with its declared type and nullability.
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS age INT;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(2)
+  let assert [_, age] = table.columns
+  age.name |> should.equal("age")
+  age.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn alter_table_add_if_not_exists_without_column_keyword_test() {
+  // PostgreSQL accepts `ADD IF NOT EXISTS ...` without the
+  // explicit `COLUMN` keyword. Treat the modifier the same way
+  // in both spellings so migrations that use either form parse.
+  let sql =
+    "CREATE TABLE users (id INTEGER PRIMARY KEY);
+ALTER TABLE users ADD IF NOT EXISTS bio TEXT;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  list.length(table.columns) |> should.equal(2)
+  let assert [_, bio] = table.columns
+  bio.name |> should.equal("bio")
+  bio.scalar_type |> should.equal(model.StringType)
+}
+
 pub fn view_with_count_expression_test() {
   let content =
     "CREATE TABLE authors (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...` — a common
PostgreSQL migration idiom — was parsed as if `if` were the
column name. The generator rejected such schemas with a
misleading `missing type for column if` error instead of
applying the new column. This change treats the `IF NOT EXISTS`
modifier the way every other DDL helper already does: a
semantically neutral prefix that is skipped before the column
definition is parsed.

## Changes

- `src/sqlode/schema_parser.gleam`: after matching the
  `ALTER TABLE ... ADD [COLUMN]` preamble in
  `extract_alter_table_parts`, strip a leading
  `IF NOT EXISTS` keyword triple before handing the remaining
  tokens to `parse_column_tokens`. The existing
  `is_alter_table_add_column_tokens` detector already recognises
  both spellings as ADD-COLUMN statements, so the fix is scoped
  to the token-extraction step.
- `test/schema_parser_test.gleam`: regression tests for both the
  explicit-`COLUMN` spelling (`ADD COLUMN IF NOT EXISTS age INT`)
  and the implicit spelling (`ADD IF NOT EXISTS bio TEXT`).

## Design Decisions

The parser has no side effects to rerun on repeat migrations, so
the idempotency modifier is purely syntactic and can be dropped
before the column definition is parsed. This mirrors the way
`DROP COLUMN IF EXISTS` and top-level `ALTER TABLE IF EXISTS`
are already handled — a local token-level strip rather than a
new statement shape.

Closes #448