### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-26
+
 ### Fixed
 
 - `INSERT INTO ... VALUES (..., CAST(? AS BLOB), ...)` and

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest init --engine=sqli
 docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
 ```
 
-The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.9.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
+The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.10.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
 
 ### Initialize config
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.9.0"
+version = "0.10.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.9.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.10.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.9.0"
+pub const version = "0.10.0"


### PR DESCRIPTION
### Fixed

- `INSERT INTO ... VALUES (..., CAST(? AS BLOB), ...)` and
  similar `CAST(? AS <type>)` slots now consume a parameter
  position correctly. Previously `infer_insert_params` only
  matched a bare `[Placeholder]` token and silently skipped
  CAST-wrapped placeholders, which shifted every subsequent
  column-to-parameter mapping by one and surfaced as
  "could not infer type" on a column the user never touched.
  As a side-effect the BLOB-column scenarios reported in the
  Issue (writes into BLOB columns, `WHERE blob_col = ?`,
  `CAST(? AS BLOB)` overrides) now generate cleanly with the
  correct `BitArray` parameter type. (#477)
- SQLite's `INSERT OR <conflict-action> INTO ...` syntax
  (`INSERT OR IGNORE`, `INSERT OR REPLACE`, `INSERT OR ABORT`,
  `INSERT OR FAIL`, `INSERT OR ROLLBACK`) now analyses identically
  to a plain `INSERT`. Previously the analyser only matched the
  bare `INSERT INTO` shape and surfaced "could not infer type for
  parameter" for every parameter when the conflict-action
  qualifier was present, forcing callers to drop to raw sqlight
  for upsert / idempotent-insert queries. Three call sites
  (`token_utils.find_insert_loop`,
  `column_inferencer.detect_dml_target`,
  `expr_parser.parse_insert_body`) now route through a shared
  `token_utils.strip_insert_or_action` helper. (#478)
- A column literally named `type` no longer trips the analyser
  with `unsupported expression "type"`. `type` is not a reserved
  keyword in any of the three engines sqlode supports (SQLite /
  PostgreSQL / MySQL all accept it as a non-reserved identifier),
  so a query like `SELECT id, type FROM blobs` now analyses and
  generates cleanly. The lexer no longer reserves `type` as a
  Keyword token; the schema-parser paths that legitimately need
  to recognise it (`CREATE TYPE`, `DROP TYPE`,
  `ALTER COLUMN ... TYPE`, `ALTER COLUMN ... SET DATA TYPE`) now
  do a case-insensitive `Ident` match instead. Existing
  `CREATE TYPE name AS ENUM (...)` schemas keep working
  unchanged. (#479)
- `naming.to_snake_case` now preserves trailing digit suffixes
  attached to the preceding letter run, so column names like
  `sha256` / `utf8` / `base64` / `oauth2` / `ipv4` / `md5` / `s3` /
  `http2` are emitted as `sha256` etc. in generated Gleam,
  rather than the previous `sha_256` / `utf_8` / `base_64` …
  shapes that read like a division. The digit→letter direction
  stays a split point (e.g. `256sha` → `256_sha`) — the
  convention is asymmetric. PascalCase / camelCase inputs follow
  the same rule (`Sha256Hash` → `sha256_hash`, `GetV2Author` →
  `get_v2_author`). (#480)
