### PR TITLE
feat(cli): rewrite generic command-not-found error into class-specific message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The CLI now rewrites the previous misleading
+  `command not found` diagnostic into a class-specific message that
+  names the actual failure mode:
+  - no arguments →
+    `error: missing subcommand. Run 'sqlode --help' to see available
+    commands.`
+  - leading-dash argument (e.g. `--xyz`, `-h`, `--version`) →
+    `error: unrecognized option '<arg>'. Run 'sqlode --help' to see
+    available options.`
+  - non-flag, non-subcommand argument (e.g. `foo`) →
+    `error: unknown subcommand '<arg>'. Run 'sqlode --help' to see
+    available commands.`
+
+  The rewriting is in `sqlode.rewrite_error` and is pinned by tests;
+  errors that did NOT originate from glint's `command not found`
+  path (config-load failures, generate-time errors, etc.) reach the
+  user verbatim. (#466)
 - The CLI now sends error diagnostics (unknown flag / no-args /
   invalid subcommand) to **stderr** with exit code 1, matching the
   POSIX/CLIG convention. Pipelines like

--- a/src/sqlode.gleam
+++ b/src/sqlode.gleam
@@ -1,5 +1,6 @@
 import argv
 import gleam/io
+import gleam/string
 import glint
 import sqlode/cli
 
@@ -16,14 +17,49 @@ pub fn main() -> Nil {
   //   * `Ok(Out(_))` → command ran; per-command side effects
   //     already wrote whatever they needed to.
   //
-  // (#465)
-  case glint.execute(cli.app(), argv.load().arguments) {
+  // For the error path we additionally rewrite glint's generic
+  // `command not found` diagnostic into a class-specific message
+  // (`unrecognized option '--xyz'`, `missing subcommand`, etc.) so
+  // the user sees the actual failure mode instead of a misleading
+  // `127`-style "binary not found" reading. (#465, #466)
+  let args = argv.load().arguments
+  case glint.execute(cli.app(), args) {
     Error(message) -> {
-      io.println_error(message)
+      io.println_error(rewrite_error(args, message))
       exit(1)
     }
     Ok(glint.Help(text)) -> io.println(text)
     Ok(glint.Out(_)) -> Nil
+  }
+}
+
+/// Replace glint's generic `command not found` snag with a
+/// class-specific diagnostic that names the actual failure mode.
+/// Pure so the test suite can pin every branch without spawning
+/// the binary. (#466)
+@internal
+pub fn rewrite_error(args: List(String), original: String) -> String {
+  case string.contains(original, "command not found") {
+    True -> classify_invocation(args)
+    False -> original
+  }
+}
+
+fn classify_invocation(args: List(String)) -> String {
+  case args {
+    [] ->
+      "error: missing subcommand. Run 'sqlode --help' to see available commands."
+    [first, ..] ->
+      case string.starts_with(first, "-") {
+        True ->
+          "error: unrecognized option '"
+          <> first
+          <> "'. Run 'sqlode --help' to see available options."
+        False ->
+          "error: unknown subcommand '"
+          <> first
+          <> "'. Run 'sqlode --help' to see available commands."
+      }
   }
 }
 

--- a/test/entry_test.gleam
+++ b/test/entry_test.gleam
@@ -1,0 +1,73 @@
+//// Tests for the top-level `sqlode.main` error-rewriting helper.
+////
+//// `glint.execute` returns a generic snag-formatted message
+//// (`"failed to run command\n  cause:\n    command not found\n..."`)
+//// for unknown flags, missing subcommands, and unknown subcommands
+//// alike. `sqlode.rewrite_error` classifies those cases and returns
+//// a class-specific message; this file pins the classification so a
+//// regression that broadens or narrows a branch fails loudly. (#466)
+
+import gleam/string
+import gleeunit/should
+import sqlode
+
+const glint_command_not_found = "error: failed to run command
+
+cause:
+  0: command not found
+
+See the following help text, available via the '--help' flag.
+"
+
+pub fn rewrite_error_no_args_says_missing_subcommand_test() {
+  let result = sqlode.rewrite_error([], glint_command_not_found)
+  result
+  |> string.contains("missing subcommand")
+  |> should.be_true
+}
+
+pub fn rewrite_error_long_flag_says_unrecognized_option_test() {
+  let result = sqlode.rewrite_error(["--xyz"], glint_command_not_found)
+  result
+  |> string.contains("unrecognized option '--xyz'")
+  |> should.be_true
+}
+
+pub fn rewrite_error_short_flag_says_unrecognized_option_test() {
+  let result = sqlode.rewrite_error(["-h"], glint_command_not_found)
+  result
+  |> string.contains("unrecognized option '-h'")
+  |> should.be_true
+}
+
+pub fn rewrite_error_version_flag_says_unrecognized_option_test() {
+  // The headline #466 case: `--version` is a flag, not a command.
+  // The previous wording "command not found" was misleading.
+  let result = sqlode.rewrite_error(["--version"], glint_command_not_found)
+  result
+  |> string.contains("unrecognized option '--version'")
+  |> should.be_true
+}
+
+pub fn rewrite_error_unknown_subcommand_says_unknown_subcommand_test() {
+  let result = sqlode.rewrite_error(["foo"], glint_command_not_found)
+  result
+  |> string.contains("unknown subcommand 'foo'")
+  |> should.be_true
+}
+
+pub fn rewrite_error_passes_through_unrelated_messages_test() {
+  // Errors that did NOT originate from glint's "command not found"
+  // path must reach the user verbatim — sqlode does not own their
+  // wording (e.g. config-load failures, generate-time errors).
+  let original = "error: config file not found at /tmp/missing.yaml"
+  sqlode.rewrite_error(["generate"], original)
+  |> should.equal(original)
+}
+
+pub fn rewrite_error_no_args_does_not_call_unrecognized_option_test() {
+  // Negative form: empty args must NOT produce the flag wording.
+  sqlode.rewrite_error([], glint_command_not_found)
+  |> string.contains("unrecognized option")
+  |> should.be_false
+}

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -1,6 +1,7 @@
 import cli_test
 import codegen_test
 import config_test
+import entry_test
 import generate_test
 import gleeunit
 import lexer_test
@@ -857,4 +858,34 @@ pub fn init_does_not_overwrite_existing_stubs_test() {
 
 pub fn version_command_succeeds_test() {
   cli_test.version_command_succeeds_test()
+}
+
+// --- Entry-point error rewriting (#466) ---
+
+pub fn rewrite_error_no_args_says_missing_subcommand_test() {
+  entry_test.rewrite_error_no_args_says_missing_subcommand_test()
+}
+
+pub fn rewrite_error_long_flag_says_unrecognized_option_test() {
+  entry_test.rewrite_error_long_flag_says_unrecognized_option_test()
+}
+
+pub fn rewrite_error_short_flag_says_unrecognized_option_test() {
+  entry_test.rewrite_error_short_flag_says_unrecognized_option_test()
+}
+
+pub fn rewrite_error_version_flag_says_unrecognized_option_test() {
+  entry_test.rewrite_error_version_flag_says_unrecognized_option_test()
+}
+
+pub fn rewrite_error_unknown_subcommand_says_unknown_subcommand_test() {
+  entry_test.rewrite_error_unknown_subcommand_says_unknown_subcommand_test()
+}
+
+pub fn rewrite_error_passes_through_unrelated_messages_test() {
+  entry_test.rewrite_error_passes_through_unrelated_messages_test()
+}
+
+pub fn rewrite_error_no_args_does_not_call_unrecognized_option_test() {
+  entry_test.rewrite_error_no_args_does_not_call_unrecognized_option_test()
 }


### PR DESCRIPTION
## Summary

`sqlode --version`, `sqlode -h`, `sqlode --xyz`, `sqlode foo`, and
`sqlode` (no args) all rendered as glint's generic
`error: failed to run command\ncause:\n  0: command not found\n`
diagnostic. The wording is misleading on every path:

- `--version` is a flag, not a command — saying \"command not
  found\" implies the user passed an unknown subcommand.
- No-args invocations also surfaced as \"command not found\" even
  though no command was attempted.
- The \"failed to run command\" framing reads like a 127-style
  binary-not-found error to anyone skimming logs, even though the
  binary ran fine.

This change rewrites the diagnostic in `sqlode.main` into one of
three class-specific messages that match how `git`, `cargo`, `go`,
and most modern CLIs phrase the same conditions.

## Changes

- `src/sqlode.gleam`:
  - `rewrite_error(args, original)` (`@internal`, pure): if the
    glint message contains `\"command not found\"`, replace it
    based on the args:
    - `[]` → `error: missing subcommand. Run 'sqlode --help' to
      see available commands.`
    - leading-dash arg (e.g. `--xyz`, `-h`, `--version`) →
      `error: unrecognized option '<arg>'. Run 'sqlode --help' to
      see available options.`
    - non-flag arg → `error: unknown subcommand '<arg>'. Run
      'sqlode --help' to see available commands.`
  - Errors that did NOT originate from the `command not found`
    path (config-load failures, generate-time errors) reach the
    user verbatim.
  - `main` now routes `Error(message)` through `rewrite_error`
    before sending it to stderr, building on the dispatch
    introduced in #465.
- `test/entry_test.gleam` (new): seven tests pin every classification
  branch plus the pass-through behaviour. Uses a fixture
  `glint_command_not_found` constant so the rewriter is exercised
  against the actual glint snag format.
- `test/sqlode_test.gleam`: re-export the new tests under the
  project's existing `_test` aggregator pattern.
- `CHANGELOG.md`: note the user-visible message changes under
  `### Changed`, with the exact wording for each branch so future
  reviewers can spot regressions.

## Design Decisions

- Pinned the trigger on the literal substring `\"command not
  found\"` rather than parsing glint's snag tree. The trigger is
  stable across glint versions (a public-API string in
  `glint.gleam:544`) and the substring approach degrades safely:
  if a future glint release rewords it, the rewriter passes the
  original through unchanged rather than producing a wrong
  classification.
- Classified flags by `string.starts_with(\"-\")` rather than
  parsing the actual flag schema. The dash heuristic matches
  every shape glint accepts (`-x`, `-xyz`, `--xyz`, `--xyz=value`)
  and aligns with how POSIX/CLIG describe the syntax. Building a
  schema-aware classifier would require duplicating glint's flag
  parser; not worth the maintenance burden for an error message.
- Made `rewrite_error` `@internal pub` so the test suite can pin
  every branch without exposing the function as public API
  surface.
- Did not add a `--version` alias here. The Issue mentions it as
  an example of misleading wording, not as a request to make
  `--version` work as a flag. That belongs in a separate PR if
  desired (#467 is also CLI-shaped and may share that
  conversation).
- Did not add \"Did you mean ...?\" suggestions for unknown
  subcommands. The Issue lists it as one possible improvement;
  implementing it requires a Levenshtein helper and a list of
  registered subcommands. The class-specific rewording covers the
  primary complaint; spelling suggestions can layer on later.

## Limitations

- Multi-arg invocations like `sqlode foo --bar` are classified by
  the **first** token. The first token is the failing one in the
  glint code path that produces \"command not found\", so the
  classification is accurate; subsequent args are ignored on
  purpose to keep the message short.
- Errors emitted by sqlode subcommands themselves (e.g. `sqlode
  generate --config=missing.yaml`) are NOT rewritten — the
  pass-through branch is exercised by
  `rewrite_error_passes_through_unrelated_messages_test`.

Closes #466