### PR TITLE
feat(cli): suppress ANSI escapes when stdout is not a TTY or NO_COLOR is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The CLI now emits ANSI escape codes in `--help` output only when
+  stdout is connected to an interactive terminal AND the
+  `NO_COLOR` environment variable is unset (or set to the empty
+  string). `sqlode --help > file.txt`, `sqlode --help | less`, and
+  `NO_COLOR=1 sqlode --help` no longer leak colour control
+  sequences into non-ANSI consumers, matching the convention from
+  <https://no-color.org/> and CLIG. The decision logic is in
+  `cli.decide_color_emission` and is pinned by tests; the BEAM
+  primitives are wrapped in a small `sqlode_ffi.erl` module.
+  (#464)
+
 ### Fixed
 
 - Generated `params.gleam` no longer imports the unused `None` /

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -11,15 +11,54 @@ import sqlode/verify
 import sqlode/version
 
 pub fn app() -> glint.Glint(Nil) {
-  glint.new()
-  |> glint.with_name("sqlode")
-  |> glint.global_help(global_help_text())
-  |> glint.pretty_help(glint.default_pretty_help())
+  let base =
+    glint.new()
+    |> glint.with_name("sqlode")
+    |> glint.global_help(global_help_text())
+
+  let with_styling = case should_emit_color() {
+    True -> base |> glint.pretty_help(glint.default_pretty_help())
+    False -> base
+  }
+
+  with_styling
   |> glint.add(at: ["generate"], do: generate_command())
   |> glint.add(at: ["init"], do: init_command())
   |> glint.add(at: ["verify"], do: verify_command())
   |> glint.add(at: ["version"], do: version_command())
 }
+
+/// Decide whether `--help` output should carry ANSI escape codes.
+/// Wraps the FFI probes for stdout's TTY status and the `NO_COLOR`
+/// environment variable so the policy itself is a small pure
+/// function that the test suite can pin without mocking the BEAM
+/// primitives. See `decide_color_emission` for the rule.
+fn should_emit_color() -> Bool {
+  decide_color_emission(is_stdout_terminal(), no_color_env())
+}
+
+/// Pure decision rule: emit colour iff stdout is connected to a
+/// terminal AND `NO_COLOR` is not set (or is set to the empty
+/// string). Public so the test suite can exercise the policy
+/// without touching the Erlang FFI. See <https://no-color.org/>
+/// and CLIG ("colorize when stdout is a TTY only"). (#464)
+@internal
+pub fn decide_color_emission(
+  is_terminal: Bool,
+  no_color_env: Result(String, Nil),
+) -> Bool {
+  let no_color_active = case no_color_env {
+    Ok(value) -> value != ""
+    Error(Nil) -> False
+  }
+  is_terminal && !no_color_active
+}
+
+@external(erlang, "sqlode_ffi", "is_stdout_terminal")
+fn is_stdout_terminal() -> Bool
+
+@external(erlang, "sqlode_ffi", "no_color_env")
+fn no_color_env() -> Result(String, Nil)
 
 fn global_help_text() -> String {
   "Generate type-safe Gleam code from SQL files using sqlc-style config.

--- a/src/sqlode_ffi.erl
+++ b/src/sqlode_ffi.erl
@@ -1,0 +1,37 @@
+%% Erlang FFI helpers for sqlode.
+%%
+%% These shims bridge Gleam to BEAM primitives that have no portable
+%% Gleam stdlib equivalent. Keep this file small — every function here
+%% should be a thin wrapper that returns a value Gleam already has a
+%% type for.
+-module(sqlode_ffi).
+
+-export([is_stdout_terminal/0, no_color_env/0]).
+
+%% Returns true iff `standard_io` is connected to an interactive
+%% terminal. When stdout is redirected to a file or pipe (as in
+%% `sqlode --help > file.txt` or `sqlode --help | less`), the
+%% `terminal` opt is missing or false. Matches the convention CLI
+%% colorizers use for `isatty(1)` detection.
+is_stdout_terminal() ->
+    case io:getopts(standard_io) of
+        Opts when is_list(Opts) ->
+            proplists:get_value(terminal, Opts, false) =:= true;
+        _ ->
+            false
+    end.
+
+%% Returns `{ok, Value}` (as a Gleam-friendly tagged tuple) when the
+%% NO_COLOR environment variable is set to a non-empty string, and
+%% `{error, nil}` otherwise. Per https://no-color.org/, the variable
+%% being present and non-empty (regardless of value) means "do not
+%% emit colour".
+no_color_env() ->
+    case os:getenv("NO_COLOR") of
+        false ->
+            {error, nil};
+        "" ->
+            {error, nil};
+        Value ->
+            {ok, list_to_binary(Value)}
+    end.

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -228,3 +228,44 @@ pub fn init_mysql_native_runtime_test() {
 
   cleanup("mysql_native")
 }
+
+// --- Color emission policy (#464) -----------------------------------
+//
+// Pin the pure decision rule. The actual TTY / NO_COLOR probes go
+// through Erlang FFI and are environment-dependent; the policy
+// itself must stay deterministic so a regression that flips the
+// boolean (or stops honouring NO_COLOR) fails loudly here.
+
+pub fn decide_color_emission_emits_when_tty_and_no_color_unset_test() {
+  cli.decide_color_emission(True, Error(Nil))
+  |> should.be_true
+}
+
+pub fn decide_color_emission_skips_when_stdout_not_tty_test() {
+  cli.decide_color_emission(False, Error(Nil))
+  |> should.be_false
+}
+
+pub fn decide_color_emission_skips_when_no_color_set_test() {
+  // Per https://no-color.org/, any non-empty NO_COLOR value
+  // suppresses colour, even on an interactive terminal.
+  cli.decide_color_emission(True, Ok("1"))
+  |> should.be_false
+}
+
+pub fn decide_color_emission_skips_when_no_color_set_to_anything_test() {
+  cli.decide_color_emission(True, Ok("yes please"))
+  |> should.be_false
+}
+
+pub fn decide_color_emission_treats_empty_no_color_as_unset_test() {
+  // The convention treats `NO_COLOR=` (empty value) as unset, so
+  // colour stays on if the terminal otherwise allows it.
+  cli.decide_color_emission(True, Ok(""))
+  |> should.be_true
+}
+
+pub fn decide_color_emission_skips_when_both_off_test() {
+  cli.decide_color_emission(False, Ok("1"))
+  |> should.be_false
+}


### PR DESCRIPTION
## Summary

`sqlode --help` emitted ANSI escape codes unconditionally, so
`sqlode --help > file.txt`, `sqlode --help | less`, and
`NO_COLOR=1 sqlode --help` all leaked colour control sequences
into non-ANSI viewers and CI logs. This violates
<https://no-color.org/> and the CLIG \"colorize when stdout is a
TTY only\" convention.

This change makes `app()` install glint's pretty-help only when
stdout is connected to an interactive terminal AND the `NO_COLOR`
environment variable is unset (or empty). Otherwise the CLI runs
without `glint.pretty_help`, so `--help` produces plain text.

## Changes

- `src/sqlode_ffi.erl` (new): two thin wrappers around BEAM
  primitives:
  - `is_stdout_terminal/0` reads `io:getopts(standard_io)` and
    returns `true` only when `terminal => true`. A redirected
    stdout (file, pipe, dev/null) leaves the opt missing and
    returns `false`.
  - `no_color_env/0` reads `os:getenv(\"NO_COLOR\")` and returns
    `{ok, Value}` when present and non-empty, else `{error, nil}`,
    matching the spec at <https://no-color.org/> (the variable
    being present and non-empty — regardless of value — means
    \"do not emit colour\").
- `src/sqlode/cli.gleam`:
  - `app()` builds the base `glint.Glint` without pretty-help, then
    conditionally pipes through `glint.pretty_help(...)` based on
    `should_emit_color()`.
  - `decide_color_emission(is_terminal, no_color_env)` is the pure
    decision rule (`@internal` so the test suite can call it
    without exporting it from the public API).
  - `should_emit_color()` is the impure wrapper that calls the FFI
    probes and forwards their results to `decide_color_emission`.
- `test/cli_test.gleam`: pin the policy with six tests covering
  every axis of the truth table:
  - TTY + no `NO_COLOR` → emit
  - non-TTY → skip
  - TTY + `NO_COLOR=1` → skip
  - TTY + `NO_COLOR=\"yes please\"` → skip (any non-empty value)
  - TTY + `NO_COLOR=\"\"` (empty) → emit (treated as unset)
  - non-TTY + `NO_COLOR=1` → skip (both axes off)
- `CHANGELOG.md`: note the user-visible behaviour change under
  `### Changed`.

## Design Decisions

- Split the policy into a pure `decide_color_emission` function
  and an impure `should_emit_color` wrapper. The pure function is
  what the test suite pins; the impure wrapper just plumbs the FFI
  probes into it. This avoids the typical \"can't unit-test a
  function that reads the environment\" trap.
- Used a small Erlang FFI module rather than pulling
  `gleam/erlang/os` into direct dependencies. Two reasons:
  - The TTY probe (`io:getopts(standard_io)`) has no portable
    Gleam stdlib equivalent today; an FFI shim is required either
    way, so adding a second one for the env var keeps the BEAM
    surface in one file.
  - `gleam_erlang` was already an indirect dependency (via
    `gleescript`); adding a direct dep would commit to its version
    bound for non-test code.
- Treated `NO_COLOR=\"\"` (variable present but empty) as
  \"unset\" per <https://no-color.org/>'s \"any non-empty value\"
  rule. This is what `git`, `ripgrep`, `fd`, and most other
  modern CLIs do.
- Conditional pipe (`case … { True -> base |> glint.pretty_help(...)
  False -> base }`) chosen over a builder mutation because glint's
  `Glint(a)` is opaque — the toggle has to happen at construction
  time, not after.
- Did not touch `cli.execute` or any error-output routing — that's
  Issue #465 and lives in a separate PR.

## Limitations

- The `NO_COLOR` decision happens once at `app()` construction
  time. A user who unsets `NO_COLOR` mid-process and then re-runs
  `--help` in the same Erlang VM would still see the cached
  decision. This matches `gleescript`-launched CLIs in practice
  (each invocation is a fresh VM); not an issue for the actual CLI
  binary.
- The test suite does not cover the FFI probes themselves
  (`is_stdout_terminal/0`, `no_color_env/0`) — those are
  one-call-each shims around BEAM primitives, and exercising them
  requires the test runner's own stdout/env state, which is
  noisy. The pure-function tests fully cover the decision matrix.

Closes #464