### PR TITLE
fix(analyzer): treat CAST(? AS <type>) as a placeholder slot in INSERT VALUES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `INSERT INTO ... VALUES (..., CAST(? AS BLOB), ...)` and
+  similar `CAST(? AS <type>)` slots now consume a parameter
+  position correctly. Previously `infer_insert_params` only
+  matched a bare `[Placeholder]` token and silently skipped
+  CAST-wrapped placeholders, which shifted every subsequent
+  column-to-parameter mapping by one and surfaced as
+  "could not infer type" on a column the user never touched.
+  As a side-effect the BLOB-column scenarios reported in the
+  Issue (writes into BLOB columns, `WHERE blob_col = ?`,
+  `CAST(? AS BLOB)` overrides) now generate cleanly with the
+  correct `BitArray` parameter type. (#477)
 - SQLite's `INSERT OR <conflict-action> INTO ...` syntax
   (`INSERT OR IGNORE`, `INSERT OR REPLACE`, `INSERT OR ABORT`,
   `INSERT OR FAIL`, `INSERT OR ROLLBACK`) now analyses identically

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -76,9 +76,26 @@ fn map_insert_columns(
   case columns, values {
     [], _ | _, [] -> acc
     [column_name, ..rest_columns], [value_tokens, ..rest_values] -> {
-      // Check if value is a single placeholder token
+      // Check if the VALUES slot is a placeholder we can hand back
+      // to the column-type inferencer. We accept two shapes:
+      //
+      //   * a bare `?` / `:name` / `$1` token, and
+      //   * `CAST(? AS <type>)` — common explicit-cast escape hatch
+      //     for SQLite (`CAST(? AS BLOB)`, `CAST(? AS INTEGER)`).
+      //     The placeholder still consumes a position in the SQL
+      //     parameter list, so without this match the placeholder
+      //     index would silently drift for every parameter that
+      //     follows. (#477)
       let value_placeholder = case value_tokens {
         [lexer.Placeholder(p)] -> Some(p)
+        [
+          lexer.Keyword("cast"),
+          lexer.LParen,
+          lexer.Placeholder(p),
+          lexer.Keyword("as"),
+          _,
+          lexer.RParen,
+        ] -> Some(p)
         _ -> None
       }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -2977,6 +2977,81 @@ SELECT t.id FROM (SELECT id FROM authors) AS t;"
   col.scalar_type |> should.equal(model.IntType)
 }
 
+// --- BLOB / CAST(? AS <type>) inference (#477) ---
+//
+// SQLite uses `BLOB` for byte columns and `CAST(? AS BLOB)` as the
+// dialect-native explicit-type override. The analyser must:
+//
+//   1. Infer parameter types from BLOB columns just like it does
+//      for INTEGER / TEXT — the storage class maps cleanly to
+//      sqlode's `BytesType` / runtime `SqlBytes`.
+//   2. Treat `CAST(? AS <type>)` in a VALUES slot as a placeholder
+//      that consumes a parameter position. Previously the
+//      `infer_insert_params` walker only matched a bare
+//      `[Placeholder]` token and silently dropped CAST-wrapped
+//      placeholders, which shifted every subsequent parameter's
+//      column-mapping by one and surfaced as "could not infer
+//      type" on a column the user never touched.
+
+fn blob_catalog() -> model.Catalog {
+  let schema =
+    "CREATE TABLE blobs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      sha256 BLOB NOT NULL UNIQUE,
+      size INTEGER NOT NULL,
+      mime_type TEXT NOT NULL,
+      body BLOB NOT NULL
+    );"
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("inline_schema.sql", schema)])
+  catalog
+}
+
+fn analyze_blob_query(sql: String) -> model.AnalyzedQuery {
+  let naming_ctx = naming.new()
+  let catalog = blob_catalog()
+  let assert Ok(queries) =
+    query_parser.parse_file("inline.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+  query
+}
+
+pub fn insert_into_blob_columns_infers_bytes_test() {
+  let sql =
+    "-- name: InsertBlob :exec\nINSERT INTO blobs (sha256, size, mime_type, body) VALUES (?, ?, ?, ?);"
+  let query = analyze_blob_query(sql)
+  let assert [sha256_param, size_param, mime_param, body_param] = query.params
+  sha256_param.scalar_type |> should.equal(model.BytesType)
+  size_param.scalar_type |> should.equal(model.IntType)
+  mime_param.scalar_type |> should.equal(model.StringType)
+  body_param.scalar_type |> should.equal(model.BytesType)
+}
+
+pub fn select_where_blob_column_infers_bytes_test() {
+  let sql =
+    "-- name: FindBlobBySha :one\nSELECT id, sha256, size FROM blobs WHERE sha256 = ?;"
+  let query = analyze_blob_query(sql)
+  let assert [sha_param] = query.params
+  sha_param.scalar_type |> should.equal(model.BytesType)
+}
+
+pub fn insert_with_cast_blob_placeholder_infers_bytes_test() {
+  // `CAST(? AS BLOB)` must be recognised as a placeholder slot so
+  // the column-to-parameter mapping stays aligned. Before the fix
+  // the CAST-wrapped slots were silently skipped, shifting every
+  // subsequent column by one.
+  let sql =
+    "-- name: InsertBlobCast :exec\nINSERT INTO blobs (sha256, size, mime_type, body) VALUES (CAST(? AS BLOB), ?, ?, CAST(? AS BLOB));"
+  let query = analyze_blob_query(sql)
+  let assert [sha_param, size_param, mime_param, body_param] = query.params
+  sha_param.scalar_type |> should.equal(model.BytesType)
+  size_param.scalar_type |> should.equal(model.IntType)
+  mime_param.scalar_type |> should.equal(model.StringType)
+  body_param.scalar_type |> should.equal(model.BytesType)
+}
+
 // --- INSERT OR <conflict-action> (#478) ---
 //
 // SQLite's `INSERT OR REPLACE / ROLLBACK / ABORT / FAIL / IGNORE

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -696,6 +696,20 @@ pub fn snake_case_keeps_pascal_case_with_digit_suffix_intact_test() {
   naming_test.snake_case_keeps_pascal_case_with_digit_suffix_intact_test()
 }
 
+// --- BLOB / CAST(? AS <type>) inference (#477) ---
+
+pub fn insert_into_blob_columns_infers_bytes_test() {
+  query_analyzer_test.insert_into_blob_columns_infers_bytes_test()
+}
+
+pub fn select_where_blob_column_infers_bytes_test() {
+  query_analyzer_test.select_where_blob_column_infers_bytes_test()
+}
+
+pub fn insert_with_cast_blob_placeholder_infers_bytes_test() {
+  query_analyzer_test.insert_with_cast_blob_placeholder_infers_bytes_test()
+}
+
 // --- INSERT OR <conflict-action> (#478) ---
 
 pub fn insert_or_ignore_infers_params_test() {


### PR DESCRIPTION
## Summary

`infer_insert_params` only matched a bare `[Placeholder]` token in
each VALUES slot, so `CAST(? AS BLOB)` (and any other
`CAST(? AS <type>)` form) was silently dropped from the column-to-
parameter mapping. The placeholder still consumed a position in
the SQL parameter list, so every parameter that followed a
CAST-wrapped slot got mapped to the wrong column — surfacing as
`could not infer type` on a parameter the user never directly
touched.

The Issue framed this as a BLOB-inference problem because the
SQLite-native explicit-cast escape hatch (`CAST(? AS BLOB)`) is
the natural workaround when a user wants to pin a parameter type
on a BLOB column. With the matcher now accepting CAST-wrapped
placeholders, every BLOB scenario the Issue lists analyses
cleanly:

- `INSERT INTO blobs (sha256, ..., body) VALUES (?, ..., ?)` —
  works (BLOB columns infer `BytesType` → `BitArray`).
- `WHERE blob_col = ?` — already worked via the IR walker.
- `INSERT INTO ... VALUES (CAST(? AS BLOB), ..., CAST(? AS BLOB))`
  — works after this fix.

## Changes

- `src/sqlode/query_analyzer/param_inferencer.gleam`:
  - Extend the `value_placeholder` match in `map_insert_columns`
    to recognise the six-token `[cast, LParen, Placeholder, as,
    type, RParen]` shape in addition to the bare `[Placeholder]`
    shape. The placeholder string is what the existing
    `placeholder.resolve_index` already understands.
  - Long inline comment recording why the second pattern exists
    and what it prevents (silent column-mapping drift).
- `test/query_analyzer_test.gleam`: add three regression tests
  under `BLOB / CAST(? AS <type>) inference (#477)` :
  - `insert_into_blob_columns_infers_bytes_test` — bare
    `INSERT INTO blobs (...)` with two BLOB columns; verifies
    every parameter resolves to the right scalar type.
  - `select_where_blob_column_infers_bytes_test` — `WHERE
    sha256 = ?` against a BLOB column. (Pre-existing
    behaviour; pinned to catch regressions.)
  - `insert_with_cast_blob_placeholder_infers_bytes_test` —
    the headline case. Mixed CAST-wrapped and bare placeholders
    in one VALUES list; the column mapping must NOT drift.
- `test/sqlode_test.gleam`: re-export the three new tests under
  the project's aggregator pattern.
- `CHANGELOG.md`: note the fix under `### Fixed` with the
  CAST-wrapped placeholder mapping called out as the load-bearing
  detail.

## Design Decisions

- Used the column's declared type for the CAST-wrapped
  placeholder rather than the type named inside the `CAST(...)`.
  In every realistic use the user wraps `?` in a CAST whose type
  matches the column being inserted into (the whole point is to
  pin the same type the column already has). Honouring the
  column type keeps the rule consistent with the bare-`?` case
  and avoids a second source of truth that could conflict with
  the schema. A future enhancement could promote the CAST type
  when the user deliberately differs from the column (e.g. for
  loose-schema SQLite tables); that's out of scope for this fix.
- Matched the literal six-token shape rather than a more
  permissive scan because the lexer normalises `CAST` and `AS`
  to lowercase keywords and the placeholder always lands in the
  middle slot. A scan-with-state implementation would have to
  re-implement the same constraints with no behaviour change.
- Did not extend the `value_placeholder` match to cover other
  expression shapes (`COALESCE(?, default)`, `?+0`, etc.).
  Those don't preserve the column's type the way `CAST(? AS T)`
  does, and the Issue is explicitly about the CAST escape
  hatch documented at SQLite's own page on placeholders. Adding
  broader matches risks misclassifying placeholders inside
  expressions whose result type is not the column type.
- The `WHERE blob_col = ?` path was already covered by the IR
  walker (which transparently unwraps `Cast(Param)` per the
  existing comment in `infer_equality_params`). Added the test
  anyway as a regression guard — the Issue framed it as part of
  the same bug, and pinning the contract here costs almost
  nothing.

## Limitations

- The type inferencer only inspects the **column** type when a
  CAST-wrapped placeholder is present; it does not honour a
  CAST-name that differs from the column type. If a user really
  needs to push a different type through a column (e.g.
  `CAST(? AS TEXT)` into a BLOB column for some sqlite3
  type-affinity hack), the fix here will give them
  `BitArray`-typed parameters, not `String`. Realistic
  workloads do not do this.
- ON CONFLICT, EXCLUDED.<col>, and other PostgreSQL upsert
  forms are still unaddressed. Those land between
  `VALUES (...)` and the statement terminator, not in a VALUES
  slot, so they go through different code paths.

Closes #477