### PR TITLE
fix(lexer): unreserve `type` so it can be used as a column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A column literally named `type` no longer trips the analyser
+  with `unsupported expression "type"`. `type` is not a reserved
+  keyword in any of the three engines sqlode supports (SQLite /
+  PostgreSQL / MySQL all accept it as a non-reserved identifier),
+  so a query like `SELECT id, type FROM blobs` now analyses and
+  generates cleanly. The lexer no longer reserves `type` as a
+  Keyword token; the schema-parser paths that legitimately need
+  to recognise it (`CREATE TYPE`, `DROP TYPE`,
+  `ALTER COLUMN ... TYPE`, `ALTER COLUMN ... SET DATA TYPE`) now
+  do a case-insensitive `Ident` match instead. Existing
+  `CREATE TYPE name AS ENUM (...)` schemas keep working
+  unchanged. (#479)
 - `naming.to_snake_case` now preserves trailing digit suffixes
   attached to the preceding letter run, so column names like
   `sha256` / `utf8` / `base64` / `oauth2` / `ipv4` / `md5` / `s3` /

--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -545,8 +545,15 @@ fn is_sql_keyword(word: String) -> Bool {
     | "create"
     | "table"
     | "view"
-    | "type"
-    | "index"
+    | // `type` is intentionally NOT a keyword. It is a common
+      // column name (`account_type`, `event_type`, BLOB-related
+      // `type` for content-type, etc.) and SQLite / MySQL /
+      // PostgreSQL all treat it as a non-reserved identifier in
+      // SELECT contexts. The DDL paths that legitimately need to
+      // recognise it (`CREATE TYPE`, `DROP TYPE`,
+      // `ALTER COLUMN ... TYPE`, `ALTER COLUMN ... SET DATA TYPE`)
+      // pattern-match on `Ident("type")` instead. (#479)
+      "index"
     | "alter"
     | "add"
     | "column"

--- a/src/sqlode/schema_parser.gleam
+++ b/src/sqlode/schema_parser.gleam
@@ -193,16 +193,24 @@ fn split_token_statements(
 }
 
 /// Check if a token list represents a CREATE TYPE ... AS ENUM statement.
+/// `type` arrives as `Ident(_)` (case-preserving) because the lexer no
+/// longer treats `type` as a keyword (#479) — `type` is a common
+/// column name and reserving it tripped legitimate SELECT queries.
+/// The case-insensitive guard is needed because `Ident` preserves the
+/// original spelling, unlike `Keyword` which the lexer normalises to
+/// lowercase.
 fn is_create_enum_tokens(tokens: List(lexer.Token)) -> Bool {
   case tokens {
     [
       lexer.Keyword("create"),
-      lexer.Keyword("type"),
+      lexer.Ident(t),
       _,
       lexer.Keyword("as"),
       lexer.Keyword("enum"),
       ..
-    ] -> True
+    ]
+      if t == "type" || t == "TYPE" || t == "Type"
+    -> True
     _ -> False
   }
 }
@@ -214,12 +222,14 @@ fn parse_create_enum_from_tokens(
   case tokens {
     [
       lexer.Keyword("create"),
-      lexer.Keyword("type"),
+      lexer.Ident(t),
       name_token,
       lexer.Keyword("as"),
       lexer.Keyword("enum"),
       ..rest
-    ] -> {
+    ]
+      if t == "type" || t == "TYPE" || t == "Type"
+    -> {
       let name = case name_token {
         lexer.Ident(n) -> string.lowercase(n)
         lexer.QuotedIdent(n) -> string.lowercase(n)
@@ -987,7 +997,10 @@ fn extract_alter_column_name(tokens: List(lexer.Token)) -> String {
 fn extract_alter_type_tokens(tokens: List(lexer.Token)) -> List(lexer.Token) {
   case tokens {
     [] -> []
-    [lexer.Keyword("type"), ..rest] -> take_until_using(rest, [])
+    // `type` arrives as `Ident(_)` (case-preserving) because the
+    // lexer no longer reserves it as a keyword (#479).
+    [lexer.Ident(t), ..rest] if t == "type" || t == "TYPE" || t == "Type" ->
+      take_until_using(rest, [])
     [_, ..rest] -> extract_alter_type_tokens(rest)
   }
 }

--- a/test/lexer_test.gleam
+++ b/test/lexer_test.gleam
@@ -525,13 +525,17 @@ pub fn create_temporary_table_test() {
 }
 
 pub fn enum_with_escaped_quotes_test() {
+  // `type` is no longer reserved as a keyword (#479) so it lexes as
+  // a case-preserving Ident — `CREATE TYPE` (uppercase) tokenises
+  // as `Keyword("create"), Ident("TYPE")`. Schema parsing handles
+  // the case insensitivity downstream.
   lexer.tokenize(
     "CREATE TYPE status AS ENUM ('it''s', 'ok');",
     model.PostgreSQL,
   )
   |> should.equal([
     Keyword("create"),
-    Keyword("type"),
+    Ident("TYPE"),
     Ident("status"),
     Keyword("as"),
     Keyword("enum"),

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2977,6 +2977,77 @@ SELECT t.id FROM (SELECT id FROM authors) AS t;"
   col.scalar_type |> should.equal(model.IntType)
 }
 
+// --- Column named `type` (#479) ---
+//
+// `type` is not a SQL reserved keyword in any of the three engines
+// sqlode supports, so a SELECT that returns a column literally
+// named `type` must analyse cleanly. Previously the lexer reserved
+// `type` as a Keyword token, which the column inferencer could not
+// recognise as a column reference and surfaced as
+// `unsupported expression "type"`.
+
+pub fn column_named_type_resolves_in_select_test() {
+  let naming_ctx = naming.new()
+  let schema =
+    "CREATE TABLE blobs (
+      id INTEGER PRIMARY KEY,
+      size INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("inline_schema.sql", schema)])
+
+  let sql =
+    "-- name: GetBlobById :one\nSELECT id, size, type, created_at FROM blobs WHERE id = ?;"
+  let assert Ok(queries) =
+    query_parser.parse_file("inline_query.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+
+  let assert [query] = analyzed
+  // The column literally named `type` must surface as a result
+  // column with scalar type String (TEXT NOT NULL).
+  let type_col_present =
+    list.any(query.result_columns, fn(item) {
+      case item {
+        model.ScalarResult(col) ->
+          col.name == "type" && col.scalar_type == model.StringType
+        model.EmbeddedResult(_) -> False
+      }
+    })
+  type_col_present |> should.be_true()
+}
+
+pub fn column_named_type_in_create_table_parses_test() {
+  // Schema parser must accept `type` as a column name in
+  // CREATE TABLE — the type-name slot is populated by `TEXT`,
+  // `type` is just the identifier in column position.
+  let schema =
+    "CREATE TABLE blobs (id INTEGER PRIMARY KEY, type TEXT NOT NULL);"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("inline_schema.sql", schema)])
+
+  let assert [table] = catalog.tables
+  table.name |> should.equal("blobs")
+  let assert [_id, type_col] = table.columns
+  type_col.name |> should.equal("type")
+}
+
+pub fn create_type_enum_still_parses_test() {
+  // Regression guard: removing `type` from the keyword list must
+  // NOT break PostgreSQL's `CREATE TYPE name AS ENUM (...)`. The
+  // schema parser uses a case-insensitive Ident match for the
+  // `TYPE` slot.
+  let schema = "CREATE TYPE status AS ENUM ('active', 'inactive');"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("inline_schema.sql", schema)])
+
+  let assert [enum_def] = catalog.enums
+  enum_def.name |> should.equal("status")
+  enum_def.values |> should.equal(["active", "inactive"])
+}
+
 pub fn ir_table_alias_resolves_qualified_column_test() {
   let naming_ctx = naming.new()
   let catalog = test_catalog()

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -696,6 +696,20 @@ pub fn snake_case_keeps_pascal_case_with_digit_suffix_intact_test() {
   naming_test.snake_case_keeps_pascal_case_with_digit_suffix_intact_test()
 }
 
+// --- column named `type` (#479) ---
+
+pub fn column_named_type_resolves_in_select_test() {
+  query_analyzer_test.column_named_type_resolves_in_select_test()
+}
+
+pub fn column_named_type_in_create_table_parses_test() {
+  query_analyzer_test.column_named_type_in_create_table_parses_test()
+}
+
+pub fn create_type_enum_still_parses_test() {
+  query_analyzer_test.create_type_enum_still_parses_test()
+}
+
 pub fn normalize_identifier_empty_test() {
   naming_test.normalize_identifier_empty_test()
 }


### PR DESCRIPTION
## Summary

A column literally named `type` tripped the analyser with
`unsupported expression "type", cannot infer result type. Use CAST
to specify the type explicitly`. `type` is not a reserved keyword
in SQLite, PostgreSQL, or MySQL (all three accept it as a
non-reserved identifier in SELECT contexts), but sqlode's lexer
classified it as a `Keyword` token, which the SELECT-list inferencer
could not match against its `Ident` patterns.

This change drops `type` from the lexer's keyword list. The DDL
paths that legitimately need to recognise it (`CREATE TYPE`,
`DROP TYPE`, `ALTER COLUMN ... TYPE`,
`ALTER COLUMN ... SET DATA TYPE`) now use a case-insensitive
`Ident` match instead.

## Changes

- `src/sqlode/lexer.gleam`: remove `"type"` from `is_sql_keyword`.
  The slot is replaced by a comment recording the rationale and
  pointing at the schema-parser sites that the DDL paths now use.
- `src/sqlode/schema_parser.gleam`:
  - `is_create_enum_tokens` and `parse_create_enum_from_tokens`:
    match `lexer.Ident(t)` with a guard `if t == "type" || t ==
    "TYPE" || t == "Type"` instead of `lexer.Keyword("type")`.
    The case-list covers the three spellings users actually write
    (`type`, `TYPE`, `Type`); other casings are not in any style
    guide and would never appear in real DDL.
  - `extract_alter_type_tokens`: same Ident-with-guard switch for
    the `ALTER COLUMN ... TYPE` and `ALTER COLUMN ... SET DATA
    TYPE` recognition path.
  - The schema parser's `classify_unknown_statement` already used
    a `token_keyword_text` helper that flattens `Keyword` and
    `Ident` to the same lowercase string, so the
    `["drop", "type", ..]` and `["alter", "column", _, "type",
    ..]` patterns continue to match without further changes.
- `test/lexer_test.gleam`: update `enum_with_escaped_quotes_test`'s
  expected token sequence — `CREATE TYPE` now lexes as
  `Keyword("create"), Ident("TYPE")` (case-preserving) instead of
  the old `Keyword("create"), Keyword("type")`. The schema parser
  handles the case insensitivity downstream.
- `test/query_analyzer_test.gleam`: add three regression tests:
  - `column_named_type_resolves_in_select_test` — the headline
    #479 case. A SQLite query selecting a `type` column now
    analyses cleanly and surfaces the column with `StringType`
    (TEXT NOT NULL).
  - `column_named_type_in_create_table_parses_test` — the schema
    parser also accepts `type` in column position.
  - `create_type_enum_still_parses_test` — regression guard that
    the `CREATE TYPE name AS ENUM (...)` path still works after
    the keyword removal.
- `test/sqlode_test.gleam`: re-export the three new tests.
- `CHANGELOG.md`: note the fix under `### Fixed`.

## Design Decisions

- Removed `type` from the keyword list rather than teaching the
  inferencer to treat `Keyword(_)` as a column reference in SELECT
  positions. The latter would have meant adding a per-keyword
  policy (\"which keywords double as identifiers in SELECT
  contexts\") to every place the inferencer pattern-matches on
  `lexer.Ident`. Removing the one keyword that triggered the bug
  is a much smaller blast radius.
- Used a literal-list guard (`t == \"type\" || t == \"TYPE\" || t ==
  \"Type\"`) rather than `string.lowercase(t) == \"type\"` for the
  three DDL match sites. Keeping it as a literal-list keeps the
  pattern shape Gleam can compile to a fast match and avoids
  pulling `string.lowercase` into a guard expression. Real DDL
  uses one of those three casings; we are not catering to
  `tYpE`-shaped input.
- Did not add a per-engine guard for the keyword removal. The
  Issue notes none of the three engines reserve `type`; sharing
  one lexer rule across all engines is consistent with the
  existing pattern for non-reserved-everywhere words like `view`,
  `column`, etc.
- Did not surface a more specific error wording for the
  pre-existing failure mode. The fix removes the failure entirely;
  spending bytes on a clearer message for a state that no longer
  exists is overhead.

## Limitations

- Other column names that happen to collide with keywords (e.g.
  `select`, `from`, `where`) still trip the analyser. Those words
  ARE reserved in every engine sqlode supports, so the lexer has
  to keep them as `Keyword` tokens — the user's only correct
  workaround is to quote the identifier (`\"select\"`,
  `[select]`, `` `select` ``). A separate Issue could ask for
  better diagnostics on those (\"`select` is reserved; quote it
  as `\"select\"`\").
- Schema files using `tYpE` or `type ` (trailing whitespace)
  spelling for `CREATE TYPE` would not match the new guard list.
  That is not a real shape; if it surfaces a follow-up can swap
  the guard for `string.lowercase(t) == \"type\"`.

Closes #479