### PR TITLE
fix(cli): drop manual global help block to remove duplicated --help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `sqlode --help` no longer renders the same usage information
+  twice. Previously a manually-authored `global_help` block printed
+  first, followed by glint's auto-generated `USAGE: / SUBCOMMANDS:`
+  layout — same content, two formats. The manual block is
+  removed; glint's auto-generated layout is now the single source
+  of truth, so the two views cannot drift. Per-subcommand help
+  (`sqlode generate --help`, `sqlode init --help`, etc.) continues
+  to use each command's `glint.command_help(...)` block, which
+  already carried the auto-discovery and example details that the
+  removed global block duplicated. (#467)
 - The CLI now rewrites the previous misleading
   `command not found` diagnostic into a class-specific message that
   names the actual failure mode:

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -11,10 +11,17 @@ import sqlode/verify
 import sqlode/version
 
 pub fn app() -> glint.Glint(Nil) {
+  // Help-text source: glint's auto-generated USAGE / SUBCOMMANDS /
+  // FLAGS layout for top-level `--help`, and each command's own
+  // `glint.command_help(...)` block for per-subcommand `--help`.
+  // Previously a manually-authored `global_help` block was layered
+  // on top of the auto-generated one, so `--help` printed the same
+  // information twice in two different layouts. Per #467 we keep the
+  // auto-generated path as the single source of truth so the two
+  // layouts cannot drift.
   let base =
     glint.new()
     |> glint.with_name("sqlode")
-    |> glint.global_help(global_help_text())
 
   let with_styling = case should_emit_color() {
     True -> base |> glint.pretty_help(glint.default_pretty_help())
@@ -59,22 +66,6 @@ fn is_stdout_terminal() -> Bool
 
 @external(erlang, "sqlode_ffi", "no_color_env")
 fn no_color_env() -> Result(String, Nil)
-
-fn global_help_text() -> String {
-  "Generate type-safe Gleam code from SQL files using sqlc-style config.
-
-Usage:
-  sqlode generate [--config=<path>]
-  sqlode verify [--config=<path>]
-  sqlode init [--output=./sqlode.yaml] [--engine=postgresql|sqlite|mysql] [--runtime=raw|native]
-  sqlode version
-
-Without --config, generate/verify auto-discovers sqlode.yaml,
-sqlode.yml, sqlc.yaml, sqlc.yml, or sqlc.json in the current
-directory.
-
-Run `sqlode <command> --help` for details on each command."
-}
 
 /// Candidate config filenames searched, in order, when --config is not
 /// given. The first match wins; if two or more files exist the command


### PR DESCRIPTION
## Summary

`sqlode --help` printed the same usage information twice in two
different layouts: a manually-authored `global_help` block first,
then glint's auto-generated `USAGE: / SUBCOMMANDS:` block right
underneath. A user reading top-to-bottom was presented with the
same content rendered two ways — jarring, and the two layouts
could drift over time as the manual block was edited but the
auto-generated one stayed unchanged (or vice versa).

This change removes the manual `global_help` block and lets glint's
auto-generated layout be the single source of truth. Per-subcommand
`--help` (`sqlode generate --help`, `sqlode init --help`, etc.) is
unaffected — each command's `glint.command_help(...)` text was
already the per-command source and continues to render normally.

## Changes

- `src/sqlode/cli.gleam`:
  - Drop the `glint.global_help(global_help_text())` call from
    `app()`.
  - Delete the now-unused `global_help_text()` function.
  - Add an inline comment in `app()` recording the decision so
    future maintainers do not re-introduce the manual block by
    accident.
- `CHANGELOG.md`: note the user-visible behaviour change under
  `### Changed`.

## Design Decisions

- Picked Issue Option 2 (drop the manual block) over Option 1
  (port the manual content into glint's structured form). Option 1
  would have required rewriting the auto-discovery prose into per-
  subcommand `command_help` text — but every subcommand's
  `command_help` already explains its own auto-discovery semantics
  (see `generate_command()` and `verify_command()` in the same
  file), so the global text was redundant. Option 2 is therefore
  also subtractive at the user-information level, not just at the
  layout level.
- Did NOT touch `glint.pretty_help` — the colouring / TTY check
  introduced in #464 is still the source of truth for whether
  ANSI escapes appear. The duplication being fixed here was about
  *content*, not *colour*.
- Did NOT touch the per-subcommand `glint.command_help(...)` text.
  Each subcommand's manual block is the only source for that
  subcommand's description; removing it would lose information,
  not just deduplicate it. The subcommand `--help` is rendered
  through the same auto-generated layout as the top-level one,
  with the manual `command_help` content surfacing as the
  description.
- The Issue notes glint's example-rendering also collapses
  newlines to spaces in the auto-generated output. That is an
  upstream issue with `glint`'s help-formatting layer (separate
  from the duplication addressed here) and does not block this
  fix; once duplication is gone the formatting issue is the only
  remaining surface concern, and a separate PR (or upstream
  report) can address it without needing to revisit this change.

## Limitations

- The previous global block contained a one-line note pointing
  users at `sqlode <command> --help`. The auto-generated help
  shows `SUBCOMMANDS:` with each name, which serves the same
  purpose; the explicit hint is gone.
- Visual diff for users running `sqlode --help` in their workflow:
  the leading paragraph and `Usage:` / multi-line summary disappear,
  replaced by glint's `USAGE: / SUBCOMMANDS:` layout (which was
  already there underneath).

Closes #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate help display in `sqlode --help` by consolidating to a single auto-generated help view, eliminating redundant information and improving clarity.

* **Documentation**
  * Updated CHANGELOG documenting the streamlined help output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->