### PR TITLE
fix(analyzer): accept INSERT OR <conflict-action> INTO for parameter inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- SQLite's `INSERT OR <conflict-action> INTO ...` syntax
+  (`INSERT OR IGNORE`, `INSERT OR REPLACE`, `INSERT OR ABORT`,
+  `INSERT OR FAIL`, `INSERT OR ROLLBACK`) now analyses identically
+  to a plain `INSERT`. Previously the analyser only matched the
+  bare `INSERT INTO` shape and surfaced "could not infer type for
+  parameter" for every parameter when the conflict-action
+  qualifier was present, forcing callers to drop to raw sqlight
+  for upsert / idempotent-insert queries. Three call sites
+  (`token_utils.find_insert_loop`,
+  `column_inferencer.detect_dml_target`,
+  `expr_parser.parse_insert_body`) now route through a shared
+  `token_utils.strip_insert_or_action` helper. (#478)
 - A column literally named `type` no longer trips the analyser
   with `unsupported expression "type"`. `type` is not a reserved
   keyword in any of the three engines sqlode supports (SQLite /

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -384,10 +384,14 @@ pub fn infer_columns_from_tokens_scoped(
 fn detect_dml_target(tokens: List(lexer.Token)) -> Option(String) {
   let stripped = tok_strip_cte(tokens)
   case stripped {
-    [lexer.Keyword("insert"), lexer.Keyword("into"), ..rest] -> {
-      let #(name, _) = token_utils.read_table_name(rest)
-      name
-    }
+    [lexer.Keyword("insert"), ..rest] ->
+      case token_utils.strip_insert_or_action(rest) {
+        [lexer.Keyword("into"), ..after_into] -> {
+          let #(name, _) = token_utils.read_table_name(after_into)
+          name
+        }
+        _ -> None
+      }
     [lexer.Keyword("update"), ..rest] -> {
       let #(name, _) = token_utils.read_table_name(rest)
       name

--- a/src/sqlode/query_analyzer/expr_parser.gleam
+++ b/src/sqlode/query_analyzer/expr_parser.gleam
@@ -42,6 +42,7 @@ import gleam/string
 import sqlode/lexer
 import sqlode/model
 import sqlode/naming
+import sqlode/query_analyzer/token_utils
 import sqlode/query_ir
 
 /// Parse a full statement from its token list. Never fails; unknown
@@ -758,7 +759,7 @@ fn parse_insert_body(
   tokens: List(lexer.Token),
   engine: model.Engine,
 ) -> query_ir.Stmt {
-  case tokens {
+  case token_utils.strip_insert_or_action(tokens) {
     [lexer.Keyword("into"), ..after_into] ->
       parse_insert_target(ctes, after_into, engine)
     _ ->

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -260,9 +260,49 @@ pub fn find_insert_parts(tokens: List(lexer.Token)) -> Option(InsertParts) {
 fn find_insert_loop(tokens: List(lexer.Token)) -> Option(InsertParts) {
   case tokens {
     [] -> None
-    [lexer.Keyword("insert"), lexer.Keyword("into"), ..rest] ->
-      parse_insert_after_into(rest)
+    [lexer.Keyword("insert"), ..rest] ->
+      case strip_insert_or_action(rest) {
+        [lexer.Keyword("into"), ..after_into] ->
+          parse_insert_after_into(after_into)
+        _ -> find_insert_loop(rest)
+      }
     [_, ..rest] -> find_insert_loop(rest)
+  }
+}
+
+/// Strip a leading SQLite-specific `OR <conflict-action>` qualifier
+/// from the token stream that follows `INSERT`. Returns the input
+/// unchanged when the next token is not `OR`. The five conflict
+/// actions per <https://www.sqlite.org/lang_insert.html> are
+/// REPLACE, ROLLBACK, ABORT, FAIL, IGNORE — REPLACE and ROLLBACK
+/// are reserved keywords, the other three lex as `Ident` tokens
+/// (case-preserving). (#478)
+pub fn strip_insert_or_action(tokens: List(lexer.Token)) -> List(lexer.Token) {
+  case tokens {
+    [lexer.Keyword("or"), action, ..rest] ->
+      case is_insert_or_action_token(action) {
+        True -> rest
+        False -> tokens
+      }
+    _ -> tokens
+  }
+}
+
+fn is_insert_or_action_token(token: lexer.Token) -> Bool {
+  case token {
+    lexer.Keyword("replace") -> True
+    lexer.Keyword("rollback") -> True
+    lexer.Ident(t) ->
+      t == "ignore"
+      || t == "IGNORE"
+      || t == "Ignore"
+      || t == "abort"
+      || t == "ABORT"
+      || t == "Abort"
+      || t == "fail"
+      || t == "FAIL"
+      || t == "Fail"
+    _ -> False
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2977,6 +2977,83 @@ SELECT t.id FROM (SELECT id FROM authors) AS t;"
   col.scalar_type |> should.equal(model.IntType)
 }
 
+// --- INSERT OR <conflict-action> (#478) ---
+//
+// SQLite's `INSERT OR REPLACE / ROLLBACK / ABORT / FAIL / IGNORE
+// INTO ...` syntax must analyse identically to a plain INSERT —
+// the conflict-action qualifier doesn't change column / parameter
+// positions. Previously the analyser only matched the bare
+// `INSERT INTO` shape and surfaced "could not infer type" for
+// every parameter when the qualifier was present.
+
+fn insert_or_action_catalog() -> model.Catalog {
+  let schema =
+    "CREATE TABLE tags (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      blob_id INTEGER NOT NULL,
+      tag TEXT NOT NULL
+    );"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("inline_schema.sql", schema)])
+  catalog
+}
+
+fn analyze_insert_or_query(sql: String) -> model.AnalyzedQuery {
+  let naming_ctx = naming.new()
+  let catalog = insert_or_action_catalog()
+  let assert Ok(queries) =
+    query_parser.parse_file("inline.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+  query
+}
+
+pub fn insert_or_ignore_infers_params_test() {
+  let sql =
+    "-- name: InsertTag :exec\nINSERT OR IGNORE INTO tags (blob_id, tag) VALUES (?, ?);"
+  let query = analyze_insert_or_query(sql)
+  let assert [blob_id_param, tag_param] = query.params
+  blob_id_param.scalar_type |> should.equal(model.IntType)
+  tag_param.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn insert_or_replace_infers_params_test() {
+  let sql =
+    "-- name: ReplaceTag :exec\nINSERT OR REPLACE INTO tags (blob_id, tag) VALUES (?, ?);"
+  let query = analyze_insert_or_query(sql)
+  let assert [blob_id_param, tag_param] = query.params
+  blob_id_param.scalar_type |> should.equal(model.IntType)
+  tag_param.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn insert_or_abort_infers_params_test() {
+  let sql =
+    "-- name: AbortTag :exec\nINSERT OR ABORT INTO tags (blob_id, tag) VALUES (?, ?);"
+  let query = analyze_insert_or_query(sql)
+  let assert [blob_id_param, tag_param] = query.params
+  blob_id_param.scalar_type |> should.equal(model.IntType)
+  tag_param.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn insert_or_fail_infers_params_test() {
+  let sql =
+    "-- name: FailTag :exec\nINSERT OR FAIL INTO tags (blob_id, tag) VALUES (?, ?);"
+  let query = analyze_insert_or_query(sql)
+  let assert [blob_id_param, tag_param] = query.params
+  blob_id_param.scalar_type |> should.equal(model.IntType)
+  tag_param.scalar_type |> should.equal(model.StringType)
+}
+
+pub fn insert_or_rollback_infers_params_test() {
+  let sql =
+    "-- name: RollbackTag :exec\nINSERT OR ROLLBACK INTO tags (blob_id, tag) VALUES (?, ?);"
+  let query = analyze_insert_or_query(sql)
+  let assert [blob_id_param, tag_param] = query.params
+  blob_id_param.scalar_type |> should.equal(model.IntType)
+  tag_param.scalar_type |> should.equal(model.StringType)
+}
+
 // --- Column named `type` (#479) ---
 //
 // `type` is not a SQL reserved keyword in any of the three engines

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -696,6 +696,28 @@ pub fn snake_case_keeps_pascal_case_with_digit_suffix_intact_test() {
   naming_test.snake_case_keeps_pascal_case_with_digit_suffix_intact_test()
 }
 
+// --- INSERT OR <conflict-action> (#478) ---
+
+pub fn insert_or_ignore_infers_params_test() {
+  query_analyzer_test.insert_or_ignore_infers_params_test()
+}
+
+pub fn insert_or_replace_infers_params_test() {
+  query_analyzer_test.insert_or_replace_infers_params_test()
+}
+
+pub fn insert_or_abort_infers_params_test() {
+  query_analyzer_test.insert_or_abort_infers_params_test()
+}
+
+pub fn insert_or_fail_infers_params_test() {
+  query_analyzer_test.insert_or_fail_infers_params_test()
+}
+
+pub fn insert_or_rollback_infers_params_test() {
+  query_analyzer_test.insert_or_rollback_infers_params_test()
+}
+
 // --- column named `type` (#479) ---
 
 pub fn column_named_type_resolves_in_select_test() {


### PR DESCRIPTION
## Summary

`INSERT OR IGNORE INTO ...` (and the four sister forms — `OR
REPLACE`, `OR ABORT`, `OR FAIL`, `OR ROLLBACK`) broke parameter
type inference: every parameter in the VALUES list surfaced as
`could not infer type for parameter $N`. Removing the conflict-
action qualifier — keeping every other token identical — made the
same query work. The bug forced callers writing idempotent
upserts to drop down to raw sqlight.

The five forms are documented at <https://www.sqlite.org/lang_insert.html>;
they differ from a plain INSERT only in the inserted modifier
between `INSERT` and `INTO`. The analyser's three INSERT match
sites all hard-coded the bare `INSERT INTO` shape and silently
fell through on the qualified form.

## Changes

- `src/sqlode/query_analyzer/token_utils.gleam`:
  - New `pub fn strip_insert_or_action(tokens)` that consumes a
    leading `OR <conflict-action>` qualifier from the token stream
    that follows `INSERT`. Returns the input unchanged when the
    next token is not `OR`. The five conflict actions are encoded
    in a private `is_insert_or_action_token` helper:
    - REPLACE / ROLLBACK lex as `Keyword` tokens (the lexer
      already reserves them).
    - ABORT / FAIL / IGNORE lex as `Ident` (case-preserving). The
      helper accepts the three common spellings (`abort`,
      `ABORT`, `Abort`) for each — same scheme as the
      case-insensitive `Ident` matches introduced in #479.
  - `find_insert_loop` now matches `[Keyword(\"insert\"), ..rest]`
    and routes through `strip_insert_or_action(rest)` before
    expecting `Keyword(\"into\")`.
- `src/sqlode/query_analyzer/column_inferencer.gleam`:
  - `detect_dml_target` updated the same way so that the table
    target is correctly identified for every INSERT shape.
- `src/sqlode/query_analyzer/expr_parser.gleam`:
  - `parse_insert_body` routes its input through
    `token_utils.strip_insert_or_action` before expecting
    `Keyword(\"into\")`. New `import sqlode/query_analyzer/token_utils`.
- `test/query_analyzer_test.gleam`: add five tests under
  `INSERT OR <conflict-action> (#478)` — one per qualifier
  (`IGNORE`, `REPLACE`, `ABORT`, `FAIL`, `ROLLBACK`). Each
  asserts that the two parameters in `VALUES (?, ?)` are
  correctly inferred as `Int` (blob_id) and `String` (tag),
  matching the column types of the test fixture's `tags` table.
- `test/sqlode_test.gleam`: re-export the five tests under the
  project's aggregator pattern.
- `CHANGELOG.md`: note the fix under `### Fixed` with the three
  call sites named so future maintainers understand the spread
  of the change.

## Design Decisions

- Centralised the `OR <action>` skip into one helper rather than
  inlining the pattern at three call sites. The match sites are
  in three different modules; a single helper keeps the
  conflict-action list in exactly one place and means a future
  SQL dialect that adds another action only needs one edit.
- Defensive `strip_insert_or_action` returns `tokens` unchanged
  when the next token is not `OR`, instead of panicking or
  matching narrowly. This lets every call site call it
  unconditionally without first checking for `OR` itself, and
  makes it safe to layer in more INSERT-relevant preprocessing
  later without rewriting the call sites.
- Did not extend `is_insert_or_action_token` to PostgreSQL /
  MySQL conflict syntaxes (`ON CONFLICT ... DO NOTHING`,
  `ON DUPLICATE KEY UPDATE`). Those land between `VALUES (...)`
  and the statement terminator, not between `INSERT` and `INTO`,
  so they don't go through this code path. SQLite's `OR
  <action>` is the only INSERT-modifier-between-INSERT-and-INTO
  shape across the three engines sqlode supports.
- Used a literal-list spelling guard for the `Ident` cases (same
  shape as #479's `t == \"type\" || t == \"TYPE\" || t ==
  \"Type\"`) rather than `string.lowercase(t) == \"abort\"`. Real
  DDL uses one of the three casings; we are not catering to
  `IgNoRe`-shaped input.

## Limitations

- The handler accepts `INSERT OR REPLACE INTO` and friends but
  does not type-check the conflict-action token itself. A typo
  like `INSERT OR REPLAACE INTO` will fall through to the bare
  `INSERT INTO` mismatch path and surface as the original
  \"could not infer type\" error. That's the same behaviour as
  before for any malformed INSERT and is out of scope here.
- The fix only touches the three INSERT-matching sites listed
  above. If a future code path is added that hardcodes the bare
  `INSERT INTO` shape, it will reintroduce the bug for itself —
  the `strip_insert_or_action` helper has to be wired into each
  new site by hand.

Closes #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed parameter type inference for SQLite `INSERT OR IGNORE/REPLACE/ABORT/FAIL/ROLLBACK` statements. The analyzer now properly recognizes these conflict-action variants and infers parameter types consistently with standard `INSERT` statements.

* **Tests**
  * Added test coverage for all `INSERT OR` conflict-action variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->