### PR TITLE
fix(analyzer)!: tailor type-inference error placeholder and cast hint to engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   primitives are wrapped in a small `sqlode_ffi.erl` module.
   (#464)
 
+### Changed
+
+- **BREAKING**: `query_analyzer.analysis_error_to_string` now
+  takes a second `engine: model.Engine` argument so the rendered
+  message is tailored to the configured engine. Placeholder
+  references and cast-syntax hints both follow the engine's
+  dialect:
+  - PostgreSQL — `$N` references, `$N::int` cast suggestion
+    (unchanged from before).
+  - SQLite — `?N` references, `CAST(? AS INTEGER)` cast suggestion.
+  - MySQL — `?N` references, `CAST(? AS SIGNED)` cast suggestion.
+
+  Prior to this change every error referenced `$N` and suggested
+  `$N::int` regardless of the engine, which produced parser errors
+  in SQLite / MySQL when the user followed the hint as-is. Internal
+  callers (`generate.gleam`, `verify.gleam`) are migrated; library
+  consumers calling `analysis_error_to_string` directly need to add
+  the engine argument. (#473)
+
 ### Fixed
 
 - Generated `params.gleam` and `queries.gleam` no longer emit

--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -137,7 +137,10 @@ fn load_and_analyze_queries(
   use analyzed <- result.try(
     query_analyzer.analyze_queries(block.engine, catalog, naming_ctx, queries)
     |> result.map_error(fn(error) {
-      QueryAnalysisError(detail: query_analyzer.analysis_error_to_string(error))
+      QueryAnalysisError(detail: query_analyzer.analysis_error_to_string(
+        error,
+        block.engine,
+      ))
     }),
   )
   use Nil <- result.try(validate_unsupported_annotations(analyzed))

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -17,8 +17,11 @@ import sqlode/query_ir
 pub type AnalysisError =
   context.AnalysisError
 
-pub fn analysis_error_to_string(error: AnalysisError) -> String {
-  context.analysis_error_to_string(error)
+pub fn analysis_error_to_string(
+  error: AnalysisError,
+  engine: model.Engine,
+) -> String {
+  context.analysis_error_to_string(error, engine)
 }
 
 pub fn analyze_queries(

--- a/src/sqlode/query_analyzer/context.gleam
+++ b/src/sqlode/query_analyzer/context.gleam
@@ -29,7 +29,17 @@ pub type AnalysisError {
   )
 }
 
-pub fn analysis_error_to_string(error: AnalysisError) -> String {
+/// Render an `AnalysisError` as a user-facing message tailored to
+/// `engine`. Placeholder references and cast-syntax hints both
+/// follow the configured engine's dialect — `$1` / `$1::int` for
+/// PostgreSQL, `?1` / `CAST(? AS INTEGER)` for SQLite, `?1` /
+/// `CAST(? AS SIGNED)` for MySQL — so the suggested fix in the
+/// error message is something the user can paste into their query
+/// without further translation. (#473)
+pub fn analysis_error_to_string(
+  error: AnalysisError,
+  engine: model.Engine,
+) -> String {
   case error {
     TableNotFound(query_name:, table_name:) ->
       "Query \""
@@ -48,18 +58,17 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
     ParameterTypeNotInferred(query_name:, param_index:) ->
       "Query \""
       <> query_name
-      <> "\": could not infer type for parameter $"
-      <> int.to_string(param_index)
-      <> ". Use a type cast (e.g. $"
-      <> int.to_string(param_index)
-      <> "::int) to specify the type"
+      <> "\": could not infer type for parameter "
+      <> placeholder_label(engine, param_index)
+      <> ". "
+      <> cast_hint(engine, param_index)
     UnrecognizedCastType(query_name:, param_index:, cast_type:) ->
       "Query \""
       <> query_name
       <> "\": unrecognized cast type \""
       <> cast_type
-      <> "\" for parameter $"
-      <> int.to_string(param_index)
+      <> "\" for parameter "
+      <> placeholder_label(engine, param_index)
     CompoundColumnCountMismatch(query_name:, first_count:, branch_count:) ->
       "Query \""
       <> query_name
@@ -70,8 +79,8 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
     ParameterTypeConflict(query_name:, param_index:, type_a:, type_b:) ->
       "Query \""
       <> query_name
-      <> "\": parameter $"
-      <> int.to_string(param_index)
+      <> "\": parameter "
+      <> placeholder_label(engine, param_index)
       <> " has conflicting inferred types \""
       <> scalar_type_label(type_a)
       <> "\" and \""
@@ -91,6 +100,33 @@ pub fn analysis_error_to_string(error: AnalysisError) -> String {
       <> "\" is ambiguous — found in tables: "
       <> string.join(matching_tables, ", ")
       <> ". Use a table qualifier (e.g. table.column) to resolve the ambiguity"
+  }
+}
+
+/// Engine-specific user-facing placeholder reference, e.g. `$1` for
+/// PostgreSQL, `?1` for SQLite / MySQL. The 1-based positional form
+/// `?N` is used for the latter two so the message points at a
+/// specific parameter even though MySQL's wire-level placeholder is
+/// the bare `?`. SQLite accepts `?N` natively.
+fn placeholder_label(engine: model.Engine, idx: Int) -> String {
+  case engine {
+    model.PostgreSQL -> "$" <> int.to_string(idx)
+    model.SQLite -> "?" <> int.to_string(idx)
+    model.MySQL -> "?" <> int.to_string(idx)
+  }
+}
+
+/// Engine-specific cast-syntax hint. The placeholder shown inside
+/// the hint matches the engine's dialect so the user can copy the
+/// suggestion verbatim into their query.
+fn cast_hint(engine: model.Engine, idx: Int) -> String {
+  case engine {
+    model.PostgreSQL ->
+      "Use a type cast (e.g. $"
+      <> int.to_string(idx)
+      <> "::int) to specify the type"
+    model.SQLite -> "Use CAST(? AS INTEGER) to specify the type"
+    model.MySQL -> "Use CAST(? AS SIGNED) to specify the type"
   }
 }
 

--- a/src/sqlode/verify.gleam
+++ b/src/sqlode/verify.gleam
@@ -131,7 +131,7 @@ fn load_and_analyze(
   )
   use analyzed <- result.try(
     query_analyzer.analyze_queries(block.engine, catalog, naming_ctx, queries)
-    |> result.map_error(query_analyzer.analysis_error_to_string),
+    |> result.map_error(query_analyzer.analysis_error_to_string(_, block.engine)),
   )
   use Nil <- result.try(
     query_validation.validate_unsupported_annotations(analyzed)

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -582,7 +582,7 @@ SELECT id FROM authors;"
       naming_ctx,
       queries,
     )
-  let msg = query_analyzer.analysis_error_to_string(err)
+  let msg = query_analyzer.analysis_error_to_string(err, model.PostgreSQL)
   msg |> string.contains("2") |> should.be_true()
   msg |> string.contains("1") |> should.be_true()
   msg |> string.contains("BadUnion") |> should.be_true()
@@ -697,7 +697,7 @@ pub fn table_not_found_error_test() {
 
 pub fn analysis_error_to_string_table_not_found_test() {
   let error = context.TableNotFound(query_name: "GetUsers", table_name: "users")
-  let msg = query_analyzer.analysis_error_to_string(error)
+  let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)
   string.contains(msg, "GetUsers") |> should.be_true()
   string.contains(msg, "users") |> should.be_true()
   string.contains(msg, "not found") |> should.be_true()
@@ -710,7 +710,7 @@ pub fn analysis_error_to_string_column_not_found_test() {
       table_name: "users",
       column_name: "email",
     )
-  let msg = query_analyzer.analysis_error_to_string(error)
+  let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)
   string.contains(msg, "GetUser") |> should.be_true()
   string.contains(msg, "email") |> should.be_true()
   string.contains(msg, "users") |> should.be_true()
@@ -754,7 +754,7 @@ pub fn unrecognized_cast_type_error_test() {
 pub fn analysis_error_to_string_parameter_not_inferred_test() {
   let error =
     context.ParameterTypeNotInferred(query_name: "Bare", param_index: 1)
-  let msg = query_analyzer.analysis_error_to_string(error)
+  let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)
   string.contains(msg, "Bare") |> should.be_true()
   string.contains(msg, "$1") |> should.be_true()
 }
@@ -766,9 +766,75 @@ pub fn analysis_error_to_string_unrecognized_cast_test() {
       param_index: 1,
       cast_type: "geometry",
     )
-  let msg = query_analyzer.analysis_error_to_string(error)
+  let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)
   string.contains(msg, "BadCast") |> should.be_true()
   string.contains(msg, "geometry") |> should.be_true()
+}
+
+// --- Engine-aware cast hint (#473) ---
+//
+// Pin the per-engine wording so the suggested fix in the error
+// message matches the configured engine's dialect — `$N::int` for
+// PostgreSQL, `CAST(? AS INTEGER)` for SQLite, `CAST(? AS SIGNED)`
+// for MySQL — and the placeholder reference matches too. Following
+// the suggestion as-is must produce valid SQL for the engine.
+
+pub fn parameter_not_inferred_postgres_uses_dollar_cast_hint_test() {
+  let error =
+    context.ParameterTypeNotInferred(query_name: "Bare", param_index: 1)
+  let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)
+  string.contains(msg, "$1") |> should.be_true()
+  string.contains(msg, "$1::int") |> should.be_true()
+}
+
+pub fn parameter_not_inferred_sqlite_uses_cast_as_integer_hint_test() {
+  // Headline #473 case: SQLite must NOT see `$1::int` (Postgres
+  // syntax). The placeholder reference uses `?N` and the suggested
+  // cast uses ANSI-shaped `CAST(? AS INTEGER)`.
+  let error =
+    context.ParameterTypeNotInferred(query_name: "Bare", param_index: 1)
+  let msg = query_analyzer.analysis_error_to_string(error, model.SQLite)
+  string.contains(msg, "?1") |> should.be_true()
+  string.contains(msg, "CAST(? AS INTEGER)") |> should.be_true()
+  string.contains(msg, "$1") |> should.be_false()
+  string.contains(msg, "::int") |> should.be_false()
+}
+
+pub fn parameter_not_inferred_mysql_uses_cast_as_signed_hint_test() {
+  let error =
+    context.ParameterTypeNotInferred(query_name: "Bare", param_index: 2)
+  let msg = query_analyzer.analysis_error_to_string(error, model.MySQL)
+  string.contains(msg, "?2") |> should.be_true()
+  string.contains(msg, "CAST(? AS SIGNED)") |> should.be_true()
+  string.contains(msg, "$2") |> should.be_false()
+  string.contains(msg, "::int") |> should.be_false()
+}
+
+pub fn unrecognized_cast_sqlite_uses_question_mark_label_test() {
+  // Placeholder reference dialect must follow the engine for every
+  // error variant, not just ParameterTypeNotInferred.
+  let error =
+    context.UnrecognizedCastType(
+      query_name: "BadCast",
+      param_index: 3,
+      cast_type: "geometry",
+    )
+  let msg = query_analyzer.analysis_error_to_string(error, model.SQLite)
+  string.contains(msg, "?3") |> should.be_true()
+  string.contains(msg, "$3") |> should.be_false()
+}
+
+pub fn parameter_type_conflict_mysql_uses_question_mark_label_test() {
+  let error =
+    context.ParameterTypeConflict(
+      query_name: "Conflict",
+      param_index: 5,
+      type_a: model.IntType,
+      type_b: model.StringType,
+    )
+  let msg = query_analyzer.analysis_error_to_string(error, model.MySQL)
+  string.contains(msg, "?5") |> should.be_true()
+  string.contains(msg, "$5") |> should.be_false()
 }
 
 pub fn left_join_makes_right_table_nullable_test() {
@@ -1418,7 +1484,7 @@ pub fn unsupported_expression_error_message_test() {
       query_name: "BadQuery",
       expression: "my_custom_udf(id)",
     )
-  let msg = query_analyzer.analysis_error_to_string(error)
+  let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)
   string.contains(msg, "unsupported expression") |> should.be_true()
   string.contains(msg, "BadQuery") |> should.be_true()
 }

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -580,6 +580,28 @@ pub fn analysis_error_to_string_unrecognized_cast_test() {
   query_analyzer_test.analysis_error_to_string_unrecognized_cast_test()
 }
 
+// --- Engine-aware cast hint (#473) ---
+
+pub fn parameter_not_inferred_postgres_uses_dollar_cast_hint_test() {
+  query_analyzer_test.parameter_not_inferred_postgres_uses_dollar_cast_hint_test()
+}
+
+pub fn parameter_not_inferred_sqlite_uses_cast_as_integer_hint_test() {
+  query_analyzer_test.parameter_not_inferred_sqlite_uses_cast_as_integer_hint_test()
+}
+
+pub fn parameter_not_inferred_mysql_uses_cast_as_signed_hint_test() {
+  query_analyzer_test.parameter_not_inferred_mysql_uses_cast_as_signed_hint_test()
+}
+
+pub fn unrecognized_cast_sqlite_uses_question_mark_label_test() {
+  query_analyzer_test.unrecognized_cast_sqlite_uses_question_mark_label_test()
+}
+
+pub fn parameter_type_conflict_mysql_uses_question_mark_label_test() {
+  query_analyzer_test.parameter_type_conflict_mysql_uses_question_mark_label_test()
+}
+
 pub fn unrecognized_sql_type_returns_error_test() {
   schema_parser_test.unrecognized_sql_type_returns_error_test()
 }


### PR DESCRIPTION
## Summary

`sqlode generate` rejected a SQLite `WHERE x BETWEEN ? AND ?` query
with:

```
Query "ListEntries": could not infer type for parameter $1.
Use a type cast (e.g. $1::int) to specify the type
```

Both halves of that message are wrong for SQLite:

- `\$1` is a Postgres-style placeholder reference. SQLite uses `?`
  (or `?N`); the configured engine never produced `\$N`.
- `\$1::int` is a Postgres-only cast extension. Pasting that into a
  SQLite query is a parse error.

The same failure mode affected MySQL, where the canonical cast
form is `CAST(? AS SIGNED)`. Following the hint produced a fresh
error in both engines.

This change makes `analysis_error_to_string` engine-aware. The
placeholder reference and the cast-syntax hint both now follow the
configured engine's dialect, so the suggested fix in the error
message is something the user can paste into their query verbatim.

## Changes

- `src/sqlode/query_analyzer/context.gleam`:
  - `analysis_error_to_string` now takes a second `engine:
    model.Engine` argument.
  - Two new private helpers, `placeholder_label(engine, idx)` and
    `cast_hint(engine, idx)`, encode the dialect for each engine
    in one place. The `ParameterTypeNotInferred`,
    `UnrecognizedCastType`, and `ParameterTypeConflict` arms all
    route through `placeholder_label` (and the first one through
    `cast_hint`) so a future engine only requires editing two
    helpers.
  - Engine matrix:

    | engine | placeholder | cast hint |
    |---|---|---|
    | PostgreSQL | `\$N` | `Use a type cast (e.g. \$N::int) to specify the type` |
    | SQLite | `?N` | `Use CAST(? AS INTEGER) to specify the type` |
    | MySQL | `?N` | `Use CAST(? AS SIGNED) to specify the type` |

- `src/sqlode/query_analyzer.gleam`: bump the public re-export
  signature to match.
- `src/sqlode/generate.gleam`: pass `block.engine` into
  `analysis_error_to_string`.
- `src/sqlode/verify.gleam`: same.
- `test/query_analyzer_test.gleam`:
  - Update the six existing call sites to pass `model.PostgreSQL`
    (the previous default the tests were written against).
  - Add five new tests pinning the per-engine wording: PostgreSQL
    keeps the dollar/cast hint; SQLite swaps to `?N` and `CAST(?
    AS INTEGER)` AND must NOT produce \`\$1\` / \`::int\`; MySQL
    swaps to `?N` and `CAST(? AS SIGNED)`; the placeholder-label
    swap also takes effect on \`UnrecognizedCastType\` and
    \`ParameterTypeConflict\`.
- `test/sqlode_test.gleam`: re-export the five new tests.
- `CHANGELOG.md`: note the user-visible behaviour change AND the
  signature change under `### Changed` with a `**BREAKING**`
  marker so library consumers calling
  `analysis_error_to_string` directly know to add the engine
  argument.

## Design Decisions

- Threaded the engine through the function signature rather than
  baking it into the `AnalysisError` variants. The error type is
  produced deep inside the analyser (per parameter, per query) and
  is reused across multiple consumers; carrying engine on every
  variant would duplicate the same value across hundreds of error
  values without buying anything. Passing it at the formatting
  boundary keeps the value where it is naturally available
  (`block.engine` is in scope at every caller).
- Used `?N` (1-based) for SQLite and MySQL placeholders. SQLite
  natively accepts the `?N` form; MySQL's wire-level placeholder
  is the bare `?` but the *reference* in an error message is
  informational, and `?N` reads as \"the Nth `?`\" without
  ambiguity. The alternative — falling back to prose like
  \"parameter at position N\" — would have meant longer messages
  with no syntactic precedent in the engine's own diagnostics.
- Marked the change as breaking (`!` in the commit type) because
  `analysis_error_to_string` is `pub` and library consumers can
  call it. The CHANGELOG entry spells out the migration (one
  added argument). No internal call site is left in the old
  shape.
- Did not add an engine-aware variant of `UnsupportedExpression`'s
  hint (`Use CAST to specify the type explicitly`), because that
  message does not embed any engine-specific syntax — it just
  tells the user to use `CAST`, which all three engines support
  in the ANSI form. Touching it would be churn without a user
  benefit.

## Limitations

- This PR fixes the *suggestion* shape but does not extend the
  type inferencer to handle every SQLite range query out of the
  box. The Issue notes that even with `CAST(? AS TEXT)`
  substituted in, sqlode still failed with the same \"could not
  infer type\" error for some shapes — that is a separate
  inferencer-coverage gap (a follow-up Issue would track it). The
  diagnostic the user now sees is at least pasteable.
- Library consumers calling `analysis_error_to_string` directly
  must add the engine argument. The CHANGELOG flags this; the
  internal callers are migrated.

Closes #473