### PR TITLE
fix(schema): fail fast on ALTER COLUMN TYPE USING drift

### DIFF
--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -148,8 +148,13 @@ fn parse_content(
                     warnings,
                   ))
                 DDLApplied(action:) -> {
-                  let #(new_tables, new_enums) =
-                    apply_ddl_action(action, tables, current_enums, engine)
+                  use #(new_tables, new_enums) <- result.try(apply_ddl_action(
+                    action,
+                    path,
+                    tables,
+                    current_enums,
+                    engine,
+                  ))
                   Ok(#(new_tables, new_enums, warnings))
                 }
                 Ignored -> Ok(#(tables, current_enums, warnings))
@@ -975,11 +980,26 @@ fn extract_alter_column_name(tokens: List(lexer.Token)) -> String {
 }
 
 /// Extract TYPE tokens from ALTER [COLUMN] <name> [SET DATA] TYPE <tokens>.
+/// Stops at a trailing `USING <expr>` cast clause so the new type
+/// parses cleanly. Without this, the USING keywords would merge into
+/// the rendered type text and every ALTER TYPE with a USING cast
+/// would silently degrade into a parse failure.
 fn extract_alter_type_tokens(tokens: List(lexer.Token)) -> List(lexer.Token) {
   case tokens {
     [] -> []
-    [lexer.Keyword("type"), ..rest] -> rest
+    [lexer.Keyword("type"), ..rest] -> take_until_using(rest, [])
     [_, ..rest] -> extract_alter_type_tokens(rest)
+  }
+}
+
+fn take_until_using(
+  tokens: List(lexer.Token),
+  acc: List(lexer.Token),
+) -> List(lexer.Token) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [lexer.Keyword("using"), ..] -> list.reverse(acc)
+    [tok, ..rest] -> take_until_using(rest, [tok, ..acc])
   }
 }
 
@@ -990,85 +1010,98 @@ fn extract_alter_type_tokens(tokens: List(lexer.Token)) -> List(lexer.Token) {
 /// classification rules as CREATE TABLE.
 fn apply_ddl_action(
   action: DDLAction,
+  path: String,
   tables: List(model.Table),
   enums: List(model.EnumDef),
   engine: model.Engine,
-) -> #(List(model.Table), List(model.EnumDef)) {
+) -> Result(#(List(model.Table), List(model.EnumDef)), ParseError) {
   case action {
-    DropTable(table_name:) -> #(
-      list.filter(tables, fn(t) {
-        string.lowercase(t.name) != string.lowercase(table_name)
-      }),
-      enums,
-    )
-    DropView(view_name:) -> #(
-      list.filter(tables, fn(t) {
-        string.lowercase(t.name) != string.lowercase(view_name)
-      }),
-      enums,
-    )
-    DropType(type_name:) -> #(
-      tables,
-      list.filter(enums, fn(e) {
-        string.lowercase(e.name) != string.lowercase(type_name)
-      }),
-    )
-    AlterDropColumn(table_name:, column_name:) -> #(
-      list.map(tables, fn(t) {
-        case string.lowercase(t.name) == string.lowercase(table_name) {
-          True ->
-            model.Table(
-              ..t,
-              columns: list.filter(t.columns, fn(c) {
-                string.lowercase(c.name) != string.lowercase(column_name)
-              }),
-            )
-          False -> t
-        }
-      }),
-      enums,
-    )
-    AlterRenameTable(old_name:, new_name:) -> #(
-      list.map(tables, fn(t) {
-        case string.lowercase(t.name) == string.lowercase(old_name) {
-          True -> model.Table(..t, name: string.lowercase(new_name))
-          False -> t
-        }
-      }),
-      enums,
-    )
-    AlterRenameColumn(table_name:, old_name:, new_name:) -> #(
-      list.map(tables, fn(t) {
-        case string.lowercase(t.name) == string.lowercase(table_name) {
-          True ->
-            model.Table(
-              ..t,
-              columns: list.map(t.columns, fn(c) {
-                case string.lowercase(c.name) == string.lowercase(old_name) {
-                  True -> model.Column(..c, name: string.lowercase(new_name))
-                  False -> c
-                }
-              }),
-            )
-          False -> t
-        }
-      }),
-      enums,
-    )
+    DropTable(table_name:) ->
+      Ok(#(
+        list.filter(tables, fn(t) {
+          string.lowercase(t.name) != string.lowercase(table_name)
+        }),
+        enums,
+      ))
+    DropView(view_name:) ->
+      Ok(#(
+        list.filter(tables, fn(t) {
+          string.lowercase(t.name) != string.lowercase(view_name)
+        }),
+        enums,
+      ))
+    DropType(type_name:) ->
+      Ok(#(
+        tables,
+        list.filter(enums, fn(e) {
+          string.lowercase(e.name) != string.lowercase(type_name)
+        }),
+      ))
+    AlterDropColumn(table_name:, column_name:) ->
+      Ok(#(
+        list.map(tables, fn(t) {
+          case string.lowercase(t.name) == string.lowercase(table_name) {
+            True ->
+              model.Table(
+                ..t,
+                columns: list.filter(t.columns, fn(c) {
+                  string.lowercase(c.name) != string.lowercase(column_name)
+                }),
+              )
+            False -> t
+          }
+        }),
+        enums,
+      ))
+    AlterRenameTable(old_name:, new_name:) ->
+      Ok(#(
+        list.map(tables, fn(t) {
+          case string.lowercase(t.name) == string.lowercase(old_name) {
+            True -> model.Table(..t, name: string.lowercase(new_name))
+            False -> t
+          }
+        }),
+        enums,
+      ))
+    AlterRenameColumn(table_name:, old_name:, new_name:) ->
+      Ok(#(
+        list.map(tables, fn(t) {
+          case string.lowercase(t.name) == string.lowercase(table_name) {
+            True ->
+              model.Table(
+                ..t,
+                columns: list.map(t.columns, fn(c) {
+                  case string.lowercase(c.name) == string.lowercase(old_name) {
+                    True -> model.Column(..c, name: string.lowercase(new_name))
+                    False -> c
+                  }
+                }),
+              )
+            False -> t
+          }
+        }),
+        enums,
+      ))
     AlterColumnType(table_name:, column_name:, type_tokens:) -> {
       let type_text = render_type_tokens(type_tokens)
-      let new_type = case model.parse_sql_type_for_engine(type_text, engine) {
-        Ok(t) -> Some(t)
-        Error(_) -> None
-      }
-      case new_type {
-        Some(scalar_type) -> #(
-          rewrite_column(tables, table_name, column_name, fn(c) {
-            model.Column(..c, scalar_type:)
-          }),
-          enums,
-        )
-        None -> #(tables, enums)
+      case model.parse_sql_type_for_engine(type_text, engine) {
+        Ok(scalar_type) ->
+          Ok(#(
+            rewrite_column(tables, table_name, column_name, fn(c) {
+              model.Column(..c, scalar_type:)
+            }),
+            enums,
+          ))
+        Error(_) ->
+          Error(InvalidColumn(
+            path:,
+            table: table_name,
+            detail: "ALTER COLUMN \""
+              <> column_name
+              <> "\" TYPE: unsupported or unrecognized type \""
+              <> type_text
+              <> "\". Use a supported SQL type; if this statement should be ignored, remove it from the schema file.",
+          ))
       }
     }
     AlterModifyColumn(table_name:, column_name:, type_tokens:, nullable:) -> {
@@ -1084,7 +1117,7 @@ fn apply_ddl_action(
         rewrite_column(tables, table_name, column_name, fn(c) {
           model.Column(..c, scalar_type:, nullable:)
         })
-      #(updated_tables, new_enums)
+      Ok(#(updated_tables, new_enums))
     }
     AlterChangeColumn(
       table_name:,
@@ -1109,44 +1142,50 @@ fn apply_ddl_action(
             nullable:,
           )
         })
-      #(updated_tables, new_enums)
+      Ok(#(updated_tables, new_enums))
     }
-    AlterColumnSetNotNull(table_name:, column_name:) -> #(
-      list.map(tables, fn(t) {
-        case string.lowercase(t.name) == string.lowercase(table_name) {
-          True ->
-            model.Table(
-              ..t,
-              columns: list.map(t.columns, fn(c) {
-                case string.lowercase(c.name) == string.lowercase(column_name) {
-                  True -> model.Column(..c, nullable: False)
-                  False -> c
-                }
-              }),
-            )
-          False -> t
-        }
-      }),
-      enums,
-    )
-    AlterColumnDropNotNull(table_name:, column_name:) -> #(
-      list.map(tables, fn(t) {
-        case string.lowercase(t.name) == string.lowercase(table_name) {
-          True ->
-            model.Table(
-              ..t,
-              columns: list.map(t.columns, fn(c) {
-                case string.lowercase(c.name) == string.lowercase(column_name) {
-                  True -> model.Column(..c, nullable: True)
-                  False -> c
-                }
-              }),
-            )
-          False -> t
-        }
-      }),
-      enums,
-    )
+    AlterColumnSetNotNull(table_name:, column_name:) ->
+      Ok(#(
+        list.map(tables, fn(t) {
+          case string.lowercase(t.name) == string.lowercase(table_name) {
+            True ->
+              model.Table(
+                ..t,
+                columns: list.map(t.columns, fn(c) {
+                  case
+                    string.lowercase(c.name) == string.lowercase(column_name)
+                  {
+                    True -> model.Column(..c, nullable: False)
+                    False -> c
+                  }
+                }),
+              )
+            False -> t
+          }
+        }),
+        enums,
+      ))
+    AlterColumnDropNotNull(table_name:, column_name:) ->
+      Ok(#(
+        list.map(tables, fn(t) {
+          case string.lowercase(t.name) == string.lowercase(table_name) {
+            True ->
+              model.Table(
+                ..t,
+                columns: list.map(t.columns, fn(c) {
+                  case
+                    string.lowercase(c.name) == string.lowercase(column_name)
+                  {
+                    True -> model.Column(..c, nullable: True)
+                    False -> c
+                  }
+                }),
+              )
+            False -> t
+          }
+        }),
+        enums,
+      ))
   }
 }
 

--- a/test/schema_parser_test.gleam
+++ b/test/schema_parser_test.gleam
@@ -817,6 +817,36 @@ ALTER TABLE users ALTER COLUMN score TYPE TEXT;"
   col2.scalar_type |> should.equal(model.StringType)
 }
 
+pub fn alter_table_alter_column_type_with_using_cast_test() {
+  // Before Issue #447, sqlode rendered the entire
+  // "uuid using id::uuid" token stream as the new type text.
+  // parse_sql_type_for_engine failed, the generator silently
+  // preserved the old `text` type, and `models.gleam` was
+  // wrong without any diagnostic. The type extractor must now
+  // stop at the `USING` keyword so the new type parses.
+  let sql =
+    "CREATE TABLE users (id TEXT NOT NULL);
+ALTER TABLE users ALTER COLUMN id TYPE UUID USING id::uuid;"
+  let assert Ok(#(catalog, _)) = schema_parser.parse_files([#("test.sql", sql)])
+  let assert [table] = catalog.tables
+  let assert [id] = table.columns
+  id.scalar_type |> should.equal(model.UuidType)
+}
+
+pub fn alter_table_alter_column_type_unsupported_fails_fast_test() {
+  // A genuinely unrecognized type must surface a hard error
+  // instead of the prior silent no-op. Operators need to see
+  // the unsupported type name so they can fix the schema
+  // rather than debug a subtly wrong generated model.
+  let sql =
+    "CREATE TABLE users (id TEXT NOT NULL);
+ALTER TABLE users ALTER COLUMN id TYPE nonexistent_type;"
+  let assert Error(error) = schema_parser.parse_files([#("bad.sql", sql)])
+  let msg = schema_parser.error_to_string(error)
+  string.contains(msg, "ALTER COLUMN") |> should.be_true()
+  string.contains(msg, "nonexistent_type") |> should.be_true()
+}
+
 pub fn alter_table_drop_constraint_stays_silent_test() {
   let sql =
     "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL);


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ALTER COLUMN ... TYPE ... USING ...` — a common
PostgreSQL migration shape — previously degraded into a silent
no-op: the full token stream (including the `USING` cast clause)
was fed through `parse_sql_type_for_engine`, failed to match any
known type, and the generator preserved the old catalog type
without any diagnostic. Generated `models.gleam` was wrong and
the user had no signal that the schema change had not been
applied. The parser now isolates the new type correctly and
raises a hard error on any genuinely unrecognized type so
codegen can no longer silently drift from the schema.

## Changes

- `src/sqlode/schema_parser.gleam`
  - `extract_alter_type_tokens` stops at a trailing `USING`
    keyword via a new `take_until_using` helper, so the cast
    expression no longer merges into the rendered type text.
  - `apply_ddl_action` now takes `path` and returns
    `Result(..., ParseError)`. Most branches trivially wrap in
    `Ok`; the `AlterColumnType` branch returns an
    `InvalidColumn` error (identifying the column and the
    offending type text) when `parse_sql_type_for_engine`
    cannot classify the new type.
  - `parse_content` threads the parse error through via
    `result.try`, matching how `apply_alter_table_add_column`
    already propagates errors.
- `test/schema_parser_test.gleam`: regression tests for
  `TEXT → UUID USING id::uuid` (parses cleanly) and an
  unsupported type (fails fast with a diagnostic that names
  both the `ALTER COLUMN` site and the bad type text).

## Design Decisions

Two failure modes share the same surface today: a supported
type hidden behind a `USING` cast, and a genuinely unrecognized
type. The fix addresses both: `USING` is stripped so the
common case parses, and whatever remains must be a real type
or the schema is rejected. Both acceptance criteria in the
issue (support USING *or* fail fast) are met — we do both, and
prefer hard errors to silent catalog drift.

`InvalidColumn` is reused instead of a new variant because the
failure is semantically a column-level type parse error; adding
a variant would have rippled through every `error_to_string`
caller without changing the user-facing message.

Closes #447