### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-27
+
+### Fixed
+
+- `QueryInfo.sql` now shows engine-native placeholders (`$1` for PostgreSQL,
+  `?1` for SQLite, `?` for MySQL) instead of internal `__sqlode_param_N__`
+  markers. This makes the metadata suitable for logging, debugging, and
+  query cache keys without additional processing. (#496)
+
 ## [0.11.0] - 2026-04-27
 
 ### Fixed

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.11.0"
+version = "0.12.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.11.0"
+pub const version = "0.12.0"


### PR DESCRIPTION
### Fixed

- `QueryInfo.sql` now shows engine-native placeholders (`$1` for PostgreSQL,
  `?1` for SQLite, `?` for MySQL) instead of internal `__sqlode_param_N__`
  markers. This makes the metadata suitable for logging, debugging, and
  query cache keys without additional processing. (#496)