### PR TITLE
fix(codegen): import non-local param types in generated modules

### DIFF
--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -51,10 +51,11 @@ pub fn render_enum_or_set_decoder(
 /// Render a param / record field's Gleam type for generated modules
 /// that are NOT `models.gleam` itself (currently `params.gleam` and
 /// `queries.gleam`). They reach the generated `EnumType` / `SetType`
-/// definitions through a plain `import db/models`, so every external
-/// reference must be qualified with `models.` — the bare names only
-/// work inside `models.gleam` where the types are declared.
-/// `ArrayType` recurses so arrays of enum / set stay qualified.
+/// definitions and rich-scalar aliases / wrappers through a plain
+/// `import db/models`, so every external reference must be qualified
+/// with `models.` — the bare names only work inside `models.gleam`
+/// where the types are declared. `ArrayType` recurses so arrays of
+/// enum / set / rich scalars stay qualified.
 pub fn qualified_field_type(
   scalar_type: model.ScalarType,
   type_mapping_mode: model.TypeMapping,
@@ -67,7 +68,34 @@ pub fn qualified_field_type(
       "List(models." <> type_mapping.set_value_type_name(name) <> ")"
     model.ArrayType(element) ->
       "List(" <> qualified_field_type(element, type_mapping_mode) <> ")"
-    _ -> type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
+    _ ->
+      case needs_models_prefix_for_rich_type(scalar_type, type_mapping_mode) {
+        True ->
+          "models."
+          <> type_mapping.scalar_type_to_gleam_type(
+            scalar_type,
+            type_mapping_mode,
+          )
+        False ->
+          type_mapping.scalar_type_to_gleam_type(scalar_type, type_mapping_mode)
+      }
+  }
+}
+
+/// Rich scalars (`UUID` / `TIMESTAMP` / `DATE` / ...) only acquire a
+/// distinct Gleam type under `rich` / `strong` mapping — the string
+/// mapping keeps them as plain `String`. Under either rich mapping
+/// mode, the resulting type (an alias or a wrapper) lives in
+/// `models.gleam` and must be qualified when referenced from
+/// `params.gleam` / `queries.gleam`.
+fn needs_models_prefix_for_rich_type(
+  scalar_type: model.ScalarType,
+  type_mapping_mode: model.TypeMapping,
+) -> Bool {
+  case type_mapping_mode {
+    model.RichMapping | model.StrongMapping ->
+      type_mapping.is_rich_type(scalar_type)
+    model.StringMapping -> False
   }
 }
 

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -23,8 +23,15 @@ pub fn render(
     common.param_scalar_types(queries)
     |> common.custom_type_imports
 
-  let needs_models_for_strong =
-    type_mapping == model.StrongMapping
+  // Both `strong` and `rich` mappings qualify rich scalars through
+  // `models.<Alias|Wrapper>`. Under `strong` mapping the encoder
+  // also references `models.<type>_to_string(...)` to unwrap values
+  // before handing them to the runtime. Under `rich` mapping the
+  // aliases compile to plain `String` at runtime, but the
+  // `models.` qualifier in the record field types still needs the
+  // module import.
+  let needs_models_for_rich =
+    { type_mapping == model.StrongMapping || type_mapping == model.RichMapping }
     && list.any(queries, fn(q) {
       list.any(q.params, fn(p) { type_mapping.is_rich_type(p.scalar_type) })
     })
@@ -39,7 +46,7 @@ pub fn render(
           False -> []
         },
         ["import gleam/option.{type Option, None, Some}", runtime_import_line],
-        case has_enums || needs_models_for_strong {
+        case has_enums || needs_models_for_rich {
           True -> ["import " <> module_path <> "/models"]
           False -> []
         },
@@ -52,7 +59,7 @@ pub fn render(
           False -> []
         },
         [runtime_import_line],
-        case has_enums || needs_models_for_strong {
+        case has_enums || needs_models_for_rich {
           True -> ["import " <> module_path <> "/models"]
           False -> []
         },

--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -92,6 +92,27 @@ pub fn render(
     }
     || list.any(queries, fn(q) { list.any(q.params, fn(p) { p.nullable }) })
 
+  // Param rich scalars in `prepare_*` signatures flow through
+  // `common.qualified_field_type`, which prefixes them with
+  // `models.`. `queries.gleam` therefore needs the models import
+  // whenever any prepare-helper references a rich scalar, not only
+  // when the file has row-returning decoders.
+  let needs_models_for_rich_params =
+    {
+      gleam.type_mapping == model.StrongMapping
+      || gleam.type_mapping == model.RichMapping
+    }
+    && list.any(queries, fn(q) {
+      list.any(q.params, fn(p) { type_mapping.is_rich_type(p.scalar_type) })
+    })
+
+  // Module-qualified custom types referenced by `prepare_*` need
+  // their own selective `import myapp/types.{type UserId}` line so
+  // the generated signatures compile as written.
+  let custom_imports =
+    common.param_scalar_types(queries)
+    |> common.custom_type_imports
+
   let imports =
     list.flatten([
       case has_slices {
@@ -111,10 +132,11 @@ pub fn render(
         True -> ["import " <> module_path <> "/params"]
         False -> []
       },
-      case has_decoders {
+      case has_decoders || needs_models_for_rich_params {
         True -> ["import " <> module_path <> "/models"]
         False -> []
       },
+      custom_imports,
     ])
 
   string.join(

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -312,6 +312,143 @@ pub fn module_qualified_custom_type_in_params_generates_import_test() {
   cleanup()
 }
 
+pub fn module_qualified_custom_type_in_queries_generates_import_test() {
+  // Before Issue #444, the `prepare_*` helpers emitted signatures
+  // like `pub fn prepare_get_author(id: UserId) -> ...` but
+  // `queries.gleam` only imported `db/models`, never the module
+  // the custom type came from. The generated file did not
+  // compile. `queries.gleam` must emit the same selective
+  // `import myapp/types.{type UserId}` that `params.gleam`
+  // already adds, so the `prepare_*` argument types resolve.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "myapp/types.UserId",
+            nullable: option.None,
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let queries = read_generated("queries.gleam")
+
+  string.contains(queries, "import myapp/types.{type UserId}")
+  |> should.be_true()
+  // prepare_* signatures reference the custom type.
+  string.contains(queries, "id: UserId") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn strong_mapping_qualifies_rich_types_in_params_test() {
+  // Before Issue #444, `params.gleam` emitted record fields like
+  // `id: SqlUuid` under strong mapping even though the file only
+  // imported `db/models`. The compiler rejected those bare names
+  // because `SqlUuid` is declared in `models.gleam`, not in
+  // `params.gleam`. Every reference must now be qualified
+  // through the `models.` prefix so the generated source
+  // compiles without the user writing additional imports.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/write_only_rich_schema.sql"],
+      queries: ["test/fixtures/write_only_rich_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.StrongMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+
+  let params = read_generated("params.gleam")
+  string.contains(params, "id: models.SqlUuid") |> should.be_true()
+  string.contains(params, "created_at: models.SqlTimestamp")
+  |> should.be_true()
+
+  let queries = read_generated("queries.gleam")
+  string.contains(queries, "id: models.SqlUuid") |> should.be_true()
+  string.contains(queries, "created_at: models.SqlTimestamp")
+  |> should.be_true()
+  // queries.gleam needs the models import for `:exec` helpers too,
+  // not only for row decoders.
+  string.contains(queries, "/models") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn rich_mapping_qualifies_rich_types_in_params_test() {
+  // Rich mapping emits plain `pub type SqlUuid = String` aliases,
+  // not wrapper variants, but the alias still lives in
+  // `models.gleam`. `params.gleam` / `queries.gleam` must still
+  // qualify references with `models.` or Gleam cannot resolve
+  // the name.
+  cleanup()
+  let block =
+    model.SqlBlock(
+      name: option.None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/write_only_rich_schema.sql"],
+      queries: ["test/fixtures/write_only_rich_query.sql"],
+      gleam: model.GleamOutput(
+        out: test_out,
+        runtime: model.Raw,
+        type_mapping: model.RichMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  run_generate(block)
+
+  let params = read_generated("params.gleam")
+  string.contains(params, "id: models.SqlUuid") |> should.be_true()
+  string.contains(params, "created_at: models.SqlTimestamp")
+  |> should.be_true()
+
+  let queries = read_generated("queries.gleam")
+  string.contains(queries, "id: models.SqlUuid") |> should.be_true()
+  string.contains(queries, "/models") |> should.be_true()
+
+  cleanup()
+}
+
 pub fn bare_custom_type_omits_module_import_test() {
   cleanup()
   let block =


### PR DESCRIPTION
## Summary

Generated `params.gleam` / `queries.gleam` referenced non-local
types without bringing them into scope. Two shapes were broken:

1. `queries.gleam`'s `prepare_*` helpers used
   module-qualified custom types (`myapp/types.UserId`) as bare
   names without emitting the `import myapp/types.{type UserId}`
   line that `params.gleam` already added.
2. Under `rich` / `strong` type mapping, rich scalars (`SqlUuid`
   / `SqlTimestamp` / ...) were declared inside `models.gleam`
   but referenced as bare names from `params.gleam` /
   `queries.gleam`, which only imported `db/models` (or nothing
   at all for write-only queries). The generator produced code
   that did not compile as written.

Every non-local type reference in `params.gleam` /
`queries.gleam` is now either selectively imported
(module-qualified custom types) or qualified through `models.`
(rich scalars and enum / set types), matching the issue's
expected contract.

## Changes

- `src/sqlode/codegen/common.gleam`: `qualified_field_type`
  now prefixes rich scalars with `models.` when the active
  mapping is `rich` or `strong` (the modes where
  `type_mapping.is_rich_type` yields a distinct type). A new
  `needs_models_prefix_for_rich_type` helper keeps the
  condition readable.
- `src/sqlode/codegen/params.gleam`: rename the former
  `needs_models_for_strong` flag to `needs_models_for_rich`
  and extend it to `RichMapping`, since the `models.` qualifier
  is required in both rich-mapping modes, not only strong.
- `src/sqlode/codegen/queries.gleam`: emit
  `import <module_path>/models` whenever any `prepare_*` helper
  references a rich scalar (previously only emitted for row
  decoders), and carry forward the module-qualified custom-type
  imports from `params.gleam` so the `prepare_*` argument types
  resolve.
- `test/generate_test.gleam`: regression tests for
  module-qualified custom types in `queries.gleam`, strong
  mapping rich-scalar qualification, and rich mapping
  rich-scalar qualification. Each asserts both the import
  lines and the `models.` prefix on the emitted field types.

## Design Decisions

Selective imports for module-qualified custom types keep the
existing ergonomic signature shape (`prepare_foo(id: UserId)`);
for rich scalars the `models.` qualification is preferred
because the type name is sqlode-generated and grouping it under
`models.` makes the origin obvious in generated source.
`qualified_field_type` already has the right shape to decide
this per-scalar, so the change is localised.

Array-of-rich-type params still rely on
`type_mapping.is_rich_type`, which returns `False` for
`ArrayType`. Generated code emits `List(SomeRich)` instead of
`List(models.SomeRich)` for those; that limitation is shared
with the native adapter decoder and is out of scope here.

Closes #444