### PR TITLE
fix(codegen): keep strong type helpers for write-only queries

### DIFF
--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -370,7 +370,23 @@ fn collect_rich_scalar_types(
       })
     })
 
-  list.flatten([table_types, query_types])
+  // Params bring their own rich scalars into scope. Without this,
+  // a write-only query (`:exec`) whose table is pruned away by
+  // `omit_unused_models` would reference `SqlUuid` / `SqlTimestamp`
+  // in `params.gleam` / `queries.gleam` without the wrapper types
+  // being emitted from `models.gleam` — the core of Issue #446.
+  let param_types =
+    queries
+    |> list.flat_map(fn(query) {
+      list.filter_map(query.params, fn(p) {
+        case type_mapping.is_rich_type(p.scalar_type) {
+          True -> Ok(p.scalar_type)
+          False -> Error(Nil)
+        }
+      })
+    })
+
+  list.flatten([table_types, query_types, param_types])
   |> list.unique
   |> list.sort(fn(a, b) {
     string.compare(

--- a/test/fixtures/write_only_rich_query.sql
+++ b/test/fixtures/write_only_rich_query.sql
@@ -1,0 +1,2 @@
+-- name: CreateUser :exec
+INSERT INTO users (id, created_at) VALUES ($1, $2);

--- a/test/fixtures/write_only_rich_schema.sql
+++ b/test/fixtures/write_only_rich_schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+  id UUID NOT NULL,
+  created_at TIMESTAMP NOT NULL
+);

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -527,6 +527,99 @@ pub fn strong_type_mapping_wraps_nullable_raw_decoder_fields_test() {
   cleanup()
 }
 
+pub fn omit_unused_models_keeps_strong_wrappers_for_exec_params_test() {
+  // Before Issue #446, `omit_unused_models: true` pruned every
+  // table that no result column referenced. An `:exec` query
+  // with rich scalar params (UUID / TIMESTAMP / ...) would leave
+  // `params.gleam` / `queries.gleam` referencing `models.SqlUuid`
+  // without `models.gleam` emitting the wrapper type — the
+  // generated project was internally inconsistent and failed to
+  // compile. The fix is to thread param rich types through the
+  // wrapper collection so they survive pruning.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/write_only_rich_schema.sql"],
+      queries: ["test/fixtures/write_only_rich_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StrongMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: True,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // models.gleam must still emit the strong wrapper types the
+  // params reference, even though the users table was pruned.
+  string.contains(models, "pub type SqlUuid {\n  SqlUuid(String)\n}")
+  |> should.be_true()
+  string.contains(models, "pub type SqlTimestamp {\n  SqlTimestamp(String)\n}")
+  |> should.be_true()
+
+  // And the unwrap helpers that params.gleam depends on at runtime.
+  string.contains(models, "pub fn sql_uuid_to_string(value: SqlUuid) -> String")
+  |> should.be_true()
+  string.contains(
+    models,
+    "pub fn sql_timestamp_to_string(value: SqlTimestamp) -> String",
+  )
+  |> should.be_true()
+
+  // params.gleam must reference the wrappers (sanity check) so a
+  // regression that stops referring to them is caught here.
+  let params = read_generated("params.gleam")
+  string.contains(params, "models.sql_uuid_to_string(") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn omit_unused_models_keeps_rich_aliases_for_exec_params_test() {
+  // Same shape as above but for `rich` mapping: params.gleam
+  // references the `SqlUuid` / `SqlTimestamp` aliases, and
+  // models.gleam must still emit them after pruning. Under rich
+  // mapping the aliases are `pub type SqlUuid = String` rather
+  // than a wrapper variant, so we assert on that shape.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/write_only_rich_schema.sql"],
+      queries: ["test/fixtures/write_only_rich_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.RichMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: True,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  string.contains(models, "pub type SqlUuid =") |> should.be_true()
+  string.contains(models, "pub type SqlTimestamp =") |> should.be_true()
+
+  cleanup()
+}
+
 pub fn string_type_mapping_does_not_emit_aliases_test() {
   cleanup()
   let block = base_block(model.empty_overrides())


### PR DESCRIPTION
## Summary

`omit_unused_models: true` combined with `rich` / `strong` type
mapping produced internally inconsistent generated output for
write-only queries. The pruning pass dropped every table that
no result column referenced, so an `:exec` query with rich
scalar params (UUID / TIMESTAMP / DATE / JSON) would leave
`params.gleam` and `queries.gleam` referencing
`models.SqlUuid` / `models.SqlTimestamp` while `models.gleam`
no longer emitted those wrapper types. The project failed to
compile with no diagnostic. Rich types from query params are
now collected separately from the catalog, so the wrappers
survive even when their source tables are pruned away.

## Changes

- `src/sqlode/codegen/models.gleam`: extend
  `collect_rich_scalar_types` to walk `query.params` in
  addition to catalog tables and result columns. Param rich
  scalars flow into both `render_semantic_type_aliases`
  (rich mapping) and `render_strong_type_wrappers` (strong
  mapping), so the generated `models.gleam` always emits the
  wrappers/aliases that `params.gleam` and `queries.gleam`
  reference.
- `test/fixtures/write_only_rich_schema.sql`,
  `test/fixtures/write_only_rich_query.sql`: minimal pair
  with `:exec` + UUID / TIMESTAMP params.
- `test/generate_test.gleam`: two regression tests covering
  `omit_unused_models + strong + :exec` (wrapper types, unwrap
  helpers, and `params.gleam` still references them) and
  `omit_unused_models + rich + :exec` (semantic type aliases
  are emitted).

## Design Decisions

Option (A) synthesise the wrapper types directly rather than
Option (B) retaining the underlying table. Retaining the table
would pull in every column of the row type — including columns
the query never touches — which defeats the purpose of
`omit_unused_models`. The collection-extension approach keeps
pruning aggressive while still producing a self-consistent
output; the only thing that changes is the visibility of the
rich scalar wrappers.

Array-of-rich-type params (e.g. `UUID[]`) are still missed
because `type_mapping.is_rich_type` returns `False` for
`ArrayType`. That is a pre-existing limitation shared with the
native adapter decoder path and is out of scope here.

Closes #446