### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-23
+
+### Fixed
+
+- **Placeholder syntax is validated per engine before analysis**
+  (#459). `sqlode verify` / `generate` now reject placeholder styles
+  that do not belong to the configured engine — MySQL `@name` /
+  `:name` / `?N`, PostgreSQL `?` / `:name` / `$name`, etc. — with a
+  diagnostic that names the offending token and lists the accepted
+  forms. Previously the unsupported styles either survived into
+  generated SQL unchanged or surfaced as late, misleading type
+  inference errors.
+- **Wrong-engine UPSERT tails are rejected at parse time** (#460).
+  `ON DUPLICATE KEY UPDATE` under PostgreSQL / SQLite and
+  `ON CONFLICT ... DO UPDATE / NOTHING` under MySQL now fail fast
+  with a clear diagnostic, instead of being silently copied into
+  the generated query. The emitted SQL can no longer disagree with
+  the configured engine.
+- **Sparse SQLite numbered placeholders are rejected** (#461).
+  `?N` indices must now form a contiguous set starting at `?1`, so
+  queries that write `?2` without `?1`, or skip from `?1` to `?3`,
+  are caught before codegen. Previously the parser accepted them
+  while emitting metadata (`param_count`, param layout) that did
+  not honour the declared placeholder indices.
+
 ## [0.7.0] - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest init --engine=sqli
 docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
 ```
 
-The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.7.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
+The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.8.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
 
 ### Initialize config
 

--- a/examples/sqlite-basic/gleam.toml
+++ b/examples/sqlite-basic/gleam.toml
@@ -7,7 +7,7 @@ target = "erlang"
 [dependencies]
 gleam_stdlib = ">= 0.40.0 and < 2.0.0"
 sqlight = ">= 1.0.0 and < 2.0.0"
-sqlode = ">= 0.7.0 and < 1.0.0"
+sqlode = ">= 0.8.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.5.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.7.0"
+version = "0.8.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.7.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -27,6 +27,12 @@ pub type ParseError {
     engine: model.Engine,
     tail: String,
   )
+  SparseNumberedPlaceholders(
+    path: String,
+    line: Int,
+    name: String,
+    indices: List(Int),
+  )
 }
 
 type PendingQuery {
@@ -221,16 +227,26 @@ fn finalize_pending(
                     tail:,
                   ))
                 Ok(Nil) ->
-                  Ok(finalize_ok(
-                    parsed_rev,
-                    name:,
-                    function_name:,
-                    command:,
-                    path:,
-                    tokens:,
-                    macros:,
-                    engine:,
-                  ))
+                  case validate_sqlite_numbered_placeholders(engine, tokens) {
+                    Error(indices) ->
+                      Error(SparseNumberedPlaceholders(
+                        path:,
+                        line: start_line,
+                        name:,
+                        indices:,
+                      ))
+                    Ok(Nil) ->
+                      Ok(finalize_ok(
+                        parsed_rev,
+                        name:,
+                        function_name:,
+                        command:,
+                        path:,
+                        tokens:,
+                        macros:,
+                        engine:,
+                      ))
+                  }
               }
           }
         }
@@ -486,7 +502,23 @@ pub fn error_to_string(error: ParseError) -> String {
       <> model.engine_to_string(engine)
       <> "; "
       <> upsert_hint(engine)
+    SparseNumberedPlaceholders(path:, line:, name:, indices:) ->
+      path
+      <> ":"
+      <> int.to_string(line)
+      <> ": query "
+      <> name
+      <> ": sparse SQLite numbered placeholders "
+      <> format_indices(indices)
+      <> "; numbered placeholders must form a contiguous set starting from ?1 (e.g. ?1, ?2, ?3)"
   }
+}
+
+fn format_indices(indices: List(Int)) -> String {
+  indices
+  |> list.sort(int.compare)
+  |> list.map(fn(i) { "?" <> int.to_string(i) })
+  |> string.join(", ")
 }
 
 fn upsert_hint(engine: model.Engine) -> String {
@@ -560,6 +592,50 @@ fn is_positive_int(s: String) -> Bool {
   case int.parse(s) {
     Ok(n) if n > 0 -> True
     _ -> False
+  }
+}
+
+/// Reject sparse SQLite numbered placeholders.
+///
+/// SQLite accepts `?N` with explicit indices, but sqlode's parameter count
+/// and runtime expansion assume the declared indices form a contiguous set
+/// starting from 1. A query that uses `?2` alone, or `?1` and `?3` with no
+/// `?2`, passes lexing but yields generated metadata that does not match the
+/// SQL text. Flag the mismatch at parse time so users can either renumber
+/// their placeholders or switch to the bare `?` / `?1, ?2, ...` forms.
+fn validate_sqlite_numbered_placeholders(
+  engine: model.Engine,
+  tokens: List(lexer.Token),
+) -> Result(Nil, List(Int)) {
+  case engine {
+    model.SQLite -> {
+      let indices =
+        tokens
+        |> list.filter_map(extract_sqlite_numbered_index)
+        |> list.unique
+      case indices {
+        [] -> Ok(Nil)
+        _ -> {
+          let max_idx = list.fold(indices, 0, int.max)
+          case max_idx == list.length(indices) {
+            True -> Ok(Nil)
+            False -> Error(indices)
+          }
+        }
+      }
+    }
+    _ -> Ok(Nil)
+  }
+}
+
+fn extract_sqlite_numbered_index(token: lexer.Token) -> Result(Int, Nil) {
+  case token {
+    lexer.Placeholder(p) ->
+      case string.first(p), string.length(p) > 1 {
+        Ok("?"), True -> int.parse(string.drop_start(p, 1))
+        _, _ -> Error(Nil)
+      }
+    _ -> Error(Nil)
   }
 }
 

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -13,6 +13,13 @@ import sqlode/runtime
 pub type ParseError {
   InvalidAnnotation(path: String, line: Int, detail: String)
   MissingSql(path: String, line: Int, name: String)
+  InvalidPlaceholder(
+    path: String,
+    line: Int,
+    name: String,
+    engine: model.Engine,
+    token: String,
+  )
 }
 
 type PendingQuery {
@@ -186,34 +193,47 @@ fn finalize_pending(
 
           let macros = list.append(at_macros, expanded_macros)
 
-          // Phase 4: Render expanded token list back to SQL
-          let expanded_sql =
-            lexer.tokens_to_string(
-              tokens,
-              lexer.TokenRenderOptions(
-                uppercase_keywords: False,
-                preserve_quotes: True,
-                engine: Some(engine),
-              ),
-            )
+          // Phase 4: Validate remaining raw placeholders match the engine
+          case validate_placeholder_syntax(engine, tokens) {
+            Error(token) ->
+              Error(InvalidPlaceholder(
+                path:,
+                line: start_line,
+                name:,
+                engine:,
+                token:,
+              ))
+            Ok(Nil) -> {
+              // Phase 5: Render expanded token list back to SQL
+              let expanded_sql =
+                lexer.tokens_to_string(
+                  tokens,
+                  lexer.TokenRenderOptions(
+                    uppercase_keywords: False,
+                    preserve_quotes: True,
+                    engine: Some(engine),
+                  ),
+                )
 
-          // Phase 5: Count parameters from the already-expanded token list
-          let param_count = count_parameters_from_tokens(engine, tokens)
+              // Phase 6: Count parameters from the already-expanded token list
+              let param_count = count_parameters_from_tokens(engine, tokens)
 
-          let parsed =
-            model.ParsedQuery(
-              name:,
-              function_name:,
-              command:,
-              sql: expanded_sql,
-              source_path: path,
-              param_count:,
-              macros:,
-            )
-          Ok([
-            query_ir.TokenizedQuery(base: parsed, tokens: tokens),
-            ..parsed_rev
-          ])
+              let parsed =
+                model.ParsedQuery(
+                  name:,
+                  function_name:,
+                  command:,
+                  sql: expanded_sql,
+                  source_path: path,
+                  param_count:,
+                  macros:,
+                )
+              Ok([
+                query_ir.TokenizedQuery(base: parsed, tokens: tokens),
+                ..parsed_rev
+              ])
+            }
+          }
         }
       }
     }
@@ -410,6 +430,82 @@ pub fn error_to_string(error: ParseError) -> String {
       <> ": query "
       <> name
       <> " is missing SQL body"
+    InvalidPlaceholder(path:, line:, name:, engine:, token:) ->
+      path
+      <> ":"
+      <> int.to_string(line)
+      <> ": query "
+      <> name
+      <> ": placeholder `"
+      <> token
+      <> "` is not valid for engine "
+      <> model.engine_to_string(engine)
+      <> "; "
+      <> allowed_placeholders_hint(engine)
+  }
+}
+
+fn allowed_placeholders_hint(engine: model.Engine) -> String {
+  case engine {
+    model.PostgreSQL ->
+      "PostgreSQL accepts `$N` or sqlode macros (`@name`, `sqlode.arg(name)`)"
+    model.MySQL ->
+      "MySQL accepts positional `?` or sqlode macros (`sqlode.arg(name)`)"
+    model.SQLite ->
+      "SQLite accepts `?`, `?N`, `:name`, `@name`, `$name`, or sqlode macros (`sqlode.arg(name)`)"
+  }
+}
+
+/// Validate that every raw placeholder token matches the configured engine.
+/// Sqlode markers (`__sqlode_param_*` / `__sqlode_slice_*`) are always
+/// accepted because they are produced by macro expansion and are rewritten
+/// to engine-specific placeholders at prepare-time.
+fn validate_placeholder_syntax(
+  engine: model.Engine,
+  tokens: List(lexer.Token),
+) -> Result(Nil, String) {
+  case tokens {
+    [] -> Ok(Nil)
+    [lexer.Placeholder(p), ..rest] ->
+      case is_marker_placeholder(p) || is_valid_raw_placeholder(engine, p) {
+        True -> validate_placeholder_syntax(engine, rest)
+        False -> Error(p)
+      }
+    [_, ..rest] -> validate_placeholder_syntax(engine, rest)
+  }
+}
+
+fn is_valid_raw_placeholder(engine: model.Engine, p: String) -> Bool {
+  case engine {
+    model.PostgreSQL -> is_dollar_numbered(p)
+    model.MySQL -> p == "?"
+    model.SQLite -> is_sqlite_placeholder_syntax(p)
+  }
+}
+
+fn is_dollar_numbered(p: String) -> Bool {
+  case string.starts_with(p, "$") {
+    False -> False
+    True -> is_positive_int(string.drop_start(p, 1))
+  }
+}
+
+fn is_sqlite_placeholder_syntax(p: String) -> Bool {
+  case p {
+    "?" -> True
+    _ ->
+      case string.first(p) {
+        Ok("?") -> is_positive_int(string.drop_start(p, 1))
+        Ok(":") | Ok("@") | Ok("$") -> string.length(p) > 1
+        _ -> False
+      }
+  }
+}
+
+fn is_positive_int(s: String) -> Bool {
+  case int.parse(s) {
+    Ok(n) if n > 0 -> True
+    _ -> False
   }
 }
 

--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -20,6 +20,13 @@ pub type ParseError {
     engine: model.Engine,
     token: String,
   )
+  WrongEngineUpsert(
+    path: String,
+    line: Int,
+    name: String,
+    engine: model.Engine,
+    tail: String,
+  )
 }
 
 type PendingQuery {
@@ -203,41 +210,66 @@ fn finalize_pending(
                 engine:,
                 token:,
               ))
-            Ok(Nil) -> {
-              // Phase 5: Render expanded token list back to SQL
-              let expanded_sql =
-                lexer.tokens_to_string(
-                  tokens,
-                  lexer.TokenRenderOptions(
-                    uppercase_keywords: False,
-                    preserve_quotes: True,
-                    engine: Some(engine),
-                  ),
-                )
-
-              // Phase 6: Count parameters from the already-expanded token list
-              let param_count = count_parameters_from_tokens(engine, tokens)
-
-              let parsed =
-                model.ParsedQuery(
-                  name:,
-                  function_name:,
-                  command:,
-                  sql: expanded_sql,
-                  source_path: path,
-                  param_count:,
-                  macros:,
-                )
-              Ok([
-                query_ir.TokenizedQuery(base: parsed, tokens: tokens),
-                ..parsed_rev
-              ])
-            }
+            Ok(Nil) ->
+              case validate_upsert_tails(engine, tokens) {
+                Error(tail) ->
+                  Error(WrongEngineUpsert(
+                    path:,
+                    line: start_line,
+                    name:,
+                    engine:,
+                    tail:,
+                  ))
+                Ok(Nil) ->
+                  Ok(finalize_ok(
+                    parsed_rev,
+                    name:,
+                    function_name:,
+                    command:,
+                    path:,
+                    tokens:,
+                    macros:,
+                    engine:,
+                  ))
+              }
           }
         }
       }
     }
   }
+}
+
+fn finalize_ok(
+  parsed_rev: List(query_ir.TokenizedQuery),
+  name name: String,
+  function_name function_name: String,
+  command command: runtime.QueryCommand,
+  path path: String,
+  tokens tokens: List(lexer.Token),
+  macros macros: List(model.Macro),
+  engine engine: model.Engine,
+) -> List(query_ir.TokenizedQuery) {
+  let expanded_sql =
+    lexer.tokens_to_string(
+      tokens,
+      lexer.TokenRenderOptions(
+        uppercase_keywords: False,
+        preserve_quotes: True,
+        engine: Some(engine),
+      ),
+    )
+  let param_count = count_parameters_from_tokens(engine, tokens)
+  let parsed =
+    model.ParsedQuery(
+      name:,
+      function_name:,
+      command:,
+      sql: expanded_sql,
+      source_path: path,
+      param_count:,
+      macros:,
+    )
+  [query_ir.TokenizedQuery(base: parsed, tokens: tokens), ..parsed_rev]
 }
 
 fn parse_annotation(
@@ -442,6 +474,28 @@ pub fn error_to_string(error: ParseError) -> String {
       <> model.engine_to_string(engine)
       <> "; "
       <> allowed_placeholders_hint(engine)
+    WrongEngineUpsert(path:, line:, name:, engine:, tail:) ->
+      path
+      <> ":"
+      <> int.to_string(line)
+      <> ": query "
+      <> name
+      <> ": `"
+      <> tail
+      <> "` is not valid for engine "
+      <> model.engine_to_string(engine)
+      <> "; "
+      <> upsert_hint(engine)
+  }
+}
+
+fn upsert_hint(engine: model.Engine) -> String {
+  case engine {
+    model.PostgreSQL ->
+      "use `ON CONFLICT ... DO UPDATE` or `ON CONFLICT ... DO NOTHING`"
+    model.SQLite ->
+      "use `ON CONFLICT ... DO UPDATE` or `ON CONFLICT ... DO NOTHING`"
+    model.MySQL -> "use `ON DUPLICATE KEY UPDATE`"
   }
 }
 
@@ -506,6 +560,32 @@ fn is_positive_int(s: String) -> Bool {
   case int.parse(s) {
     Ok(n) if n > 0 -> True
     _ -> False
+  }
+}
+
+/// Scan tokens for UPSERT tails that do not belong to the configured engine.
+/// MySQL uses `ON DUPLICATE KEY UPDATE`; PostgreSQL and SQLite use `ON
+/// CONFLICT ... DO UPDATE/NOTHING`. Accepting the wrong form silently leaks
+/// dialect-incompatible SQL into generated code, so reject it early with a
+/// diagnostic that names the offending tail.
+fn validate_upsert_tails(
+  engine: model.Engine,
+  tokens: List(lexer.Token),
+) -> Result(Nil, String) {
+  case tokens {
+    [] -> Ok(Nil)
+    [lexer.Keyword("on"), lexer.Ident(word), ..rest] ->
+      case string.lowercase(word), engine {
+        "duplicate", model.MySQL -> validate_upsert_tails(engine, rest)
+        "duplicate", _ -> Error("ON DUPLICATE KEY UPDATE")
+        _, _ -> validate_upsert_tails(engine, rest)
+      }
+    [lexer.Keyword("on"), lexer.Keyword("conflict"), ..rest] ->
+      case engine {
+        model.MySQL -> Error("ON CONFLICT")
+        _ -> validate_upsert_tails(engine, rest)
+      }
+    [_, ..rest] -> validate_upsert_tails(engine, rest)
   }
 }
 

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.7.0"
+pub const version = "0.8.0"

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -73,7 +73,7 @@ pub fn count_sqlite_named_placeholders_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetAuthor :one
-SELECT id FROM authors WHERE id = :id OR name = @name OR slug = $slug OR code = ?2;"
+SELECT id FROM authors WHERE id = :id OR name = @name OR slug = $slug OR code = ?1;"
 
   let assert Ok(queries) =
     parse_file("sqlite.sql", model.SQLite, naming_ctx, content)
@@ -1215,4 +1215,58 @@ ON CONFLICT (id) DO NOTHING;"
     parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
   let assert [query] = queries
   query.name |> should.equal("InsertOrIgnore")
+}
+
+pub fn reject_sparse_numbered_placeholder_for_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id, name FROM authors WHERE id = ?2;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: sparse SQLite numbered placeholders ?2; numbered placeholders must form a contiguous set starting from ?1 (e.g. ?1, ?2, ?3)",
+  )
+}
+
+pub fn reject_gap_in_numbered_placeholders_for_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = ?1 OR name = ?3;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: sparse SQLite numbered placeholders ?1, ?3; numbered placeholders must form a contiguous set starting from ?1 (e.g. ?1, ?2, ?3)",
+  )
+}
+
+pub fn accept_contiguous_numbered_placeholders_for_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = ?1 AND name = ?2;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(2)
+}
+
+pub fn accept_reused_numbered_placeholder_for_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = ?1 OR parent_id = ?1;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(1)
 }

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -273,18 +273,17 @@ UPDATE authors SET bio = @new_bio WHERE id = sqlode.arg(author_id);"
   ])
 }
 
-pub fn at_name_not_expanded_on_mysql_test() {
+pub fn at_name_rejected_on_mysql_test() {
   let naming_ctx = naming.new()
   let content =
     "-- name: GetByName :one
 SELECT id FROM authors WHERE name = @author_name;"
 
-  let assert Ok(queries) =
+  let assert Error(error) =
     parse_file("at.sql", model.MySQL, naming_ctx, content)
-  let assert [query] = queries
-
-  query.macros |> should.equal([])
-  string.contains(query.sql, "@author_name") |> should.be_true()
+  let msg = query_parser.error_to_string(error)
+  string.contains(msg, "@author_name") |> should.be_true()
+  string.contains(msg, "not valid for engine mysql") |> should.be_true()
 }
 
 // Error and boundary tests
@@ -964,4 +963,157 @@ SELECT 2;
   let assert [query] = queries
   query.name |> should.equal("Kept")
   query.command |> should.equal(runtime.QueryMany)
+}
+
+pub fn reject_colon_named_placeholder_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE name = :name;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.MySQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: placeholder `:name` is not valid for engine mysql; MySQL accepts positional `?` or sqlode macros (`sqlode.arg(name)`)",
+  )
+}
+
+pub fn reject_at_named_placeholder_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = @id;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.MySQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: placeholder `@id` is not valid for engine mysql; MySQL accepts positional `?` or sqlode macros (`sqlode.arg(name)`)",
+  )
+}
+
+pub fn reject_numbered_question_placeholder_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = ?1;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.MySQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: placeholder `?1` is not valid for engine mysql; MySQL accepts positional `?` or sqlode macros (`sqlode.arg(name)`)",
+  )
+}
+
+pub fn reject_colon_named_placeholder_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE name = :name;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: placeholder `:name` is not valid for engine postgresql; PostgreSQL accepts `$N` or sqlode macros (`@name`, `sqlode.arg(name)`)",
+  )
+}
+
+pub fn reject_question_placeholder_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = ?;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: placeholder `?` is not valid for engine postgresql; PostgreSQL accepts `$N` or sqlode macros (`@name`, `sqlode.arg(name)`)",
+  )
+}
+
+pub fn reject_dollar_named_placeholder_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE slug = $slug;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query GetAuthor: placeholder `$slug` is not valid for engine postgresql; PostgreSQL accepts `$N` or sqlode macros (`@name`, `sqlode.arg(name)`)",
+  )
+}
+
+pub fn accept_dollar_numbered_placeholder_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = $1 AND name = $2;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(2)
+}
+
+pub fn accept_bare_question_placeholder_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: CreateAuthor :exec
+INSERT INTO authors (name, bio) VALUES (?, ?);"
+
+  let assert Ok(queries) = parse_file("q.sql", model.MySQL, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(2)
+}
+
+pub fn accept_all_sqlite_placeholder_styles_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE id = ?1 OR name = :name OR slug = $slug OR code = ?;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(4)
+}
+
+pub fn accept_sqlode_arg_macro_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetAuthor :one
+SELECT id FROM authors WHERE name = sqlode.arg(author_name);"
+
+  let assert Ok(queries) = parse_file("q.sql", model.MySQL, naming_ctx, content)
+  let assert [query] = queries
+  query.param_count |> should.equal(1)
+}
+
+pub fn reject_placeholder_uses_query_start_line_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "
+
+-- name: GetAuthor :one
+SELECT id FROM authors WHERE name = :name;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.MySQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:3: query GetAuthor: placeholder `:name` is not valid for engine mysql; MySQL accepts positional `?` or sqlode macros (`sqlode.arg(name)`)",
+  )
 }

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -1117,3 +1117,102 @@ SELECT id FROM authors WHERE name = :name;"
     "q.sql:3: query GetAuthor: placeholder `:name` is not valid for engine mysql; MySQL accepts positional `?` or sqlode macros (`sqlode.arg(name)`)",
   )
 }
+
+pub fn reject_on_duplicate_key_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpsertAuthor :exec
+INSERT INTO authors (id, name) VALUES ($1, $2)
+ON DUPLICATE KEY UPDATE name = $2;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query UpsertAuthor: `ON DUPLICATE KEY UPDATE` is not valid for engine postgresql; use `ON CONFLICT ... DO UPDATE` or `ON CONFLICT ... DO NOTHING`",
+  )
+}
+
+pub fn reject_on_duplicate_key_for_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpsertAuthor :exec
+INSERT INTO authors (id, name) VALUES (?1, ?2)
+ON DUPLICATE KEY UPDATE name = ?2;"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query UpsertAuthor: `ON DUPLICATE KEY UPDATE` is not valid for engine sqlite; use `ON CONFLICT ... DO UPDATE` or `ON CONFLICT ... DO NOTHING`",
+  )
+}
+
+pub fn reject_on_conflict_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpsertAuthor :exec
+INSERT INTO authors (id, name) VALUES (sqlode.arg(id), sqlode.arg(name))
+ON CONFLICT (id) DO UPDATE SET name = sqlode.arg(updated_name);"
+
+  let assert Error(error) =
+    parse_file("q.sql", model.MySQL, naming_ctx, content)
+
+  query_parser.error_to_string(error)
+  |> should.equal(
+    "q.sql:1: query UpsertAuthor: `ON CONFLICT` is not valid for engine mysql; use `ON DUPLICATE KEY UPDATE`",
+  )
+}
+
+pub fn accept_on_duplicate_key_for_mysql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpsertAuthor :exec
+INSERT INTO authors (id, name) VALUES (?, ?)
+ON DUPLICATE KEY UPDATE name = VALUES(name);"
+
+  let assert Ok(queries) = parse_file("q.sql", model.MySQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("UpsertAuthor")
+}
+
+pub fn accept_on_conflict_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpsertAuthor :exec
+INSERT INTO authors (id, name) VALUES ($1, $2)
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("UpsertAuthor")
+}
+
+pub fn accept_on_conflict_for_sqlite_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: UpsertAuthor :exec
+INSERT INTO authors (id, name) VALUES (?1, ?2)
+ON CONFLICT(id) DO UPDATE SET name = excluded.name;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.SQLite, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("UpsertAuthor")
+}
+
+pub fn accept_on_conflict_do_nothing_for_postgresql_test() {
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: InsertOrIgnore :exec
+INSERT INTO authors (id, name) VALUES ($1, $2)
+ON CONFLICT (id) DO NOTHING;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [query] = queries
+  query.name |> should.equal("InsertOrIgnore")
+}


### PR DESCRIPTION
## Summary

- Bundle three parser/validation fixes and release as v0.8.0.
- `verify` / `generate` now reject placeholder styles, UPSERT tails, and SQLite numbered placeholders that do not match the configured engine, with diagnostics that name the offending token.

## Changes

- Validate placeholder syntax per engine before analysis (#459)
- Reject wrong-engine UPSERT tails at parse time (#460)
- Reject sparse SQLite numbered placeholders (#461)
- Bump version to 0.8.0 (`gleam.toml`, `version.gleam`, example + integration manifest), refresh README docker tag, and add a `[0.8.0]` section to `CHANGELOG.md`.

## Test plan

- [x] `just all` (format-check, check, build --warnings-as-errors, glinter, 961 tests, integration-prepare, shellspec 24 examples) — all green locally.
- [x] New unit tests for each of the four repro cases from #459, three from #460, and sparse / contiguous / reused cases for #461.

Closes #459
Closes #460
Closes #461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for placeholder syntax against the configured SQL engine, with clear diagnostic messages for incompatible styles.
  * Added validation for UPSERT/ON CONFLICT syntax to ensure compatibility with the selected database engine.
  * Added enforcement of contiguous numbered placeholders for SQLite, rejecting sparse indices before code generation.

* **Chores**
  * Bumped version to 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->