### PR TITLE
feat: add mise plugin for first-class install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First time here? [`doc/tutorials/getting-started-sqlite.md`](doc/tutorials/getti
 
 ### Install
 
-sqlode ships as an Erlang escript, so most paths need Erlang/OTP on the host. Option D (Docker) bundles Erlang and is the one exception.
+sqlode ships as an Erlang escript, so most paths need Erlang/OTP on the host. Option D (Docker) bundles Erlang, and option E (mise) manages both the escript and Erlang together.
 
 Whichever install path you pick, your Gleam project still needs `gleam add sqlode` because generated code imports `sqlode/runtime`.
 
@@ -64,6 +64,24 @@ docker run --rm -v "$PWD:/work" ghcr.io/nao1215/sqlode:latest generate
 ```
 
 The container's working directory is `/work`, so mounting your project there lets `init` / `generate` / `verify` write into the host. Swap `:latest` for a version tag (`:0.10.0`) to pin a release. The `:latest` tag appears once the docker workflow has run on `main`; before that, `docker build -t sqlode .` at the repo root produces the same image.
+
+#### E. mise (recommended for Gleam projects)
+
+If you already use [mise](https://mise.jdx.dev/) for managing Gleam and Erlang:
+
+```console
+mise plugin add sqlode https://github.com/nao1215/sqlode.git#mise-plugin
+mise install sqlode@latest
+```
+
+This installs the escript and manages versions alongside your Gleam/Erlang toolchain. Pin a version in `.mise.toml`:
+
+```toml
+[tools]
+sqlode = "0.12.0"
+```
+
+mise handles `PATH` automatically — no manual exports needed.
 
 ### Initialize config
 

--- a/mise-plugin/bin/download
+++ b/mise-plugin/bin/download
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Download a specific sqlode version.
+# mise sets ASDF_INSTALL_VERSION and ASDF_DOWNLOAD_PATH.
+
+set -eu
+
+REPO="nao1215/sqlode"
+VERSION="${ASDF_INSTALL_VERSION}"
+DOWNLOAD_PATH="${ASDF_DOWNLOAD_PATH}"
+
+mkdir -p "${DOWNLOAD_PATH}"
+
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/sqlode"
+
+echo "Downloading sqlode v${VERSION}..."
+curl -fsSL -o "${DOWNLOAD_PATH}/sqlode" "${URL}"
+chmod +x "${DOWNLOAD_PATH}/sqlode"

--- a/mise-plugin/bin/install
+++ b/mise-plugin/bin/install
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Install sqlode into the mise-managed path.
+# mise sets ASDF_INSTALL_PATH and ASDF_DOWNLOAD_PATH.
+
+set -eu
+
+DOWNLOAD_PATH="${ASDF_DOWNLOAD_PATH}"
+INSTALL_PATH="${ASDF_INSTALL_PATH}"
+
+mkdir -p "${INSTALL_PATH}/bin"
+cp "${DOWNLOAD_PATH}/sqlode" "${INSTALL_PATH}/bin/sqlode"
+chmod +x "${INSTALL_PATH}/bin/sqlode"
+
+echo "sqlode v${ASDF_INSTALL_VERSION} installed to ${INSTALL_PATH}/bin/sqlode"

--- a/mise-plugin/bin/list-all
+++ b/mise-plugin/bin/list-all
@@ -1,0 +1,12 @@
+#!/bin/sh
+# List all available sqlode versions (tags from GitHub).
+# mise calls this to populate the version list.
+
+set -eu
+
+REPO="nao1215/sqlode"
+
+curl -fsSL "https://api.github.com/repos/${REPO}/tags" \
+  | grep '"name"' \
+  | sed 's/.*"v\([^"]*\)".*/\1/' \
+  | tr '\n' ' '

--- a/mise-plugin/plugin.toml
+++ b/mise-plugin/plugin.toml
@@ -1,0 +1,8 @@
+[plugin]
+name = "sqlode"
+description = "Generate type-safe Gleam code from SQL schemas and queries"
+repository = "https://github.com/nao1215/sqlode"
+
+[plugin.env]
+# sqlode requires escript (Erlang/OTP) at runtime
+MISE_SQLODE_REQUIRES = "erlang"


### PR DESCRIPTION
## Summary

Add a mise/asdf-compatible plugin so users can install and manage sqlode versions alongside their Gleam/Erlang toolchain via `mise install sqlode@latest`.

## Changes

- Add `mise-plugin/bin/list-all` — fetches available versions from GitHub tags
- Add `mise-plugin/bin/download` — downloads the escript from GitHub Releases
- Add `mise-plugin/bin/install` — installs into the mise-managed directory
- Add `mise-plugin/plugin.toml` — plugin metadata
- Update README with install option E (mise) and update intro paragraph

## Usage

```console
mise plugin add sqlode https://github.com/nao1215/sqlode.git#mise-plugin
mise install sqlode@latest
```

Pin in `.mise.toml`:
```toml
[tools]
sqlode = "0.12.0"
```

Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded installation guide to include `mise` as an alternative setup option alongside existing methods.

* **New Features**
  * Introduced `mise` plugin support for simplified sqlode installation and automatic Erlang dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->