### PR TITLE
fix(infer): resolve CAST type inference in UPDATE SET clause

### DIFF
--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.10.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.13.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -236,14 +236,14 @@ fn find_equality_matches_in_stmt(
 fn assignment_match(
   assignment: query_ir.Assignment,
 ) -> Result(token_utils.EqualityMatch, Nil) {
-  case assignment.value {
-    query_ir.Param(raw:, ..) ->
+  case param_of(assignment.value) {
+    Some(raw) ->
       Ok(token_utils.EqualityMatch(
         column_name: naming.normalize_identifier(assignment.column),
         table_qualifier: None,
         placeholder: raw,
       ))
-    _ -> Error(Nil)
+    None -> Error(Nil)
   }
 }
 
@@ -884,25 +884,104 @@ pub fn extract_type_casts(
   engine: model.Engine,
   tokens: List(lexer.Token),
 ) -> Result(dict.Dict(Int, model.ScalarType), #(Int, String)) {
-  case engine {
-    model.PostgreSQL -> {
-      let casts = token_utils.find_type_casts(tokens)
-      list.try_fold(casts, dict.new(), fn(d, cast) {
-        case
-          cast.placeholder
-          |> string.replace("$", "")
-          |> int.parse
-        {
-          Ok(index) ->
-            case cast_type_to_scalar(cast.cast_type) {
-              Ok(scalar_type) -> Ok(dict.insert(d, index, scalar_type))
-              Error(Nil) -> Error(#(index, string.trim(cast.cast_type)))
-            }
-          Error(_) -> Ok(d)
-        }
-      })
+  // PostgreSQL `$N::type` casts (token_utils finds these).
+  let pg_casts = token_utils.find_type_casts(tokens)
+  use pg_dict <- result.try(
+    list.try_fold(pg_casts, dict.new(), fn(d, cast) {
+      case
+        cast.placeholder
+        |> string.replace("$", "")
+        |> int.parse
+      {
+        Ok(index) ->
+          case cast_type_to_scalar(cast.cast_type) {
+            Ok(scalar_type) -> Ok(dict.insert(d, index, scalar_type))
+            Error(Nil) -> Error(#(index, string.trim(cast.cast_type)))
+          }
+        Error(_) -> Ok(d)
+      }
+    }),
+  )
+  // SQL-standard `CAST(placeholder AS type)` — walk the token stream
+  // with an occurrence counter so SQLite anonymous `?` placeholders
+  // get the correct 1-based index (same logic as
+  // `scan_int_context_indices`).
+  let cast_hints = scan_cast_hints(tokens, engine, 1, [])
+  use cast_dict <- result.try(
+    list.try_fold(cast_hints, pg_dict, fn(d, pair) {
+      let #(index, type_name) = pair
+      case cast_type_to_scalar(type_name) {
+        Ok(scalar_type) -> Ok(dict.insert(d, index, scalar_type))
+        Error(Nil) -> Error(#(index, string.trim(type_name)))
+      }
+    }),
+  )
+  Ok(cast_dict)
+}
+
+/// Walk the token stream counting placeholder occurrences (1-based)
+/// and collect `CAST(placeholder AS type)` patterns with the
+/// resolved occurrence index.
+fn scan_cast_hints(
+  tokens: List(lexer.Token),
+  engine: model.Engine,
+  occurrence: Int,
+  acc: List(#(Int, String)),
+) -> List(#(Int, String)) {
+  case tokens {
+    [] -> list.reverse(acc)
+    // CAST(placeholder AS ident)
+    [
+      lexer.Keyword("cast"),
+      lexer.LParen,
+      lexer.Placeholder(raw),
+      lexer.Keyword("as"),
+      lexer.Ident(t),
+      lexer.RParen,
+      ..rest
+    ] -> {
+      let index = resolve_placeholder_index(engine, raw, occurrence)
+      scan_cast_hints(rest, engine, occurrence + 1, [
+        #(index, string.lowercase(t)),
+        ..acc
+      ])
     }
-    _ -> Ok(dict.new())
+    // CAST(placeholder AS keyword)
+    [
+      lexer.Keyword("cast"),
+      lexer.LParen,
+      lexer.Placeholder(raw),
+      lexer.Keyword("as"),
+      lexer.Keyword(t),
+      lexer.RParen,
+      ..rest
+    ] -> {
+      let index = resolve_placeholder_index(engine, raw, occurrence)
+      scan_cast_hints(rest, engine, occurrence + 1, [#(index, t), ..acc])
+    }
+    // Any other placeholder — count the occurrence but don't record a hint.
+    [lexer.Placeholder(_), ..rest] ->
+      scan_cast_hints(rest, engine, occurrence + 1, acc)
+    [_, ..rest] -> scan_cast_hints(rest, engine, occurrence, acc)
+  }
+}
+
+fn resolve_placeholder_index(
+  engine: model.Engine,
+  raw: String,
+  occurrence: Int,
+) -> Int {
+  case engine {
+    model.PostgreSQL ->
+      case
+        raw
+        |> string.replace("$", "")
+        |> int.parse
+      {
+        Ok(n) -> n
+        Error(_) -> occurrence
+      }
+    _ -> occurrence
   }
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -3220,3 +3220,68 @@ pub fn ir_table_alias_resolves_qualified_column_test() {
   col.name |> should.equal("id")
   col.scalar_type |> should.equal(model.IntType)
 }
+
+// ============================================================
+// Issue #501: CAST in UPDATE SET clause type inference
+// ============================================================
+
+pub fn update_set_cast_param_infers_type_from_column_pg_test() {
+  // Form 3: SET col = CAST(param AS TYPE) — column-based inference
+  // should work through CAST wrapper (PostgreSQL).
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: SetName :exec\nUPDATE authors SET name = CAST($1 AS TEXT) WHERE id = $2;"
+  let assert Ok(queries) =
+    query_parser.parse_file("cast_set.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [name_param, id_param] = query.params
+  name_param.scalar_type |> should.equal(model.StringType)
+  id_param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn update_set_cast_param_infers_type_from_column_sqlite_test() {
+  // Form 3: SET col = CAST(param AS TYPE) — column-based inference
+  // should work through CAST wrapper (SQLite).
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: SetName :exec\nUPDATE authors SET name = CAST(sqlode.arg(new_name) AS TEXT) WHERE id = sqlode.arg(author_id);"
+  let assert Ok(queries) =
+    query_parser.parse_file("cast_set.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+  let assert [name_param, id_param] = query.params
+  name_param.scalar_type |> should.equal(model.StringType)
+  id_param.scalar_type |> should.equal(model.IntType)
+}
+
+pub fn update_set_arithmetic_cast_infers_type_pg_test() {
+  // Form 2: SET col = col + CAST(param AS TYPE) — the CAST provides
+  // the type when column-based inference cannot (PostgreSQL).
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: IncrementId :exec\nUPDATE authors SET id = id + CAST($1 AS INTEGER) WHERE id = $2;"
+  let assert Ok(queries) =
+    query_parser.parse_file("arith_cast.sql", model.PostgreSQL, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  let assert [query] = analyzed
+  let assert [delta_param, id_param] = query.params
+  delta_param.scalar_type |> should.equal(model.IntType)
+  id_param.scalar_type |> should.equal(model.IntType)
+}


### PR DESCRIPTION
## Summary

- Fix `assignment_match` to unwrap `Cast(Param)` via `param_of`, enabling column-based type inference for `SET col = CAST(param AS TYPE)` patterns
- Add SQL-standard `CAST(placeholder AS type)` extraction with occurrence-based indexing for all engines (not just PostgreSQL `$N::type`)
- Support both direct CAST assignment (Form 3) and arithmetic CAST expressions (Form 2) in UPDATE SET clauses

## Changes

### `param_inferencer.gleam`
- **`assignment_match`**: Use `param_of()` helper to transparently unwrap `Cast(Param(...))` in UPDATE SET assignments, matching the behavior already used by `comparison_match`
- **`extract_type_casts`**: Extended to scan for SQL-standard `CAST(? AS type)` patterns across all engines via new `scan_cast_hints` walker with proper occurrence counting for SQLite anonymous `?` placeholders
- **`scan_cast_hints`**: New token walker that counts placeholder occurrences (1-based) and extracts CAST type hints
- **`resolve_placeholder_index`**: New helper that resolves placeholder index from raw text (`$N`) or occurrence counter

### `query_analyzer_test.gleam`
- PostgreSQL: `SET name = CAST($1 AS TEXT)` with column inference
- SQLite: `SET name = CAST(sqlode.arg(new_name) AS TEXT)` with column inference  
- PostgreSQL: `SET id = id + CAST($1 AS INTEGER)` with CAST-based inference

## Limitations

- Form 1 (`SET col = col + sqlode.arg(delta)` without CAST) still requires the workaround of direct assignment (`SET col = sqlode.arg(value)`). This is by design — without CAST or a direct column match, there is no type information to infer from.

Closes #501