### PR TITLE
fix(analyzer): infer LIMIT/OFFSET placeholders as integer regardless of engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `LIMIT sqlode.arg(name)` and `OFFSET sqlode.arg(name)` now resolve
+  on every engine without requiring an explicit cast. Previously the
+  SQLite path failed type inference with
+  `could not infer type for parameter ?N. Use CAST(? AS INTEGER) to
+  specify the type`, and the suggested workaround
+  `CAST(sqlode.arg(name) AS INTEGER)` did not help because the macro
+  expanded to `?` before the surrounding cast was inspected. The
+  analyzer now derives `IntType` from the SQL-level integer context
+  (LIMIT/OFFSET expressions must evaluate to an integer), pinning
+  every placeholder reachable from those clauses regardless of
+  engine. Implemented in `param_inferencer.extract_int_context_params`
+  (token-level walk that tracks placeholder occurrence indices to
+  match `placeholder.build`'s assignment, since SQLite anonymous `?`
+  placeholders carry `Param.index = 0` in the IR by design). User-
+  written `CAST(? AS <type>)` still wins when present, since
+  `extract_type_casts` is layered on top. Pagination queries
+  (`SELECT … LIMIT ? OFFSET ?`) work as written. (#491)
 - `:one` queries that have no FROM clause and project a single scalar
   expression (e.g. `SELECT last_insert_rowid() AS id;`,
   `SELECT random() AS r;`) now produce a complete row type and a

--- a/src/sqlode/query_analyzer.gleam
+++ b/src/sqlode/query_analyzer.gleam
@@ -201,6 +201,14 @@ fn build_params(
       )
     }),
   )
+  // Issue #491: LIMIT/OFFSET placeholders are integer by SQL spec, even
+  // without an explicit cast. Merge their inferred types into the cast
+  // dict so a `?` in `LIMIT ?` / `OFFSET ?` resolves to `IntType`. Any
+  // user-written `CAST(? AS <type>)` still wins because `extract_type_casts`
+  // is layered on top.
+  let int_context_dict =
+    param_inferencer.extract_int_context_params(tokens, engine)
+  let cast_dict = dict.merge(int_context_dict, cast_dict)
   let macro_dict = build_macro_dict(query.macros)
   use inference_dict <- result.try(build_inference_dict(query.name, inferences))
 

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -909,3 +909,87 @@ pub fn extract_type_casts(
 fn cast_type_to_scalar(type_name: String) -> Result(model.ScalarType, Nil) {
   model.parse_sql_type(string.trim(type_name))
 }
+
+// ============================================================
+// LIMIT / OFFSET integer context (Issue #491)
+// ============================================================
+
+/// Extract placeholder type hints from SQL contexts that the spec
+/// requires to be integer: the expressions following `LIMIT` and
+/// `OFFSET`. Each placeholder reachable from those keywords (until a
+/// terminating keyword or end of statement) is pinned to `IntType`.
+/// Used as a complement to `extract_type_casts` so callers can write
+/// `LIMIT sqlode.arg(lim)` / `OFFSET sqlode.arg(off)` without an
+/// explicit cast on engines like SQLite that cannot infer the type
+/// from a bare `?` (Issue #491).
+///
+/// Implementation note: this works at the token level rather than the
+/// IR, because the IR's `Param.index` is `0` for SQLite anonymous `?`
+/// placeholders (`expr_parser.decode_placeholder` deliberately
+/// returns `0` for them). The token walker assigns each placeholder
+/// an occurrence index that matches what `placeholder.build`
+/// computes, so the resulting dict keys line up with
+/// `PlaceholderOccurrence.index` consumed by `build_params`.
+pub fn extract_int_context_params(
+  tokens: List(lexer.Token),
+  engine: model.Engine,
+) -> dict.Dict(Int, model.ScalarType) {
+  let int_indices = scan_int_context_indices(tokens, engine, 1, False, [])
+  list.fold(int_indices, dict.new(), fn(d, idx) {
+    dict.insert(d, idx, model.IntType)
+  })
+}
+
+/// Walk the token stream once, counting placeholders to assign each a
+/// 1-based occurrence index, and collect those that fall inside a
+/// `LIMIT` / `OFFSET` clause. `in_int_context` flips on at `LIMIT` /
+/// `OFFSET` and flips off at any keyword that ends the integer
+/// expression (`union`, `except`, `intersect`, `returning`, `for`).
+fn scan_int_context_indices(
+  tokens: List(lexer.Token),
+  engine: model.Engine,
+  occurrence: Int,
+  in_int_context: Bool,
+  acc: List(Int),
+) -> List(Int) {
+  case tokens {
+    [] -> list.reverse(acc)
+    [lexer.Keyword(k), ..rest] -> {
+      let lower = string.lowercase(k)
+      let next_state = case lower {
+        "limit" | "offset" -> True
+        "union" | "except" | "intersect" | "returning" | "for" -> False
+        _ -> in_int_context
+      }
+      scan_int_context_indices(rest, engine, occurrence, next_state, acc)
+    }
+    [lexer.Placeholder(raw), ..rest] -> {
+      let assigned = case engine {
+        model.PostgreSQL ->
+          // `$N` carries an explicit index in its raw text.
+          case
+            raw
+            |> string.replace("$", "")
+            |> int.parse
+          {
+            Ok(n) -> n
+            Error(_) -> occurrence
+          }
+        _ -> occurrence
+      }
+      let acc = case in_int_context {
+        True -> [assigned, ..acc]
+        False -> acc
+      }
+      scan_int_context_indices(
+        rest,
+        engine,
+        occurrence + 1,
+        in_int_context,
+        acc,
+      )
+    }
+    [_, ..rest] ->
+      scan_int_context_indices(rest, engine, occurrence, in_int_context, acc)
+  }
+}

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -353,6 +353,60 @@ pub fn render_sqlight_adapter_one_function_column_test() {
   |> should.be_true()
 }
 
+/// Issue #491: SQLite engine should accept `LIMIT sqlode.arg(lim)` and
+/// `OFFSET sqlode.arg(off)` without an explicit cast. Both placeholders
+/// are bound to `IntType` by the LIMIT/OFFSET integer-context rule.
+pub fn analyze_sqlite_limit_offset_params_pin_int_type_test() {
+  let naming_ctx = naming.new()
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([
+      #("schema.sql", "CREATE TABLE pages (id INTEGER, slug TEXT);"),
+    ])
+  let query_sql =
+    "-- name: ListPages :many\nSELECT slug FROM pages ORDER BY id DESC LIMIT sqlode.arg(lim) OFFSET sqlode.arg(off);\n"
+  let assert Ok(queries) =
+    query_parser.parse_file("query.sql", model.SQLite, naming_ctx, query_sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+
+  let assert [analyzed_query] = analyzed
+  // Both placeholders surface as QueryParam entries with IntType.
+  list.length(analyzed_query.params) |> should.equal(2)
+  list.all(analyzed_query.params, fn(p) { p.scalar_type == model.IntType })
+  |> should.be_true()
+  // Param names come from the macro labels, not from the column they
+  // bind against (there is no column to bind to in LIMIT/OFFSET).
+  list.map(analyzed_query.params, fn(p) { p.field_name })
+  |> list.contains("lim")
+  |> should.be_true()
+  list.map(analyzed_query.params, fn(p) { p.field_name })
+  |> list.contains("off")
+  |> should.be_true()
+}
+
+/// Issue #491: an explicit CAST is still honoured. `LIMIT
+/// CAST(sqlode.arg(lim) AS INTEGER)` resolves to `IntType` through the
+/// LIMIT-context rule (and would also resolve through the
+/// `extract_type_casts` path for engines that support cast suffix).
+pub fn analyze_sqlite_limit_offset_with_cast_still_works_test() {
+  let naming_ctx = naming.new()
+  let assert Ok(#(catalog, _)) =
+    schema_parser.parse_files([
+      #("schema.sql", "CREATE TABLE pages (id INTEGER, slug TEXT);"),
+    ])
+  let query_sql =
+    "-- name: ListPages :many\nSELECT slug FROM pages LIMIT CAST(sqlode.arg(lim) AS INTEGER) OFFSET CAST(sqlode.arg(off) AS INTEGER);\n"
+  let assert Ok(queries) =
+    query_parser.parse_file("query.sql", model.SQLite, naming_ctx, query_sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+
+  let assert [analyzed_query] = analyzed
+  list.length(analyzed_query.params) |> should.equal(2)
+  list.all(analyzed_query.params, fn(p) { p.scalar_type == model.IntType })
+  |> should.be_true()
+}
+
 pub fn render_params_module_slice_test() {
   let naming_ctx = naming.new()
   let analyzed = analyzed_slice_queries(model.PostgreSQL)


### PR DESCRIPTION
## Summary

`LIMIT sqlode.arg(name)` / `OFFSET sqlode.arg(name)` previously failed type inference on the SQLite engine with `could not infer type for parameter ?N`, and the documented workaround `CAST(sqlode.arg(name) AS INTEGER)` was still rejected (the macro expanded to `?` before the surrounding cast was inspected). This PR derives `IntType` from the SQL-level integer context — LIMIT and OFFSET expressions must evaluate to integer — so any placeholder reachable from those clauses is pinned to `Int` regardless of engine. Pagination queries now work as written. Closes #491.

## Changes

- `src/sqlode/query_analyzer/param_inferencer.gleam`:
  - new `extract_int_context_params(tokens, engine) -> Dict(Int, ScalarType)`. Walks the token stream once, tracking a 1-based placeholder occurrence count and an `in_int_context` flag that flips on at `LIMIT` / `OFFSET` and flips off at boundary keywords (`UNION` / `EXCEPT` / `INTERSECT` / `RETURNING` / `FOR`). Every placeholder seen while the flag is on is recorded with the matching occurrence index → `IntType`.
  - The walker is implemented at the token level (not on the IR) because `expr_parser.decode_placeholder` returns `0` for SQLite anonymous `?` placeholders by design. Walking tokens lets us assign each `?` the same 1-based index that `placeholder.build_occurrences` later produces, so the resulting dict keys line up with `PlaceholderOccurrence.index` consumed by `build_params`.
- `src/sqlode/query_analyzer.gleam`:
  - `build_params` merges `extract_int_context_params(tokens, engine)` into `cast_dict` after `extract_type_casts`. `dict.merge(int_context_dict, cast_dict)` keeps `extract_type_casts` results as the source of truth, so a user-written `CAST(? AS <other-type>)` still wins.
- `test/codegen_test.gleam`:
  - `analyze_sqlite_limit_offset_params_pin_int_type_test` — full pipeline (parse → analyze) on `SELECT … LIMIT sqlode.arg(lim) OFFSET sqlode.arg(off);` against an SQLite catalog. Asserts both `QueryParam` records have `scalar_type == IntType` and that the macro labels `lim` / `off` round-trip into `field_name`.
  - `analyze_sqlite_limit_offset_with_cast_still_works_test` — same pipeline with `LIMIT CAST(sqlode.arg(lim) AS INTEGER) OFFSET CAST(sqlode.arg(off) AS INTEGER);`. Confirms the cast variant continues to resolve to `IntType` (regression cover for the cast-suffix workaround that the issue reported as broken).
- `CHANGELOG.md`: `[Unreleased]` entry describing the fix and the layering rule (CAST wins).

## Design Decisions

- **Layered, not replacement**. `extract_int_context_params` runs alongside `extract_type_casts`, not in its place. PostgreSQL's `$N::int` and SQLite's user-written `CAST(? AS BLOB)` (Issue #477) keep working unchanged: `cast_dict` is still computed from `extract_type_casts`, then `int_context_dict` is merged underneath so it only fills in placeholders that nobody else has typed.
- **Token level, not IR**. The IR would have been the natural fit (`SelectCore.limit: Option(Expr)`, `Param(index: Int, raw: String)`), but `expr_parser.decode_placeholder` deliberately returns `0` for SQLite anonymous `?` so the analyzer can surface `ParameterTypeNotInferred`. Using `Param.index` from the IR therefore loses the per-occurrence binding. Walking the tokens once and counting in source order gives the same 1-based indices `placeholder.build_occurrences` assigns, so `build_params`'s lookup hits.
- **Boundary keywords are explicit**. `LIMIT` flips the integer-context flag on; `UNION` / `EXCEPT` / `INTERSECT` / `RETURNING` / `FOR` flip it off. This deliberately stays inside a single statement: a `UNION ALL ... LIMIT ?` pair on the right-hand side of the union is still picked up by the recursive structure (the walker continues past the `UNION` boundary with the flag reset, so the second `LIMIT` re-enters the context). Subqueries' LIMITs participate in the same walk because parens do not gate the keyword scan; this is fine because every subquery `LIMIT ?` is also an integer context.
- **Engine-agnostic**. PostgreSQL `$N` placeholders carry an explicit index in the raw text; the walker honours that and falls back to the running counter only when parsing fails. MySQL and SQLite use occurrence-order indexing, matching `placeholder.build`. The implementation does not branch on engine for the LIMIT / OFFSET semantics — those are SQL-spec invariants.

## Limitations

- The walker stops the integer-context flag at `UNION` / `EXCEPT` / `INTERSECT` / `RETURNING` / `FOR` but does not currently track parenthesis depth. A statement like `SELECT (SELECT ? FROM t LIMIT 1)` does not need the inner `?` to be int-typed — and indeed it isn't, the walker only flips the flag at the *outer* LIMIT keyword. But a future case where a nested subquery's `LIMIT ?` straddles a flag boundary would behave conservatively (still int-typed). Not a regression today; flagged for future consideration.
- `FETCH FIRST n ROWS ONLY` (PostgreSQL/MySQL alternate pagination syntax) is not yet covered. Same shape as LIMIT / OFFSET; same `IntType` semantics. Left as a follow-up.

Closes #491.
