### PR TITLE
fix(codegen): wrap strong-mapped raw decoder fields

### DIFF
--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -72,6 +72,7 @@ pub fn render(
         module_path,
         table_matches,
         emit_exact_table_names,
+        gleam.type_mapping,
       ))
       |> string.join("\n\n")
   }
@@ -313,6 +314,7 @@ fn render_decoder_function(
   _module_path: String,
   table_matches: Dict(String, String),
   emit_exact_table_names: Bool,
+  type_mapping_mode: model.TypeMapping,
 ) -> String {
   let type_name = naming.to_pascal_case(naming_ctx, query.base.name) <> "Row"
   let constructor_name = case
@@ -334,10 +336,7 @@ fn render_decoder_function(
         )) -> {
           let field_name = naming.to_snake_case(naming_ctx, name)
           let base =
-            common.render_enum_or_set_decoder(
-              scalar_type,
-              type_mapping.scalar_type_to_decoder(engine, _),
-            )
+            render_raw_base_decoder(engine, scalar_type, type_mapping_mode)
           let decoder = case nullable {
             True -> "decode.optional(" <> base <> ")"
             False -> base
@@ -369,9 +368,10 @@ fn render_decoder_function(
               let #(i, ls) = inner_acc
               let field_name = naming.to_snake_case(naming_ctx, c.name)
               let base =
-                common.render_enum_or_set_decoder(
+                render_raw_base_decoder(
+                  engine,
                   c.scalar_type,
-                  type_mapping.scalar_type_to_decoder(engine, _),
+                  type_mapping_mode,
                 )
               let decoder = case c.nullable {
                 True -> "decode.optional(" <> base <> ")"
@@ -441,6 +441,46 @@ fn render_decoder_function(
     ]),
     "\n",
   )
+}
+
+/// Raw-runtime counterpart of `adapter.gleam`'s `render_base_decoder`.
+/// Under strong type mapping, rich scalar types (TIMESTAMP, DATE,
+/// UUID, etc.) need the decoded primitive wrapped by their generated
+/// `models.<Wrapper>` constructor so the resulting decoder produces
+/// a value the row type can consume. Without this, raw `queries.gleam`
+/// would decode a bare `String` / `Int` and call the row constructor
+/// with a type mismatch — a regression Issue #445 tracks.
+fn render_raw_base_decoder(
+  engine: model.Engine,
+  scalar_type: model.ScalarType,
+  type_mapping_mode: model.TypeMapping,
+) -> String {
+  case scalar_type {
+    model.EnumType(_) | model.SetType(_) ->
+      common.render_enum_or_set_decoder(
+        scalar_type,
+        type_mapping.scalar_type_to_decoder(engine, _),
+      )
+    _ ->
+      case
+        type_mapping_mode == model.StrongMapping
+        && type_mapping.is_rich_type(scalar_type)
+      {
+        True -> {
+          let constructor =
+            type_mapping.scalar_type_to_gleam_type(
+              scalar_type,
+              model.StrongMapping,
+            )
+          "decode.map("
+          <> type_mapping.scalar_type_to_decoder(engine, scalar_type)
+          <> ", models."
+          <> constructor
+          <> ")"
+        }
+        False -> type_mapping.scalar_type_to_decoder(engine, scalar_type)
+      }
+  }
 }
 
 fn render_query_info_literal(query: model.ParsedQuery) -> String {

--- a/test/fixtures/nullable_strong_query.sql
+++ b/test/fixtures/nullable_strong_query.sql
@@ -1,0 +1,2 @@
+-- name: GetItem :one
+SELECT id, external_id FROM items WHERE id = $1;

--- a/test/fixtures/nullable_strong_schema.sql
+++ b/test/fixtures/nullable_strong_schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE items (
+  id UUID NOT NULL,
+  external_id UUID
+);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -446,6 +446,87 @@ pub fn strong_type_mapping_emits_wrapper_types_test() {
   cleanup()
 }
 
+pub fn strong_type_mapping_wraps_raw_decoder_fields_test() {
+  // Before Issue #445, raw `queries.gleam` decoders decoded the
+  // underlying primitive (decode.string for UUID/TIMESTAMP, etc.)
+  // and fed it straight into the row constructor. Under strong
+  // type mapping, the row type expects `models.SqlUuid(String)`
+  // wrapper values, so the generated source failed to type-check.
+  // Raw decoder generation must now mirror the native adapter
+  // path and wrap rich decoders with the strong-type constructor.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/all_types_schema.sql"],
+      queries: ["test/fixtures/all_types_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StrongMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+  let queries = read_generated("queries.gleam")
+
+  // Rich scalar decoders must be wrapped with decode.map(..., models.<Wrapper>).
+  string.contains(queries, "decode.map(decode.string, models.SqlUuid)")
+  |> should.be_true()
+  string.contains(queries, "decode.map(decode.string, models.SqlTimestamp)")
+  |> should.be_true()
+  string.contains(queries, "decode.map(decode.string, models.SqlDate)")
+  |> should.be_true()
+
+  cleanup()
+}
+
+pub fn strong_type_mapping_wraps_nullable_raw_decoder_fields_test() {
+  // Nullable rich scalars must stack decode.optional on top of the
+  // strong-type wrapping (matching adapter.gleam's behaviour), so
+  // the decoder yields `Option(SqlUuid)` for the row constructor.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/nullable_strong_schema.sql"],
+      queries: ["test/fixtures/nullable_strong_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StrongMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+  let queries = read_generated("queries.gleam")
+
+  // Nullable UUID: decode.optional(decode.map(decode.string, models.SqlUuid))
+  string.contains(
+    queries,
+    "decode.optional(decode.map(decode.string, models.SqlUuid))",
+  )
+  |> should.be_true()
+
+  cleanup()
+}
+
 pub fn string_type_mapping_does_not_emit_aliases_test() {
   cleanup()
   let block = base_block(model.empty_overrides())


### PR DESCRIPTION
## Summary

Raw-runtime decoder generation in `queries.gleam` did not honor
`type_mapping: \"strong\"` for rich scalar types. `models.gleam`
correctly emitted wrapper types like `SqlTimestamp` / `SqlDate` /
`SqlUuid`, and the native adapter path already wrapped decoded
primitives with those constructors — but the raw path called
`decode.string` / `decode.int` and fed the bare value straight
into the row constructor, producing type-incompatible generated
code. Raw decoders now mirror the native adapter logic so both
paths produce the same value shape for strong mappings.

## Changes

- `src/sqlode/codegen/queries.gleam`
  - Thread `gleam.type_mapping` through to
    `render_decoder_function` so raw decoder generation can see
    the active mapping mode.
  - Add `render_raw_base_decoder`, the raw-path counterpart of
    `adapter.gleam`'s `render_base_decoder`. Under strong
    mapping it wraps every rich scalar decoder as
    `decode.map(<primitive decoder>, models.<Wrapper>)`, leaving
    enum / set / non-rich decoders unchanged.
  - Use the new helper for both scalar and embedded result
    columns; nullable fields stay wrapped with the existing
    `decode.optional(...)` shell.
- `test/generate_test.gleam`: two regression tests locking in
  (a) strong-mapping rich-scalar wrapping and (b) that nullable
  rich-scalar wrapping stacks `decode.optional` on top of the
  strong-type wrap, matching the native adapter behaviour.
- `test/fixtures/nullable_strong_schema.sql`,
  `test/fixtures/nullable_strong_query.sql`: minimal fixture
  pair with a nullable UUID column for the nullability test.

## Design Decisions

The logic is intentionally a direct mirror of
`adapter.gleam`'s `render_base_decoder`. Sharing a single helper
across the two modules would drag the `AdapterConfig` struct
into the raw path, so we keep a thin raw-specific function that
uses `type_mapping.scalar_type_to_decoder` directly. The shape
of the generated code (`decode.map(<primitive>, models.<Wrapper>)`
wrapped in `decode.optional(...)` for nullable fields) stays
byte-identical to the native path.

Closes #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced code generation for strong type mapping: scalar values are now properly wrapped with their type constructors in generated decoders.
  * Added support for nullable fields in strong type mapping scenarios.

* **Tests**
  * Added test cases validating strong type mapping code generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->