### PR TITLE
fix(generate): suffix duplicate param names so generated Gleam compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Generated `params.gleam` and `queries.gleam` no longer emit
+  duplicate record fields, labelled arguments, or labelled
+  constructor calls when one query references the same column
+  twice (e.g. `WHERE x >= ? AND x < ?` for range scans). The
+  second and later occurrences pick up a `_<n>` suffix
+  (`x`, `x_2`, `x_3`, …) so the generated Gleam compiles.
+  Single-occurrence params keep their original names; param order
+  is preserved so placeholder binding stays correct. (#472)
 - Generated `params.gleam` no longer imports the unused `None` /
   `Some` constructors from `gleam/option`; only `type Option` is
   pulled in (the rendered code only references the type itself).

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -143,6 +143,7 @@ fn load_and_analyze_queries(
   use Nil <- result.try(validate_unsupported_annotations(analyzed))
   use Nil <- result.try(validate_array_engine_support(block.engine, analyzed))
   let analyzed = apply_column_renames(analyzed, block.overrides.column_renames)
+  let analyzed = disambiguate_param_names(analyzed)
   Ok(#(queries, analyzed))
 }
 
@@ -634,6 +635,58 @@ fn parse_module_qualified_type(
     Ok(#(module_path, type_name)) -> #(option.Some(module_path), type_name)
     Error(_) -> #(option.None, gleam_type)
   }
+}
+
+/// Disambiguate `field_name` collisions inside each query's params.
+/// `WHERE x >= ? AND x < ?` produces two params both named `x`,
+/// which surfaces in codegen as duplicated record fields and labelled
+/// arguments — neither is valid Gleam. We give the second and later
+/// occurrences a `_<n>` suffix (`x`, `x_2`, `x_3`, …) so the
+/// generated record / function head compiles. Single occurrences are
+/// untouched, so existing queries that reference each column once
+/// keep their names. Public so the test suite can pin the rule
+/// without going through the full generate pipeline. (#472)
+@internal
+pub fn disambiguate_param_names(
+  queries: List(model.AnalyzedQuery),
+) -> List(model.AnalyzedQuery) {
+  list.map(queries, disambiguate_query_params)
+}
+
+fn disambiguate_query_params(query: model.AnalyzedQuery) -> model.AnalyzedQuery {
+  let counts =
+    list.fold(query.params, dict.new(), fn(acc, p) {
+      dict.upsert(acc, p.field_name, fn(prev) {
+        case prev {
+          option.Some(n) -> n + 1
+          option.None -> 1
+        }
+      })
+    })
+
+  let #(_, renamed_reversed) =
+    list.fold(query.params, #(dict.new(), []), fn(acc, p) {
+      let #(seen, out) = acc
+      case dict.get(counts, p.field_name) {
+        Ok(n) if n > 1 -> {
+          let occurrence = case dict.get(seen, p.field_name) {
+            Ok(prev) -> prev + 1
+            Error(_) -> 1
+          }
+          let new_seen = dict.insert(seen, p.field_name, occurrence)
+          let new_name = case occurrence {
+            // First occurrence keeps the original name; later
+            // occurrences pick up the `_<n>` suffix.
+            1 -> p.field_name
+            _ -> p.field_name <> "_" <> int.to_string(occurrence)
+          }
+          let renamed = model.QueryParam(..p, field_name: new_name)
+          #(new_seen, [renamed, ..out])
+        }
+        _ -> #(seen, [p, ..out])
+      }
+    })
+  model.AnalyzedQuery(..query, params: list.reverse(renamed_reversed))
 }
 
 fn apply_column_renames(

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -6,6 +6,7 @@ import simplifile
 import sqlode/config
 import sqlode/generate
 import sqlode/model
+import sqlode/runtime
 
 const test_out = "test_output/generate_test"
 
@@ -2400,4 +2401,114 @@ pub fn sqlite_array_param_rejected_test() {
   let cfg = model.Config(version: 2, sql: [block])
   let _result = generate.generate_config(cfg)
   cleanup()
+}
+
+// --- Param-name disambiguation (#472) ---
+//
+// Pin the rule directly. Going through the full generate pipeline
+// for these would require a fixture schema/query pair per case;
+// disambiguate_param_names is the load-bearing logic and exposing
+// it as `@internal pub` lets every branch get a deterministic test.
+
+fn make_param(field_name: String, index: Int) -> model.QueryParam {
+  model.QueryParam(
+    index: index,
+    field_name: field_name,
+    scalar_type: model.StringType,
+    nullable: False,
+    is_list: False,
+  )
+}
+
+fn make_query(params: List(model.QueryParam)) -> model.AnalyzedQuery {
+  model.AnalyzedQuery(
+    base: model.ParsedQuery(
+      name: "Test",
+      function_name: "test",
+      command: runtime.QueryMany,
+      sql: "",
+      source_path: "fixture.sql",
+      param_count: list.length(params),
+      macros: [],
+    ),
+    params: params,
+    result_columns: [],
+  )
+}
+
+fn field_names(query: model.AnalyzedQuery) -> List(String) {
+  list.map(query.params, fn(p) { p.field_name })
+}
+
+pub fn disambiguate_param_names_keeps_unique_names_test() {
+  let q = make_query([make_param("started_at", 0), make_param("ended_at", 1)])
+  let assert [renamed] = generate.disambiguate_param_names([q])
+  field_names(renamed) |> should.equal(["started_at", "ended_at"])
+}
+
+pub fn disambiguate_param_names_suffixes_duplicate_pair_test() {
+  // The headline #472 case: WHERE x >= ? AND x < ? produces two
+  // params both named `started_at`; the second occurrence must pick
+  // up a `_2` suffix so the generated record / function head is
+  // valid Gleam.
+  let q = make_query([make_param("started_at", 0), make_param("started_at", 1)])
+  let assert [renamed] = generate.disambiguate_param_names([q])
+  field_names(renamed) |> should.equal(["started_at", "started_at_2"])
+}
+
+pub fn disambiguate_param_names_suffixes_three_way_collision_test() {
+  let q =
+    make_query([
+      make_param("x", 0),
+      make_param("x", 1),
+      make_param("x", 2),
+    ])
+  let assert [renamed] = generate.disambiguate_param_names([q])
+  field_names(renamed) |> should.equal(["x", "x_2", "x_3"])
+}
+
+pub fn disambiguate_param_names_only_renames_collisions_test() {
+  // `keep_me` appears once, `dup` appears twice — only the
+  // duplicates should change.
+  let q =
+    make_query([
+      make_param("keep_me", 0),
+      make_param("dup", 1),
+      make_param("dup", 2),
+    ])
+  let assert [renamed] = generate.disambiguate_param_names([q])
+  field_names(renamed) |> should.equal(["keep_me", "dup", "dup_2"])
+}
+
+pub fn disambiguate_param_names_handles_multiple_queries_test() {
+  // Each query is independent — a duplicate in query A must not
+  // change the names of query B's params even if the same
+  // field_name appears.
+  let q1 = make_query([make_param("x", 0), make_param("x", 1)])
+  let q2 = make_query([make_param("x", 0)])
+  let assert [r1, r2] = generate.disambiguate_param_names([q1, q2])
+  field_names(r1) |> should.equal(["x", "x_2"])
+  field_names(r2) |> should.equal(["x"])
+}
+
+pub fn disambiguate_param_names_handles_empty_param_list_test() {
+  let q = make_query([])
+  let assert [renamed] = generate.disambiguate_param_names([q])
+  field_names(renamed) |> should.equal([])
+}
+
+pub fn disambiguate_param_names_preserves_param_order_test() {
+  // The renamer must not reorder params — the indices in
+  // QueryParam.index map to placeholder positions in the SQL string
+  // and reordering would make the call site bind values to the
+  // wrong slots.
+  let q =
+    make_query([
+      make_param("a", 0),
+      make_param("b", 1),
+      make_param("a", 2),
+      make_param("b", 3),
+    ])
+  let assert [renamed] = generate.disambiguate_param_names([q])
+  field_names(renamed) |> should.equal(["a", "b", "a_2", "b_2"])
 }

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -889,3 +889,33 @@ pub fn rewrite_error_passes_through_unrelated_messages_test() {
 pub fn rewrite_error_no_args_does_not_call_unrecognized_option_test() {
   entry_test.rewrite_error_no_args_does_not_call_unrecognized_option_test()
 }
+
+// --- Param-name disambiguation (#472) ---
+
+pub fn disambiguate_param_names_keeps_unique_names_test() {
+  generate_test.disambiguate_param_names_keeps_unique_names_test()
+}
+
+pub fn disambiguate_param_names_suffixes_duplicate_pair_test() {
+  generate_test.disambiguate_param_names_suffixes_duplicate_pair_test()
+}
+
+pub fn disambiguate_param_names_suffixes_three_way_collision_test() {
+  generate_test.disambiguate_param_names_suffixes_three_way_collision_test()
+}
+
+pub fn disambiguate_param_names_only_renames_collisions_test() {
+  generate_test.disambiguate_param_names_only_renames_collisions_test()
+}
+
+pub fn disambiguate_param_names_handles_multiple_queries_test() {
+  generate_test.disambiguate_param_names_handles_multiple_queries_test()
+}
+
+pub fn disambiguate_param_names_handles_empty_param_list_test() {
+  generate_test.disambiguate_param_names_handles_empty_param_list_test()
+}
+
+pub fn disambiguate_param_names_preserves_param_order_test() {
+  generate_test.disambiguate_param_names_preserves_param_order_test()
+}


### PR DESCRIPTION
## Summary

A query that referenced the same column twice — e.g.
`WHERE started_at >= ? AND started_at < ?` for a date-range scan —
generated a `prepare_*` function head and a params record that both
declared the same field name twice. Neither shape is valid Gleam:

```gleam
pub fn prepare_list_entries(started_at: String, started_at: String) -> ...
pub type ListEntriesParams {
  ListEntriesParams(started_at: String, started_at: String)
}
```

`gleam run -m sqlode -- generate` succeeded but `gleam build`
immediately rejected the output, forcing the user to rewrite the
SQL around `BETWEEN` (which has its own SQLite type-inference
problem — see #473) or split the query into two.

This change disambiguates duplicate `field_name`s inside each
analyzed query right after `apply_column_renames`. Single
occurrences are untouched; the second and later occurrences pick up
a `_<n>` suffix (`x`, `x_2`, `x_3`, …). Param order is preserved so
SQL placeholder binding stays correct.

## Changes

- `src/sqlode/generate.gleam`:
  - Add `disambiguate_param_names(queries)` (`@internal pub`) that
    walks each query's params, counts `field_name` occurrences,
    and suffixes the second-and-later ones.
  - Wire it into `load_and_analyze_queries` immediately after the
    existing `apply_column_renames` call so every code-generation
    path (params, queries, adapter) sees the deduplicated field
    names without each one needing its own dedup logic.
- `test/generate_test.gleam`:
  - Add seven unit tests covering: unique names untouched, the
    headline two-way collision, three-way collision, mixed
    unique/duplicate, multi-query independence, empty params,
    order preservation. Each constructs `AnalyzedQuery` values
    directly so the rule is pinned without going through the full
    schema/query parsing pipeline.
- `test/sqlode_test.gleam`: re-export the seven tests under the
  project's `_test` aggregator pattern.
- `CHANGELOG.md`: note the user-visible fix under `### Fixed`.
- New `import sqlode/runtime` in `generate_test.gleam` to construct
  the test fixture's `runtime.QueryMany` command.

## Design Decisions

- Disambiguated at the analyzer-output level (in
  `load_and_analyze_queries`) rather than per-codegen-template.
  `params.gleam`, `queries.gleam`, and `adapter.gleam` all read
  `param.field_name`; running the dedup once at the boundary keeps
  the three templates from drifting and keeps each template's
  rendering logic unchanged.
- Suffix scheme: `<name>_<n>` starting at `_2` for the second
  occurrence. This matches the convention `gleam format` itself
  uses for shadowed-binding rename suggestions and reads better
  than `param1` / `param2` (which would lose the connection to the
  source column). It also leaves the first occurrence's name
  untouched — the common case of a single param keeps its
  user-visible identifier verbatim.
- Did not de-duplicate by SQL placeholder index (`?N` style) for
  two reasons:
  - Engines that use named placeholders (`:name`, `@name`,
    `$name`) genuinely repeat the **same** placeholder; deduping
    by SQL position would name them differently when they refer
    to the same value, breaking call ergonomics.
  - The collision the user actually hits is at the Gleam record /
    function-head level, which is what `field_name` represents.
- Test fixture path: chose unit tests over end-to-end fixture
  files because each end-to-end case would need its own
  schema/query pair plus a build assertion. The pure
  `disambiguate_param_names` function is the load-bearing logic;
  exposing it as `@internal pub` lets every branch get a
  deterministic test without the fixture proliferation.

## Limitations

- The renaming preserves order but does not preserve any semantic
  hint about which range bound is which (`_lo` / `_hi`). A user
  who wants meaningful names can rename the columns at the SQL
  level (e.g. introduce a CTE that aliases the column twice) —
  this PR fixes the compilation bug; a richer naming heuristic is
  out of scope.
- Existing call sites built against pre-fix generated code that
  manually worked around the bug (renaming columns at the SQL
  layer, splitting queries) keep working; the suffix only appears
  for newly-regenerated code that triggers a real collision.

Closes #472