### PR TITLE
fix(codegen): panic on SqlArray in SQLite/MySQL native adapters

### DIFF
--- a/src/sqlode/codegen/adapter.gleam
+++ b/src/sqlode/codegen/adapter.gleam
@@ -159,7 +159,7 @@ fn sqlight_value_to_driver_helper() -> String {
     runtime.SqlFloat(v) -> sqlight.float(v)
     runtime.SqlBool(v) -> sqlight.bool(v)
     runtime.SqlBytes(v) -> sqlight.blob(v)
-    runtime.SqlArray(_) -> sqlight.null()
+    runtime.SqlArray(_) -> panic as \"SqlArray is not supported in the SQLite native adapter. Use raw runtime for array parameters, or ensure sqlode.slice() values are expanded before reaching value_to_sqlight.\"
   }
 }"
 }
@@ -218,7 +218,7 @@ fn value_to_shork(value: runtime.Value) -> shork.Value {
     runtime.SqlBool(True) -> shork.int(1)
     runtime.SqlBool(False) -> shork.int(0)
     runtime.SqlBytes(v) -> bit_array_to_shork(v)
-    runtime.SqlArray(_) -> shork.null()
+    runtime.SqlArray(_) -> panic as \"SqlArray is not supported in the MySQL native adapter. Use raw runtime for array parameters, or ensure sqlode.slice() values are expanded before reaching value_to_shork.\"
   }
 }"
 }

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -557,6 +557,9 @@ pub fn render_sqlight_adapter_slice_test() {
     "fn value_to_sqlight(value: runtime.Value) -> sqlight.Value",
   )
   |> should.be_true()
+  // SqlArray should panic instead of silently converting to null (#502)
+  string.contains(rendered, "SqlArray is not supported in the SQLite native")
+  |> should.be_true()
 }
 
 pub fn expand_slice_placeholders_single_test() {
@@ -1497,6 +1500,9 @@ pub fn render_mysql_native_adapter_uses_shork_test() {
   // The stub message must not be present anywhere.
   string.contains(rendered, "MySQL adapter generation is not yet available")
   |> should.be_false()
+  // SqlArray should panic instead of silently converting to null (#502)
+  string.contains(rendered, "SqlArray is not supported in the MySQL native")
+  |> should.be_true()
 }
 
 pub fn render_mysql_native_adapter_decodes_last_insert_id_test() {


### PR DESCRIPTION
## Summary

- Replace silent `sqlight.null()` / `shork.null()` fallback for `SqlArray` with explicit `panic` in generated SQLite and MySQL native adapters
- Prevents silent data loss where array parameters become NULL on the wire

## Changes

### `adapter.gleam`
- `sqlight_value_to_driver_helper()`: `SqlArray(_)` branch now panics with a descriptive message instead of returning `sqlight.null()`
- `shork_value_to_driver_helper()`: Same treatment for MySQL adapter

### `codegen_test.gleam`
- Added assertions verifying the generated SQLite and MySQL adapters contain panic messages for SqlArray

## Design Decisions

- Chose option 3 from the issue (panic at runtime) rather than option 2 (reject at generation time) because `SqlArray` reaching `value_to_sqlight` is a programming error — the slice expansion should have already happened. A panic gives a clear stack trace pointing to the bug.
- PostgreSQL adapter is unaffected — it correctly handles arrays via `pog.array(value_to_pog, vs)`.

Closes #502