### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-26
+
 ### Changed
 
 - `sqlode --help` no longer renders the same usage information
@@ -56,9 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `cli.decide_color_emission` and is pinned by tests; the BEAM
   primitives are wrapped in a small `sqlode_ffi.erl` module.
   (#464)
-
-### Changed
-
 - **BREAKING**: `query_analyzer.analysis_error_to_string` now
   takes a second `engine: model.Engine` argument so the rendered
   message is tailored to the configured engine. Placeholder

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest init --engine=sqli
 docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
 ```
 
-The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.8.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
+The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.9.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
 
 ### Initialize config
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.8.0"
+version = "0.9.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.9.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.8.0"
+pub const version = "0.9.0"


### PR DESCRIPTION
### Changed

- `sqlode --help` no longer renders the same usage information
  twice. Previously a manually-authored `global_help` block printed
  first, followed by glint's auto-generated `USAGE: / SUBCOMMANDS:`
  layout — same content, two formats. The manual block is
  removed; glint's auto-generated layout is now the single source
  of truth, so the two views cannot drift. Per-subcommand help
  (`sqlode generate --help`, `sqlode init --help`, etc.) continues
  to use each command's `glint.command_help(...)` block, which
  already carried the auto-discovery and example details that the
  removed global block duplicated. (#467)
- The CLI now rewrites the previous misleading
  `command not found` diagnostic into a class-specific message that
  names the actual failure mode:
  - no arguments →
    `error: missing subcommand. Run 'sqlode --help' to see available
    commands.`
  - leading-dash argument (e.g. `--xyz`, `-h`, `--version`) →
    `error: unrecognized option '<arg>'. Run 'sqlode --help' to see
    available options.`
  - non-flag, non-subcommand argument (e.g. `foo`) →
    `error: unknown subcommand '<arg>'. Run 'sqlode --help' to see
    available commands.`

  The rewriting is in `sqlode.rewrite_error` and is pinned by tests;
  errors that did NOT originate from glint's `command not found`
  path (config-load failures, generate-time errors, etc.) reach the
  user verbatim. (#466)
- The CLI now sends error diagnostics (unknown flag / no-args /
  invalid subcommand) to **stderr** with exit code 1, matching the
  POSIX/CLIG convention. Pipelines like
  `sqlode | jq` no longer receive help-as-error noise on jq's
  stdin, and `sqlode <bad> 1>out 2>err` cleanly separates
  requested output from diagnostics. Explicit `--help`
  invocations still print to stdout (the help text is the
  requested output in that case). The dispatch is implemented in
  `sqlode.main`, which now drives `glint.execute` itself instead
  of going through `glint.run`. (#465)
- The CLI now emits ANSI escape codes in `--help` output only when
  stdout is connected to an interactive terminal AND the
  `NO_COLOR` environment variable is unset (or set to the empty
  string). `sqlode --help > file.txt`, `sqlode --help | less`, and
  `NO_COLOR=1 sqlode --help` no longer leak colour control
  sequences into non-ANSI consumers, matching the convention from
  <https://no-color.org/> and CLIG. The decision logic is in
  `cli.decide_color_emission` and is pinned by tests; the BEAM
  primitives are wrapped in a small `sqlode_ffi.erl` module.
  (#464)
- **BREAKING**: `query_analyzer.analysis_error_to_string` now
  takes a second `engine: model.Engine` argument so the rendered
  message is tailored to the configured engine. Placeholder
  references and cast-syntax hints both follow the engine's
  dialect:
  - PostgreSQL — `$N` references, `$N::int` cast suggestion
    (unchanged from before).
  - SQLite — `?N` references, `CAST(? AS INTEGER)` cast suggestion.
  - MySQL — `?N` references, `CAST(? AS SIGNED)` cast suggestion.

  Prior to this change every error referenced `$N` and suggested
  `$N::int` regardless of the engine, which produced parser errors
  in SQLite / MySQL when the user followed the hint as-is. Internal
  callers (`generate.gleam`, `verify.gleam`) are migrated; library
  consumers calling `analysis_error_to_string` directly need to add
  the engine argument. (#473)

### Fixed

- Generated `params.gleam` and `queries.gleam` no longer emit
  duplicate record fields, labelled arguments, or labelled
  constructor calls when one query references the same column
  twice (e.g. `WHERE x >= ? AND x < ?` for range scans). The
  second and later occurrences pick up a `_<n>` suffix
  (`x`, `x_2`, `x_3`, …) so the generated Gleam compiles.
  Single-occurrence params keep their original names; param order
  is preserved so placeholder binding stays correct. (#472)
- Generated `params.gleam` no longer imports the unused `None` /
  `Some` constructors from `gleam/option`; only `type Option` is
  pulled in (the rendered code only references the type itself).
  Generated `<engine>_adapter.gleam` now narrows its
  `gleam/option` import to what the file actually references —
  `{type Option}` when only nullable params/results force the
  type, and the full `{type Option, None, Some}` only when at
  least one query is `:one` / `:batchone` and the wrapper actually
  emits `Some(row) / None`. Downstream callers running with strict
  warnings (e.g. glinter `warnings_as_errors = true`, which sqlode
  itself uses) no longer have to suppress unused-import warnings on
  `// DO NOT EDIT` files. **Re-run `sqlode generate` to refresh
  existing `params.gleam` / `<engine>_adapter.gleam` files —
  previously generated copies still carry the broad import.**
  (#463)
