### PR TITLE
fix(naming): keep letter+digit suffixes intact in snake_case conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `naming.to_snake_case` now preserves trailing digit suffixes
+  attached to the preceding letter run, so column names like
+  `sha256` / `utf8` / `base64` / `oauth2` / `ipv4` / `md5` / `s3` /
+  `http2` are emitted as `sha256` etc. in generated Gleam,
+  rather than the previous `sha_256` / `utf_8` / `base_64` …
+  shapes that read like a division. The digit→letter direction
+  stays a split point (e.g. `256sha` → `256_sha`) — the
+  convention is asymmetric. PascalCase / camelCase inputs follow
+  the same rule (`Sha256Hash` → `sha256_hash`, `GetV2Author` →
+  `get_v2_author`). (#480)
+
 ## [0.9.0] - 2026-04-26
 
 ### Changed

--- a/src/sqlode/naming.gleam
+++ b/src/sqlode/naming.gleam
@@ -14,9 +14,33 @@ pub type NamingContext {
 pub fn new() -> NamingContext {
   // nolint: assert_ok_pattern -- the regex literal is a compile-time constant
   let assert Ok(word_separator) = regexp.from_string("[_\\-\\s./]+")
+  // Word-split rule for camelCase / PascalCase / mixed input. The
+  // four alternatives, in priority order:
+  //
+  //   1. `[A-Z]+(?=[A-Z][a-z])` — split before the trailing capital
+  //      of an ALLCAPS run that's followed by a lower run
+  //      (XMLParser → XML, Parser).
+  //   2. `[A-Z]?[a-z]+[0-9]*` — a lower-cased word with an
+  //      optional leading capital and an OPTIONAL trailing digit
+  //      run (sha256 → sha256, getV2 → getV2's "v2" piece). The
+  //      trailing-digit attachment is the #480 fix: previously
+  //      "sha256" split into ["sha", "256"] and surfaced as
+  //      `sha_256` in generated identifiers, which read like a
+  //      division. The standard convention treats `sha256` /
+  //      `utf8` / `base64` / `md5` etc. as a single word, which
+  //      is what users almost always want.
+  //   3. `[A-Z]+[0-9]*` — an ALLCAPS word with the same optional
+  //      trailing digit run (USER, ID2, UUID).
+  //   4. `[0-9]+` — a leading or otherwise-unattached digit run
+  //      (256sha → "256", "sha"). Only digits not absorbed by the
+  //      preceding letter run land here; this preserves the
+  //      digit→letter split (the standard convention is the
+  //      opposite of letter→digit).
   // nolint: assert_ok_pattern -- the regex literal is a compile-time constant
   let assert Ok(camel_case) =
-    regexp.from_string("([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)")
+    regexp.from_string(
+      "([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+[0-9]*|[A-Z]+[0-9]*|[0-9]+)",
+    )
   // nolint: assert_ok_pattern -- the regex literal is a compile-time constant
   let assert Ok(underscore_before_caps) =
     regexp.from_string("([a-z0-9])([A-Z])")

--- a/test/naming_test.gleam
+++ b/test/naming_test.gleam
@@ -66,8 +66,79 @@ pub fn snake_case_from_all_caps_test() {
 }
 
 pub fn snake_case_with_numbers_test() {
+  // Trailing-digit suffixes are now glued to the preceding letter
+  // run (#480): "V2" stays as one word, so "GetV2Author" splits as
+  // ["Get", "V2", "Author"] → "get_v2_author". Previously the
+  // letter→digit boundary was a split point, producing the
+  // misleading "get_v_2_author".
   let ctx = naming.new()
-  naming.to_snake_case(ctx, "GetV2Author") |> should.equal("get_v_2_author")
+  naming.to_snake_case(ctx, "GetV2Author") |> should.equal("get_v2_author")
+}
+
+// --- Letter+digit suffix preservation (#480) ---
+//
+// Hash / encoding / version suffixes like sha256, utf8, base64,
+// oauth2, ipv4, s3, md5, http2 are conventionally one word. The
+// snake_case conversion must NOT insert an underscore between the
+// letter run and the trailing digit run.
+
+pub fn snake_case_keeps_sha256_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "sha256") |> should.equal("sha256")
+}
+
+pub fn snake_case_keeps_utf8_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "utf8") |> should.equal("utf8")
+}
+
+pub fn snake_case_keeps_base64_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "base64") |> should.equal("base64")
+}
+
+pub fn snake_case_keeps_oauth2_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "oauth2") |> should.equal("oauth2")
+}
+
+pub fn snake_case_keeps_ipv4_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "ipv4") |> should.equal("ipv4")
+}
+
+pub fn snake_case_keeps_md5_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "md5") |> should.equal("md5")
+}
+
+pub fn snake_case_keeps_s3_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "s3") |> should.equal("s3")
+}
+
+pub fn snake_case_keeps_http2_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "http2") |> should.equal("http2")
+}
+
+pub fn snake_case_keeps_allcaps_with_digit_suffix_intact_test() {
+  // ALLCAPS-with-digit-suffix follows the same rule: "ID2" is one
+  // word, not "ID" + "2".
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "USER_ID2") |> should.equal("user_id2")
+}
+
+pub fn snake_case_splits_digit_then_letter_boundary_test() {
+  // Digit→letter direction stays a split point — the convention
+  // is asymmetric. "256sha" reads as ["256", "sha"], not "256sha".
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "256sha") |> should.equal("256_sha")
+}
+
+pub fn snake_case_keeps_pascal_case_with_digit_suffix_intact_test() {
+  let ctx = naming.new()
+  naming.to_snake_case(ctx, "Sha256Hash") |> should.equal("sha256_hash")
 }
 
 pub fn snake_case_reserved_word_escaped_test() {

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -650,6 +650,52 @@ pub fn snake_case_single_upper_char_test() {
   naming_test.snake_case_single_upper_char_test()
 }
 
+// --- snake_case letter+digit suffix preservation (#480) ---
+
+pub fn snake_case_keeps_sha256_intact_test() {
+  naming_test.snake_case_keeps_sha256_intact_test()
+}
+
+pub fn snake_case_keeps_utf8_intact_test() {
+  naming_test.snake_case_keeps_utf8_intact_test()
+}
+
+pub fn snake_case_keeps_base64_intact_test() {
+  naming_test.snake_case_keeps_base64_intact_test()
+}
+
+pub fn snake_case_keeps_oauth2_intact_test() {
+  naming_test.snake_case_keeps_oauth2_intact_test()
+}
+
+pub fn snake_case_keeps_ipv4_intact_test() {
+  naming_test.snake_case_keeps_ipv4_intact_test()
+}
+
+pub fn snake_case_keeps_md5_intact_test() {
+  naming_test.snake_case_keeps_md5_intact_test()
+}
+
+pub fn snake_case_keeps_s3_intact_test() {
+  naming_test.snake_case_keeps_s3_intact_test()
+}
+
+pub fn snake_case_keeps_http2_intact_test() {
+  naming_test.snake_case_keeps_http2_intact_test()
+}
+
+pub fn snake_case_keeps_allcaps_with_digit_suffix_intact_test() {
+  naming_test.snake_case_keeps_allcaps_with_digit_suffix_intact_test()
+}
+
+pub fn snake_case_splits_digit_then_letter_boundary_test() {
+  naming_test.snake_case_splits_digit_then_letter_boundary_test()
+}
+
+pub fn snake_case_keeps_pascal_case_with_digit_suffix_intact_test() {
+  naming_test.snake_case_keeps_pascal_case_with_digit_suffix_intact_test()
+}
+
 pub fn normalize_identifier_empty_test() {
   naming_test.normalize_identifier_empty_test()
 }


### PR DESCRIPTION
## Summary

`naming.to_snake_case` split column names like `sha256`, `utf8`,
`base64`, `oauth2`, `ipv4`, `md5`, `s3` at every letter→digit
boundary, emitting them as `sha_256`, `utf_8`, … in generated
Gleam records. The result reads like a division (\"SHA divided by
256\") rather than the conventional one-word identifier
(\"SHA-256\"). The same rule made `GetV2Author` collapse to
`get_v_2_author` instead of the more natural `get_v2_author`.

This change tightens the word-split regex so a digit run that
follows a letter run stays attached to that word. The
digit→letter direction (e.g. `256sha`) remains a split point —
the convention is asymmetric.

## Changes

- `src/sqlode/naming.gleam`:
  - Update the `camel_case` regex from
    `([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|[0-9]+)` to
    `([A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+[0-9]*|[A-Z]+[0-9]*|[0-9]+)`
    — the two middle alternatives now accept a trailing `[0-9]*`,
    so `sha256` matches as one piece. The leading-digit alternative
    `[0-9]+` is kept for digit-only words and for the digit→letter
    boundary (\"256sha\" still splits as [\"256\", \"sha\"]).
  - Add a long block comment explaining the four alternatives in
    priority order so the reasoning survives future edits.
- `test/naming_test.gleam`:
  - Update `snake_case_with_numbers_test` from `get_v_2_author`
    to `get_v2_author` to match the new rule. The old expectation
    was the bug, not the contract.
  - Add eleven new tests: `sha256`, `utf8`, `base64`, `oauth2`,
    `ipv4`, `md5`, `s3`, `http2`, `USER_ID2` (ALLCAPS), `256sha`
    (digit→letter still splits), `Sha256Hash` (PascalCase + digit
    suffix + trailing word).
- `test/sqlode_test.gleam`: re-export the eleven new tests.
- `CHANGELOG.md`: note the fix under `### Fixed` for the next
  release window.

## Design Decisions

- Picked the regex tweak over an allow-list of known suffixes
  (`{sha,utf,base,...}{N}`). The allow-list would punt on every
  unknown letter+digit combination (project-specific names like
  `region5`, `bucket3`, `tier2`); the regex change covers them
  uniformly.
- Kept the asymmetry. Digits-then-letters (\"256sha\", \"3rdParty\")
  are still split because the standard convention is to treat the
  leading digit run as its own word — that's how Gleam's own
  formatter would render `3rdParty`-shaped names. Following that
  convention here keeps round-trip identity for snake-cased input.
- Did not add a per-column override knob (Issue mentions it as a
  possible follow-up). The new default matches what the Issue
  reporter asked for and what the alphabet-soup of standards uses;
  an override would add config surface without solving an
  observable problem.
- Updated the existing `snake_case_with_numbers_test` rather than
  preserving the old expectation. The previous output
  (`get_v_2_author`) was an artifact of the over-eager split, not
  a deliberate contract. The replacement
  (`get_v2_author`) reads naturally and matches the rule the
  Issue requests.

## Limitations

- Existing generated code that named a field `sha_256` will now
  re-generate as `sha256`. This is a downstream-visible rename for
  any user who previously worked around the bug by writing the
  field as `sha256` in their SQL or by accepting the surprising
  shape. Re-running `sqlode generate` and updating the call sites
  is the migration; the CHANGELOG flags it.
- Single-letter-followed-by-digits (\"s3\", \"v1\") is intentionally
  one word. If a user really wants the old `s_3` shape they can
  spell the column `s_3` in SQL.

Closes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snake_case conversion to keep trailing digits attached to letter sequences (e.g., `sha256`, `oauth2`, `ipv4`) as single identifiers instead of separating them with underscores. This behavior applies consistently across naming conventions including PascalCase and camelCase inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->