### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-27
+
 ### Fixed
 
 - `LIMIT sqlode.arg(name)` and `OFFSET sqlode.arg(name)` now resolve

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.10.0"
+version = "0.11.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.10.0"
+pub const version = "0.11.0"


### PR DESCRIPTION
### Fixed

- `LIMIT sqlode.arg(name)` and `OFFSET sqlode.arg(name)` now resolve
  on every engine without requiring an explicit cast. Previously the
  SQLite path failed type inference with
  `could not infer type for parameter ?N. Use CAST(? AS INTEGER) to
  specify the type`, and the suggested workaround
  `CAST(sqlode.arg(name) AS INTEGER)` did not help because the macro
  expanded to `?` before the surrounding cast was inspected. The
  analyzer now derives `IntType` from the SQL-level integer context
  (LIMIT/OFFSET expressions must evaluate to an integer), pinning
  every placeholder reachable from those clauses regardless of
  engine. Implemented in `param_inferencer.extract_int_context_params`
  (token-level walk that tracks placeholder occurrence indices to
  match `placeholder.build`'s assignment, since SQLite anonymous `?`
  placeholders carry `Param.index = 0` in the IR by design). User-
  written `CAST(? AS <type>)` still wins when present, since
  `extract_type_casts` is layered on top. Pagination queries
  (`SELECT … LIMIT ? OFFSET ?`) work as written. (#491)
- `:one` queries that have no FROM clause and project a single scalar
  expression (e.g. `SELECT last_insert_rowid() AS id;`,
  `SELECT random() AS r;`) now produce a complete row type and a
  matching decoder. Previously the column inferencer treated the
  table-less SELECT as having no columns and returned `Ok([])`, so
  `models.gleam` lacked the row type while the generated adapter
  still referenced it — the consuming project failed to compile.
  Two new pieces wire this up: (1) `infer_columns_from_tokens_scoped`
  now calls a new `infer_table_less_columns` helper when no FROM
  table is in scope, which uses the existing
  `infer_expression_type_from_tokens` path to recover the column
  type/nullability; (2) the SQLite-side function dictionary
  (`type_inference.infer_function_body` and
  `column_inferencer.classify_function`) gains
  `last_insert_rowid` so the int return type and non-null property
  are recognised. Bare column references without a FROM clause are
  still rejected with `UnsupportedExpression`. (#492)
