### PR TITLE
fix: resolve internal placeholders in QueryInfo.sql to engine-native format

### DIFF
--- a/src/sqlode/codegen/queries.gleam
+++ b/src/sqlode/codegen/queries.gleam
@@ -50,7 +50,7 @@ pub fn render(
     [] -> "[]"
     _ ->
       queries
-      |> list.map(fn(query) { render_query_info_literal(query.base) })
+      |> list.map(fn(query) { render_query_info_literal(query.base, engine) })
       |> string.join(", ")
       |> fn(items) { "[" <> items <> "]" }
   }
@@ -505,14 +505,41 @@ fn render_raw_base_decoder(
   }
 }
 
-fn render_query_info_literal(query: model.ParsedQuery) -> String {
+fn render_query_info_literal(
+  query: model.ParsedQuery,
+  engine: model.Engine,
+) -> String {
+  let sql = resolve_static_placeholders(query.sql, query.param_count, engine)
   "runtime.QueryInfo(name: \""
   <> common.escape_string(query.name)
   <> "\", sql: \""
-  <> common.escape_string(query.sql)
+  <> common.escape_string(sql)
   <> "\", command: runtime."
   <> model.query_command_to_string(query.command)
   <> ", param_count: "
   <> int.to_string(query.param_count)
   <> ")"
+}
+
+/// Replace internal `__sqlode_param_N__` and `__sqlode_slice_N__` markers with
+/// engine-native placeholders for static display in QueryInfo.sql.
+/// Slice markers are treated as a single placeholder since their runtime
+/// expansion size is unknown at generation time.
+fn resolve_static_placeholders(
+  sql: String,
+  param_count: Int,
+  engine: model.Engine,
+) -> String {
+  int.range(from: 1, to: param_count + 1, with: sql, run: fn(current_sql, idx) {
+    let param = runtime.param_marker(idx)
+    let slice = runtime.slice_marker(idx)
+    let placeholder = case engine {
+      model.PostgreSQL -> "$" <> int.to_string(idx)
+      model.SQLite -> "?" <> int.to_string(idx)
+      model.MySQL -> "?"
+    }
+    current_sql
+    |> string.replace(param, placeholder)
+    |> string.replace(slice, placeholder)
+  })
 }


### PR DESCRIPTION
## Summary

Fix `QueryInfo.sql` to show engine-native placeholders (`?` for SQLite, `$N` for PostgreSQL, `?` for MySQL) instead of internal `__sqlode_param_N__` markers.

## Changes

- Pass `engine` to `render_query_info_literal` in codegen
- Add `resolve_static_placeholders` function that converts internal param/slice markers to engine-native format at generation time
- Slice markers are treated as single placeholders since runtime expansion size is unknown at codegen time

## Design Decisions

- Conversion happens at codegen time (not runtime) since QueryInfo is a static metadata view
- Uses `int.range` fold pattern consistent with the existing `expand_slice_placeholders` in runtime.gleam
- For MySQL (positional `?`), all params render as bare `?` regardless of index

Closes #496