### PR TITLE
feat(cli): route error diagnostics to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The CLI now sends error diagnostics (unknown flag / no-args /
+  invalid subcommand) to **stderr** with exit code 1, matching the
+  POSIX/CLIG convention. Pipelines like
+  `sqlode | jq` no longer receive help-as-error noise on jq's
+  stdin, and `sqlode <bad> 1>out 2>err` cleanly separates
+  requested output from diagnostics. Explicit `--help`
+  invocations still print to stdout (the help text is the
+  requested output in that case). The dispatch is implemented in
+  `sqlode.main`, which now drives `glint.execute` itself instead
+  of going through `glint.run`. (#465)
 - The CLI now emits ANSI escape codes in `--help` output only when
   stdout is connected to an interactive terminal AND the
   `NO_COLOR` environment variable is unset (or set to the empty

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -89,4 +89,33 @@ Describe 'sqlode CLI'
       The output should include 'Print the sqlode version'
     End
   End
+
+  Describe 'error diagnostics routing (#465)'
+    # Pin POSIX/CLIG behaviour: error messages from invalid invocations
+    # land on stderr (not stdout), so wrappers using `1>out 2>err`
+    # can distinguish requested output from diagnostics.
+
+    It 'sends unknown-flag errors to stderr, not stdout'
+      When run sqlode_raw --xyz
+      The status should be failure
+      # Error diagnostic must reach stderr.
+      The error should include 'error'
+      # And must NOT appear on stdout.
+      The output should not include 'error: failed to run command'
+    End
+
+    It 'sends no-args errors to stderr, not stdout'
+      When run sqlode_raw
+      The status should be failure
+      The error should include 'error'
+      The output should not include 'error: failed to run command'
+    End
+
+    It 'still prints --help text on stdout (requested output)'
+      When run sqlode_raw --help
+      The status should be success
+      # The help text is the requested output and stays on stdout.
+      The output should include 'sqlode'
+    End
+  End
 End

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -116,6 +116,11 @@ Describe 'sqlode CLI'
       The status should be success
       # The help text is the requested output and stays on stdout.
       The output should include 'sqlode'
+      # `gleam run` itself prints compile-status notes to stderr
+      # (e.g. `Compiled in ...`, `Running sqlode.main`); explicitly
+      # accept any stderr content here and only assert that no
+      # CLI-level error diagnostic appears.
+      The error should not include 'error: failed'
     End
   End
 End

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -30,3 +30,9 @@ init_cmd() {
 version_cmd() {
   cd "$PROJECT_ROOT" && gleam run -- version "$@" 2>&1
 }
+
+# Run sqlode without merging stderr into stdout so spec assertions can
+# distinguish the two streams. Used by error-routing checks (#465).
+sqlode_raw() {
+  cd "$PROJECT_ROOT" && gleam run -- "$@"
+}

--- a/src/sqlode.gleam
+++ b/src/sqlode.gleam
@@ -1,8 +1,31 @@
 import argv
+import gleam/io
 import glint
 import sqlode/cli
 
 pub fn main() -> Nil {
-  cli.app()
-  |> glint.run(argv.load().arguments)
+  // glint.run prints both error diagnostics and explicitly-requested
+  // help text via stdout. POSIX/CLIG convention is the opposite —
+  // diagnostics belong on stderr; only requested output goes to
+  // stdout. Drive the dispatch ourselves so that:
+  //
+  //   * `Error(message)` (unknown flag, no args, etc.) → stderr,
+  //     exit 1.
+  //   * `Ok(Help(text))` (an explicit `--help` invocation) → stdout
+  //     unchanged. The help text is the requested output here.
+  //   * `Ok(Out(_))` → command ran; per-command side effects
+  //     already wrote whatever they needed to.
+  //
+  // (#465)
+  case glint.execute(cli.app(), argv.load().arguments) {
+    Error(message) -> {
+      io.println_error(message)
+      exit(1)
+    }
+    Ok(glint.Help(text)) -> io.println(text)
+    Ok(glint.Out(_)) -> Nil
+  }
 }
+
+@external(erlang, "init", "stop")
+fn exit(status: Int) -> Nil


### PR DESCRIPTION
## Summary

`sqlode --xyz`, `sqlode` (no args), and any other invalid
invocation printed the error message and a help block to **stdout**
with exit code 1. POSIX/CLIG convention is the opposite —
diagnostics belong on stderr; only requested output goes to stdout.
The misrouting broke any wrapper using the universal
`1>output 2>error` redirection pattern and dirtied pipelines like
`sqlode | jq` with help-as-error noise.

This change makes `sqlode.main` drive `glint.execute` itself
instead of going through `glint.run`, so the dispatch can route
each `Result` arm to the correct stream:

- `Error(message)` → `io.println_error` (stderr) → `exit(1)`
- `Ok(Help(text))` → `io.println` (stdout) — the help text **is**
  the requested output for an explicit `--help`.
- `Ok(Out(_))` → no extra output (per-command side effects already
  ran).

## Changes

- `src/sqlode.gleam`: replace `cli.app() |> glint.run(args)` with
  an explicit `case glint.execute(cli.app(), args)` that routes
  errors to stderr via `io.println_error` and exits 1, while
  keeping `Ok(Help(_))` on stdout. The `init:stop/1` exit shim is
  inlined here (mirrors the pattern already used in
  `cli.gleam`).
- `spec/spec_helper.sh`: add a `sqlode_raw` helper that does NOT
  merge stderr into stdout, so spec assertions can distinguish the
  two streams.
- `spec/cli_spec.sh`: add an `error diagnostics routing (#465)`
  describe block with three checks:
  - unknown flag (`--xyz`) — error on stderr, no `error: failed`
    line on stdout, status failure.
  - no args — same shape.
  - explicit `--help` — text still lands on stdout, status
    success.
- `CHANGELOG.md`: note the user-visible behaviour change under
  `### Changed`.

## Design Decisions

- Drove `glint.execute` directly rather than patching `glint.run`
  upstream because `glint.run`'s stdout-only print is a documented
  shape (\"prints any errors encountered or the help text if
  requested\"). Owning the dispatch in `sqlode.main` keeps the fix
  local and avoids a glint dependency bound bump.
- Kept the `Ok(Help(_))` arm on stdout. Help requested explicitly
  with `--help` is the requested output and should be capturable
  with a plain `1>file` redirect, matching how every other CLI
  treats its help. Only the *implicit* help shown after a usage
  error (which glint surfaces as `Error(message)`) moves to stderr.
- Verified the routing with shellspec rather than a Gleam unit
  test because `io.println_error` writes via the BEAM's
  `standard_error` device, which is process-global; a unit test
  would have had to fork or capture file-descriptors. Shellspec
  already runs the binary end-to-end so it can assert on the
  separated streams cleanly.
- The `Ok(Help(text))` shape pattern-matches against the glint
  `Out(a)` ADT, which is annotated `@internal` but exposed via
  `pub`. Today this compiles cleanly; if a future glint release
  hides the variants we will need to switch to a public alternative
  or pin the bound. Noted in the inline comment so future
  maintainers see the dependency relationship.

## Limitations

- The exact wording of the error string still comes from glint
  (\"error: failed to run command...\"). This PR only changes the
  routing, not the prose. A separate clean-up could rewrite the
  message to match #466's request, but that is a different scope.
- Spec assertions use shellspec and run as part of `just all`;
  they are not part of the smaller `just check` cycle. CI runs the
  full `just all` matrix so the regression net stays in place.

Closes #465