### PR TITLE
fix(sqlite): infer row type for table-less :one with scalar function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `:one` queries that have no FROM clause and project a single scalar
+  expression (e.g. `SELECT last_insert_rowid() AS id;`,
+  `SELECT random() AS r;`) now produce a complete row type and a
+  matching decoder. Previously the column inferencer treated the
+  table-less SELECT as having no columns and returned `Ok([])`, so
+  `models.gleam` lacked the row type while the generated adapter
+  still referenced it — the consuming project failed to compile.
+  Two new pieces wire this up: (1) `infer_columns_from_tokens_scoped`
+  now calls a new `infer_table_less_columns` helper when no FROM
+  table is in scope, which uses the existing
+  `infer_expression_type_from_tokens` path to recover the column
+  type/nullability; (2) the SQLite-side function dictionary
+  (`type_inference.infer_function_body` and
+  `column_inferencer.classify_function`) gains
+  `last_insert_rowid` so the int return type and non-null property
+  are recognised. Bare column references without a FROM clause are
+  still rejected with `UnsupportedExpression`. (#492)
+
 ## [0.10.0] - 2026-04-26
 
 ### Fixed

--- a/src/sqlode/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/query_analyzer/column_inferencer.gleam
@@ -360,7 +360,13 @@ pub fn infer_columns_from_tokens_scoped(
         tok_extract_nullable_tables(main_tokens2, table_names)
 
       case effective_tables(table_names, outer_tables) {
-        [] -> Ok([])
+        // No FROM clause — try to infer columns directly from the
+        // SELECT-list expressions (scalar function calls, literals,
+        // etc.). This covers `SELECT last_insert_rowid() AS id;`-style
+        // queries (Issue #492) that were previously dropped to an
+        // empty `Ok([])` and produced a broken adapter / missing row
+        // type pair downstream.
+        [] -> infer_table_less_columns(query_name, main_tokens2, augmented)
         [primary, ..] as tables -> {
           let select_columns = tok_extract_select_columns(main_tokens2)
           resolve_select_columns(
@@ -374,6 +380,51 @@ pub fn infer_columns_from_tokens_scoped(
         }
       }
     }
+  }
+}
+
+/// Infer result columns for a SELECT statement that has no FROM clause
+/// (no real or virtual tables to resolve against). Each select-list
+/// item must be a self-contained expression — a scalar function call
+/// (`last_insert_rowid()`, `random()`, ...), a literal, or a CAST. A
+/// bare `*` or an unqualified column reference cannot be resolved and
+/// surfaces as `UnsupportedExpression`.
+fn infer_table_less_columns(
+  query_name: String,
+  tokens: List(lexer.Token),
+  catalog: model.Catalog,
+) -> Result(List(model.ResultItem), AnalysisError) {
+  let select_columns = tok_extract_select_columns(tokens)
+  case select_columns {
+    [] -> Ok([])
+    _ ->
+      list.try_map(select_columns, fn(col) {
+        case col.expression_tokens {
+          Some(expr_tokens) -> {
+            use #(scalar, nullable) <- result.try(
+              infer_expression_type_from_tokens(
+                expr_tokens,
+                catalog,
+                [],
+                query_name,
+              ),
+            )
+            Ok(
+              model.ScalarResult(model.ResultColumn(
+                name: col.name,
+                scalar_type: scalar,
+                nullable: nullable,
+                source_table: None,
+              )),
+            )
+          }
+          None ->
+            Error(UnsupportedExpression(
+              query_name: query_name,
+              expression: "unresolved column without FROM clause: " <> col.name,
+            ))
+        }
+      })
   }
 }
 
@@ -1627,7 +1678,7 @@ type FunctionClass {
 
 fn classify_function(lowered_name: String) -> FunctionClass {
   case lowered_name {
-    "count" -> FnCount
+    "count" | "last_insert_rowid" -> FnCount
     "sum" | "min" | "max" -> FnAggregateInner
     "avg" -> FnAvg
     "row_number" | "rank" | "dense_rank" | "ntile" -> FnWindowInt

--- a/src/sqlode/query_analyzer/type_inference.gleam
+++ b/src/sqlode/query_analyzer/type_inference.gleam
@@ -422,7 +422,7 @@ fn infer_function_body(
   window: Bool,
 ) -> Result(InferredType, AnalysisError) {
   case name {
-    "count" -> ok(model.IntType, False)
+    "count" | "last_insert_rowid" -> ok(model.IntType, False)
     "sum" | "min" | "max" -> infer_aggregate_from_first(scope, args, True)
     "avg" -> ok(model.FloatType, True)
     "row_number" | "rank" | "dense_rank" | "ntile" -> ok(model.IntType, False)

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -289,6 +289,70 @@ pub fn render_sqlight_adapter_test() {
   |> should.be_true()
 }
 
+/// Issue #492: a `:one` query whose only column comes from a SQLite
+/// scalar function (`last_insert_rowid()`) used to leave the type
+/// inference unable to resolve the column, so `models.gleam` did not
+/// gain a row type and the sqlight adapter referenced a non-existent
+/// type while collapsing the decoder to `decode.success(Nil)`.
+pub fn render_sqlight_adapter_one_function_column_test() {
+  let naming_ctx = naming.new()
+  let block =
+    model.SqlBlock(
+      name: None,
+      engine: model.SQLite,
+      schema: ["schema.sql"],
+      queries: ["query.sql"],
+      gleam: model.GleamOutput(
+        out: "test_output/db",
+        runtime: model.Native,
+        type_mapping: model.StringMapping,
+        emit_sql_as_comment: False,
+        emit_exact_table_names: False,
+        omit_unused_models: False,
+        vendor_runtime: False,
+        strict_views: False,
+        query_parameter_limit: option.None,
+      ),
+      overrides: model.empty_overrides(),
+    )
+
+  // No tables are needed; the column source is a scalar function.
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([#("schema.sql", "")])
+
+  let query_sql =
+    "-- name: GetLastInsertId :one\nSELECT last_insert_rowid() AS id;\n"
+  let assert Ok(queries) =
+    query_parser.parse_file("query.sql", model.SQLite, naming_ctx, query_sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+
+  let rendered = adapter.render(naming_ctx, block, analyzed, dict.new())
+
+  // The adapter must reference the row type ...
+  string.contains(rendered, "models.GetLastInsertIdRow") |> should.be_true()
+  // ... read the column with a real int decoder ...
+  string.contains(rendered, "decode.int") |> should.be_true()
+  // ... and not silently collapse to a Nil-shaped decoder.
+  string.contains(rendered, "decode.success(Nil)") |> should.be_false()
+
+  // The matching row type must also be emitted in `models.gleam` so the
+  // adapter's reference resolves at compile time.
+  let models_rendered =
+    models.render(
+      naming_ctx,
+      catalog,
+      analyzed,
+      dict.new(),
+      model.StringMapping,
+      False,
+    )
+  string.contains(models_rendered, "pub type GetLastInsertIdRow")
+  |> should.be_true()
+  string.contains(models_rendered, "id: Int")
+  |> should.be_true()
+}
+
 pub fn render_params_module_slice_test() {
   let naming_ctx = naming.new()
   let analyzed = analyzed_slice_queries(model.PostgreSQL)


### PR DESCRIPTION
## Summary

`:one` queries that have no FROM clause and project a single scalar expression — `SELECT last_insert_rowid() AS id;`, `SELECT random() AS r;`, `SELECT 1 + 2 AS n;` — used to generate a broken adapter / models pair: the column inferencer dropped to `Ok([])`, so `models.gleam` lacked the row type, but the SQLite adapter still referenced `models.<Name>Row` and shipped a `decode.success(Nil)` decoder that ignored the column. The consuming project failed to compile.

This PR wires the inferencer's existing IR-driven expression-type path (`infer_expression_type_from_tokens`) into the table-less branch and registers `last_insert_rowid` in both function dictionaries, so the row type, decoder, and adapter signature are produced consistently. Closes #492.

## Changes

- `src/sqlode/query_analyzer/column_inferencer.gleam`:
  - new `infer_table_less_columns/3` helper. Walks `tok_extract_select_columns(tokens)` and routes each `expression_tokens` through the existing `infer_expression_type_from_tokens` path (which itself goes through `expr_parser.parse_expr` → `type_inference.infer_expr_type`, falling back to the token-path classifier). Returns `ScalarResult(ResultColumn{ source_table: None })` for each select-list expression. Bare column references without a FROM clause still surface as `UnsupportedExpression` rather than collapsing silently.
  - `infer_columns_from_tokens_scoped` now calls the new helper from the `effective_tables == []` branch instead of returning `Ok([])`.
  - `classify_function` gains `last_insert_rowid` next to `count` (both `FnCount`, both yield `IntType, False`).
- `src/sqlode/query_analyzer/type_inference.gleam`: `infer_function_body` recognises `last_insert_rowid` next to `row_number` / `rank` / `dense_rank` / `ntile` (all `IntType, False`).
- `test/codegen_test.gleam`: new `render_sqlight_adapter_one_function_column_test` that drives the SQLite native runtime end-to-end on `SELECT last_insert_rowid() AS id;` and asserts (a) the adapter references `models.GetLastInsertIdRow`, (b) the decoder reads the int column (no `decode.success(Nil)` collapse), (c) `models.gleam` emits `pub type GetLastInsertIdRow` with `id: Int`.
- `CHANGELOG.md`: `[Unreleased]` entry describing the fix.

## Design Decisions

- **Reuse the existing IR-driven inference path** rather than introducing a parallel scalar-only inferencer. `infer_expression_type_from_tokens` already handles parser fallbacks, casts, function calls, and literals — the only missing piece was a caller that didn't require a FROM table. Routing through it keeps the logic in one place and means future expression types (e.g. `SELECT CAST('1' AS INTEGER) AS n`) work without further wiring.
- **Register `last_insert_rowid` in both function dictionaries**. `infer_function_body` is the IR-based path used when `expr_parser` produces a structured `Func(...)` node; `classify_function` is the token-based fallback when the parser returns `RawExpr`. Either path can fire depending on the expression shape, so both need to know the function. The two registrations agree on `IntType, False`.
- **Bare column references without FROM stay rejected**. `SELECT id;` with no FROM cannot be resolved against any table, so `infer_table_less_columns` returns `UnsupportedExpression` on the missing `expression_tokens` arm. This is the documented "fail loudly" alternative the issue asked for.
- **No new public API**. `infer_table_less_columns` is `fn` (module-private), matching the surrounding helpers in `column_inferencer.gleam`.

## Limitations

- This PR only adds `last_insert_rowid` to the function dictionaries. Other SQLite scalar functions that share the same shape (`changes()`, `total_changes()`, `sqlite_version()`) are still classified as unknown. They would now make it through the `infer_table_less_columns` path far enough to surface a useful diagnostic instead of silently returning empty columns, but each still warrants its own dictionary entry. Tracked as a follow-up rather than expanding this PR's surface.
- Multi-column scalar SELECTs (`SELECT last_insert_rowid() AS id, random() AS r;`) are supported by the same code path but were not explicitly tested in this PR — the loop in `infer_table_less_columns` is `list.try_map`, so adding such a test is purely additive.

Closes #492.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where `:one` queries selecting scalar functions (like `last_insert_rowid()`) without a FROM clause would not properly infer the result type and decoder. The system now correctly recognizes these queries and generates appropriate row types and decoders.

* **Tests**
  * Added regression test for scalar function queries without FROM clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->