### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-27
+
+### Added
+
+- mise/asdf-compatible plugin for version-managed installs. Users can now
+  run `mise plugin add sqlode` and `mise install sqlode@latest` to manage
+  sqlode alongside their Gleam/Erlang toolchain. (#433)
+
 ## [0.12.0] - 2026-04-27
 
 ### Fixed

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.12.0"
+version = "0.13.0"
 target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]

--- a/src/sqlode/version.gleam
+++ b/src/sqlode/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.12.0"
+pub const version = "0.13.0"


### PR DESCRIPTION
### Added

- mise/asdf-compatible plugin for version-managed installs. Users can now
  run `mise plugin add sqlode` and `mise install sqlode@latest` to manage
  sqlode alongside their Gleam/Erlang toolchain. (#433)