### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-23
+
+### Changed
+
+- **`verify` and `generate` share one post-parse validation path**
+  (#441, #443). The duplicate-name / unsupported-annotation /
+  array-engine / native-`:execresult` checks now live in a single
+  `sqlode/query_validation` module so `sqlode verify` rejects every
+  config `sqlode generate` would reject — the two commands can no
+  longer drift. `verify` also flags normalized query-name collisions
+  (e.g. `GetUser` and `get_user` both producing the same
+  `get_user` / `GetUserParams` / `GetUserRow` identifiers) before
+  codegen is allowed to emit duplicate Gleam declarations.
+- **`.sql` path expansion shared across commands** (#440). Directory
+  entries for `schema` / `queries` now expand through a shared
+  `sqlode/sql_paths` helper, so `sqlode verify` accepts the same
+  directory-based configs `sqlode generate` already supports and
+  produces the same empty-directory diagnostics.
+- **Release workflow runs glinter** (#442). The tag-driven
+  `release.yml` build job now runs `gleam run -m glinter` alongside
+  format / type-check / test / shellspec, matching `just all` and
+  the PR CI contract. Release artifacts are now validated against
+  the same quality bar contributors are asked to satisfy.
+
+### Fixed
+
+- **`ALTER TABLE ... ADD COLUMN IF NOT EXISTS`** (#448). The
+  idempotency modifier is now stripped before the column definition
+  is parsed, so PostgreSQL migrations that use the common
+  `ADD COLUMN IF NOT EXISTS` (and `ADD IF NOT EXISTS`) forms apply
+  cleanly instead of failing with a misleading
+  `missing type for column if` error.
+- **`ALTER COLUMN ... TYPE ... USING ...` no longer silently drifts**
+  (#447). The new type extractor stops at the trailing `USING`
+  cast clause so `TEXT → UUID USING id::uuid` parses, and a
+  genuinely unrecognized type now surfaces a hard error instead of
+  leaving the old type in the catalog without any diagnostic.
+- **Raw-runtime decoders honor strong type mapping** (#445). Rich
+  scalar decoders (`UUID` / `TIMESTAMP` / `DATE` / ...) are now
+  wrapped as `decode.map(<primitive>, models.<Wrapper>)` so raw
+  `queries.gleam` produces values the strong-mapped row types can
+  consume. Previously the native adapter path wrapped correctly but
+  the raw path decoded bare primitives, producing type-incompatible
+  generated code.
+- **`omit_unused_models` keeps strong / rich helpers for write-only
+  queries** (#446). Param rich scalars are now collected separately
+  from the catalog, so the `SqlUuid` / `SqlTimestamp` wrappers that
+  an `:exec` query references still reach `models.gleam` even when
+  pruning drops the underlying table. `params.gleam` and
+  `queries.gleam` no longer reference types the generated project
+  does not declare.
+- **Non-local param types are always imported or qualified** (#444).
+  Module-qualified custom types (`myapp/types.UserId`) referenced
+  by `prepare_*` helpers now emit the matching selective import in
+  `queries.gleam`, and rich scalars under `rich` / `strong` mapping
+  are prefixed with `models.` everywhere outside `models.gleam`.
+  The generated project compiles as written without user-written
+  follow-up imports.
+
 ## [0.6.0] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest init --engine=sqli
 docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
 ```
 
-The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.6.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
+The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.7.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
 
 ### Initialize config
 

--- a/examples/sqlite-basic/gleam.toml
+++ b/examples/sqlite-basic/gleam.toml
@@ -7,7 +7,7 @@ target = "erlang"
 [dependencies]
 gleam_stdlib = ">= 0.40.0 and < 2.0.0"
 sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = ">= 0.6.0 and < 1.0.0"
+sqlode = ">= 0.7.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.5.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.6.0"
+version = "0.7.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.6.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.7.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.6.0"
+pub const version = "0.7.0"


### PR DESCRIPTION
## Summary

Cut v0.7.0. This release bundles a wave of `verify` / `generate`
parity fixes, codegen-output correctness fixes, schema parser
fixes, and a release-pipeline quality-gate fix — all from the
Project Review Roadmap (#1) sweep.

## Changes

- `CHANGELOG.md`: new `## [0.7.0] - 2026-04-23` section with
  Changed / Fixed groupings for the nine landed PRs (#440–#448).
- `gleam.toml`, `src/sqlode/version.gleam`,
  `examples/sqlite-basic/gleam.toml`,
  `integration_test/warmup/manifest.toml`: bump `0.6.0` → `0.7.0`.
- `README.md`: bump the `docker run --rm ... :0.6.0` pin
  example to `:0.7.0` so the install snippet tracks the
  current release.

## Design Decisions

No code changes in this PR — only the release-prep metadata.
The version bump on `integration_test/warmup/manifest.toml`
keeps the local-path sqlode dependency aligned with
`gleam.toml` so integration tests resolve against the new
version after `gleam deps download`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version bumped to v0.7.0

* **Changed**
  * Consolidated validation behavior in `verify` and `generate` commands
  * Unified SQL path expansion for consistent diagnostics
  * Updated release CI workflow

* **Bug Fixes**
  * PostgreSQL migration idempotency improvements
  * Parser and codegen behavior refinements
  * Type extraction and decoder compatibility corrections
  * Model preservation for unused model filtering
  * Parameter type import enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->