### PR TITLE
fix(codegen): narrow gleam/option imports to what generated files actually use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Generated `params.gleam` no longer imports the unused `None` /
+  `Some` constructors from `gleam/option`; only `type Option` is
+  pulled in (the rendered code only references the type itself).
+  Generated `<engine>_adapter.gleam` now narrows its
+  `gleam/option` import to what the file actually references —
+  `{type Option}` when only nullable params/results force the
+  type, and the full `{type Option, None, Some}` only when at
+  least one query is `:one` / `:batchone` and the wrapper actually
+  emits `Some(row) / None`. Downstream callers running with strict
+  warnings (e.g. glinter `warnings_as_errors = true`, which sqlode
+  itself uses) no longer have to suppress unused-import warnings on
+  `// DO NOT EDIT` files. (#463)
+
 ## [0.8.0] - 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   emits `Some(row) / None`. Downstream callers running with strict
   warnings (e.g. glinter `warnings_as_errors = true`, which sqlode
   itself uses) no longer have to suppress unused-import warnings on
-  `// DO NOT EDIT` files. (#463)
+  `// DO NOT EDIT` files. **Re-run `sqlode generate` to refresh
+  existing `params.gleam` / `<engine>_adapter.gleam` files —
+  previously generated copies still carry the broad import.**
+  (#463)
 
 ## [0.8.0] - 2026-04-23
 

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -1050,6 +1050,10 @@ fn adapter_option_import(queries: List(model.AnalyzedQuery)) -> List(String) {
     False, False -> []
     True, True -> ["import gleam/option.{type Option, None, Some}"]
     True, False -> ["import gleam/option.{type Option}"]
+    // Unreachable today: `adapter_needs_option_type` short-circuits
+    // to True whenever `adapter_query_uses_option_constructors`
+    // does. Kept as a defensive guard so a future refactor that
+    // decouples the two predicates still emits a buildable import.
     False, True -> ["import gleam/option.{None, Some}"]
   }
 }

--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -264,10 +264,7 @@ fn render_adapter(
         False -> []
       },
       ["import gleam/result"],
-      case needs_option_import_for_adapter(queries) {
-        True -> ["import gleam/option.{type Option, None, Some}"]
-        False -> []
-      },
+      adapter_option_import(queries),
       [config.library_import],
       // Every generated adapter now calls `runtime.expand_slice_placeholders`
       // to substitute the placeholder markers emitted by the query parser,
@@ -1036,7 +1033,28 @@ fn render_first_or_default(
   ]
 }
 
-fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {
+/// Emit a `gleam/option` import line tailored to what the generated
+/// adapter actually references. The `Option` type is needed
+/// whenever any param / result column is nullable or whenever any
+/// query is `QueryOne` / `QueryBatchOne` (the wrapper returns
+/// `Option(Row)`); the `None` / `Some` constructors are only
+/// referenced by the `QueryOne` / `QueryBatchOne` row-list match
+/// (`[row, ..] -> Some(row)` / `[] -> None`). Pulling unused
+/// constructors into the import trips `gleam build`'s unused-import
+/// warnings under `warnings_as_errors`, which downstream users
+/// cannot fix because the file is `// DO NOT EDIT`. (#463)
+fn adapter_option_import(queries: List(model.AnalyzedQuery)) -> List(String) {
+  let needs_type = adapter_needs_option_type(queries)
+  let needs_constructors = adapter_needs_option_constructors(queries)
+  case needs_type, needs_constructors {
+    False, False -> []
+    True, True -> ["import gleam/option.{type Option, None, Some}"]
+    True, False -> ["import gleam/option.{type Option}"]
+    False, True -> ["import gleam/option.{None, Some}"]
+  }
+}
+
+fn adapter_needs_option_type(queries: List(model.AnalyzedQuery)) -> Bool {
   list.any(queries, fn(query) {
     let has_nullable_params =
       list.any(query.params, fn(param) { param.nullable })
@@ -1049,10 +1067,17 @@ fn needs_option_import_for_adapter(queries: List(model.AnalyzedQuery)) -> Bool {
             list.any(columns, fn(c) { c.nullable })
         }
       })
-    let has_one_command =
-      query.base.command == runtime.QueryOne
-      || query.base.command == runtime.QueryBatchOne
-
-    has_nullable_params || has_nullable_results || has_one_command
+    has_nullable_params
+    || has_nullable_results
+    || adapter_query_uses_option_constructors(query)
   })
+}
+
+fn adapter_needs_option_constructors(queries: List(model.AnalyzedQuery)) -> Bool {
+  list.any(queries, adapter_query_uses_option_constructors)
+}
+
+fn adapter_query_uses_option_constructors(query: model.AnalyzedQuery) -> Bool {
+  query.base.command == runtime.QueryOne
+  || query.base.command == runtime.QueryBatchOne
 }

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -38,34 +38,25 @@ pub fn render(
 
   let runtime_import_line = "import " <> runtime_import <> ".{type Value}"
 
-  let imports = case needs_option_import(queries) {
-    True ->
-      list.flatten([
-        case has_slices || has_arrays {
-          True -> ["import gleam/list"]
-          False -> []
-        },
-        ["import gleam/option.{type Option}", runtime_import_line],
-        case has_enums || needs_models_for_rich {
-          True -> ["import " <> module_path <> "/models"]
-          False -> []
-        },
-        custom_imports,
-      ])
-    False ->
-      list.flatten([
-        case has_slices || has_arrays {
-          True -> ["import gleam/list"]
-          False -> []
-        },
-        [runtime_import_line],
-        case has_enums || needs_models_for_rich {
-          True -> ["import " <> module_path <> "/models"]
-          False -> []
-        },
-        custom_imports,
-      ])
+  let option_import = case needs_option_import(queries) {
+    True -> ["import gleam/option.{type Option}"]
+    False -> []
   }
+
+  let imports =
+    list.flatten([
+      case has_slices || has_arrays {
+        True -> ["import gleam/list"]
+        False -> []
+      },
+      option_import,
+      [runtime_import_line],
+      case has_enums || needs_models_for_rich {
+        True -> ["import " <> module_path <> "/models"]
+        False -> []
+      },
+      custom_imports,
+    ])
 
   let queries_with_params =
     list.filter(queries, fn(q) { !list.is_empty(q.params) })

--- a/src/sqlode/codegen/params.gleam
+++ b/src/sqlode/codegen/params.gleam
@@ -45,7 +45,7 @@ pub fn render(
           True -> ["import gleam/list"]
           False -> []
         },
-        ["import gleam/option.{type Option, None, Some}", runtime_import_line],
+        ["import gleam/option.{type Option}", runtime_import_line],
         case has_enums || needs_models_for_rich {
           True -> ["import " <> module_path <> "/models"]
           False -> []

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -130,9 +130,14 @@ pub fn render_params_module_imports_only_option_type_test() {
 
   string.contains(rendered, "import gleam/option.{type Option}")
   |> should.be_true()
-  string.contains(rendered, "None")
+  // Negative form: must not pull in the constructors. Asserting
+  // against the import shapes directly (rather than the bare
+  // `None` / `Some` substrings) keeps this robust against future
+  // fixtures whose rendered output legitimately contains those
+  // names in unrelated contexts (column names, docstrings, etc.).
+  string.contains(rendered, "import gleam/option.{type Option, None, Some}")
   |> should.be_false()
-  string.contains(rendered, "Some")
+  string.contains(rendered, "import gleam/option.{None, Some}")
   |> should.be_false()
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -111,6 +111,31 @@ pub fn render_params_module_test() {
   |> should.be_false()
 }
 
+pub fn render_params_module_imports_only_option_type_test() {
+  // params.gleam never uses None / Some in its rendered code, so the
+  // `gleam/option` import must be type-only. A wider import trips
+  // `gleam build`'s unused-import warnings under
+  // `warnings_as_errors`, which downstream users cannot fix because
+  // the file is `// DO NOT EDIT`. Regression test for #463.
+  let naming_ctx = naming.new()
+  let analyzed = analyzed_queries("test/fixtures/macro_edge_cases.sql")
+  let rendered =
+    params.render(
+      naming_ctx,
+      analyzed,
+      model.StringMapping,
+      "db",
+      "sqlode/runtime",
+    )
+
+  string.contains(rendered, "import gleam/option.{type Option}")
+  |> should.be_true()
+  string.contains(rendered, "None")
+  |> should.be_false()
+  string.contains(rendered, "Some")
+  |> should.be_false()
+}
+
 pub fn render_models_module_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()
@@ -282,6 +307,56 @@ pub fn render_params_module_slice_test() {
   // Should import gleam/list
   string.contains(rendered, "import gleam/list")
   |> should.be_true()
+}
+
+pub fn render_pog_adapter_imports_option_constructors_with_query_one_test() {
+  // The fixture's GetAuthor query is `:one`, whose generated wrapper
+  // calls `Some(row)` / `None`. The adapter must therefore import
+  // both the type and the constructors. Regression test for #463.
+  let naming_ctx = naming.new()
+  let block = test_block_native()
+  let analyzed = analyzed_queries("test/fixtures/query.sql")
+  let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
+
+  string.contains(rendered, "import gleam/option.{type Option, None, Some}")
+  |> should.be_true()
+}
+
+pub fn render_pog_adapter_imports_only_option_type_without_query_one_test() {
+  // macro_edge_cases.sql has only `:many` and `:exec` queries (no
+  // `:one`), but its `narg(...)` params make the generated row /
+  // params types reference `Option(...)`. The adapter must import
+  // only the type — emitting `None, Some` would trip the
+  // `// DO NOT EDIT` file's unused-import warnings under
+  // `warnings_as_errors`. Regression test for #463.
+  let naming_ctx = naming.new()
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.PostgreSQL,
+      schema: ["test/fixtures/schema.sql"],
+      queries: ["test/fixtures/macro_edge_cases.sql"],
+      gleam: model.GleamOutput(
+        out: "test_output/db",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+  let analyzed = analyzed_queries("test/fixtures/macro_edge_cases.sql")
+  let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
+
+  string.contains(rendered, "import gleam/option.{type Option}")
+  |> should.be_true()
+  // Negative form: must not pull in the constructors.
+  string.contains(rendered, "import gleam/option.{type Option, None, Some}")
+  |> should.be_false()
 }
 
 pub fn render_pog_adapter_slice_test() {


### PR DESCRIPTION
## Summary

Generated `params.gleam` always imported `None` and `Some` from
`gleam/option` even though the rendered code only references the
`Option` type itself. `gleam build --warnings-as-errors` flagged
both as unused, and downstream callers couldn't fix it because the
file is `// DO NOT EDIT`.

This change scopes the `gleam/option` import emitted by both
`codegen/params.gleam` and `codegen/adapter.gleam` to exactly the
items each file references — `{type Option}` when only the type is
needed, and the full `{type Option, None, Some}` only when the
file actually emits the constructors.

## Changes

- `src/sqlode/codegen/params.gleam`: replace the always-emitted
  `import gleam/option.{type Option, None, Some}` with
  `import gleam/option.{type Option}`. The renderer never produces
  `None` / `Some` literals, so the constructors were unconditionally
  unused.
- `src/sqlode/codegen/adapter.gleam`:
  - Replace the single `needs_option_import_for_adapter`-gated
    line with a new `adapter_option_import` helper that splits the
    decision into \"needs the type\" vs \"needs the constructors\":
    - `:one` / `:batchone` queries are the only ones whose
      generated wrapper emits `Some(row) / None`, so they are the
      only ones that need the constructors.
    - The type is needed whenever any param / result column is
      nullable OR whenever a `:one` / `:batchone` exists (the
      wrapper returns `Option(Row)`).
  - Resulting matrix:
    | needs type | needs ctors | emitted import |
    |---|---|---|
    | false | false | (none) |
    | true  | false | `import gleam/option.{type Option}` |
    | true  | true  | `import gleam/option.{type Option, None, Some}` |
    | false | true  | `import gleam/option.{None, Some}` (defensive; not currently reachable) |
- `test/codegen_test.gleam`:
  - `render_params_module_imports_only_option_type_test` —
    asserts that on a fixture with nullable params (\`narg(...)\`),
    `params.render` emits the type-only import and contains no
    `None` / `Some` token.
  - `render_pog_adapter_imports_option_constructors_with_query_one_test`
    — asserts the existing `query.sql` fixture (which has
    `GetAuthor :one`) keeps the full constructor-bearing import.
  - `render_pog_adapter_imports_only_option_type_without_query_one_test`
    — asserts that `macro_edge_cases.sql` (which is `:many` /
    `:exec` only but uses `narg(...)`) emits the type-only import
    and does not pull in the constructors.
- `CHANGELOG.md`: note the fix under `[Unreleased]` with the rule
  spelled out so future reviewers do not re-broaden the import.

## Design Decisions

- Picked the per-file scoping path (Issue's primary suggestion)
  rather than file-wide glinter ignore rules in downstream
  consumers. The library is the right place to fix this — the
  alternative inverts the meaning of the `// DO NOT EDIT` header
  and pushes a workaround onto every user.
- Kept the existing `needs_option_import_for_adapter` decision
  intact (renamed to `adapter_needs_option_type`) and added a new
  `adapter_needs_option_constructors` predicate alongside it. The
  pair is small enough to keep both as named functions instead of
  inlining; the docstring on `adapter_option_import` explains
  which side surfaces which constructor.
- The `False, True` row of the matrix (\"needs constructors but
  not the type\") is defensively kept in the `case` expression so
  the codegen does not emit a malformed import if a future
  refactor introduces a `Some(...) / None` literal in a path that
  doesn't otherwise touch `Option`. Today this branch is not
  reachable; the comment in the source records that.
- Did not touch `codegen/models.gleam` or `codegen/queries.gleam` —
  both already emit `import gleam/option.{type Option}` only.

## Limitations

- This is a code-generation fix; existing generated files in
  downstream repos still contain the stale broad import until the
  user re-runs `sqlode generate`. The CHANGELOG entry flags the
  one-action remedy.
- No CHANGELOG entry under `### Changed` because the fix is
  strictly subtractive: every file that previously compiled still
  compiles bit-for-bit aside from the trimmed import line.

Closes #463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated adapter and params modules now import only the necessary symbols from `gleam/option`, eliminating unused-import warnings under strict compiler settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->