### PR TITLE
fix(parser): treat '-- name:' without valid command as regular SQL comment

### DIFF
--- a/src/sqlode/query_parser.gleam
+++ b/src/sqlode/query_parser.gleam
@@ -303,32 +303,39 @@ fn parse_annotation(
         |> list.filter(fn(part) { part != "" })
 
       case parts {
-        [name, command_text] -> {
-          use command <- result.try(
-            model.parse_query_command(command_text)
-            |> result.map_error(fn(detail) {
-              InvalidAnnotation(path:, line: line_number, detail:)
-            }),
-          )
+        [name, command_text] ->
+          case string.starts_with(command_text, ":") {
+            // Two parts where the second starts with ':' — this looks
+            // like an intentional annotation (`-- name: GetUsers :many`).
+            // Validate the command; an unrecognized command is still an error.
+            True -> {
+              use command <- result.try(
+                model.parse_query_command(command_text)
+                |> result.map_error(fn(detail) {
+                  InvalidAnnotation(path:, line: line_number, detail:)
+                }),
+              )
 
-          Ok(
-            Some(
-              PendingQuery(
-                name:,
-                function_name: naming.to_snake_case(naming_ctx, name),
-                command:,
-                start_line: line_number,
-                body_rev: [],
-              ),
-            ),
-          )
-        }
-        _ ->
-          Error(InvalidAnnotation(
-            path:,
-            line: line_number,
-            detail: "expected '-- name: <Name> <command>' or '/* name: <Name> <command> */' where command is one of: :one, :many, :exec, :execresult, :execrows, :execlastid, :batchone, :batchmany, :batchexec, :copyfrom",
-          ))
+              Ok(
+                Some(
+                  PendingQuery(
+                    name:,
+                    function_name: naming.to_snake_case(naming_ctx, name),
+                    command:,
+                    start_line: line_number,
+                    body_rev: [],
+                  ),
+                ),
+              )
+            }
+            // Second part doesn't start with ':' — not an annotation.
+            False -> Ok(None)
+          }
+        // Anything else: `-- name:` followed by text that doesn't look
+        // like an annotation (no colon-prefixed command).  Treat it as
+        // an ordinary SQL comment so it doesn't split the current query.
+        // Example: `-- name: this column stores the display name`
+        _ -> Ok(None)
       }
     }
   }

--- a/test/query_parser_test.gleam
+++ b/test/query_parser_test.gleam
@@ -288,16 +288,17 @@ SELECT id FROM authors WHERE name = @author_name;"
 
 // Error and boundary tests
 
-pub fn invalid_annotation_format_test() {
+pub fn annotation_without_command_is_treated_as_comment_test() {
+  // `-- name: OnlyName` (no colon-prefixed command) is treated as a
+  // regular SQL comment, not as an annotation.  This prevents false
+  // positives like `-- name: this column stores the display name`.
   let naming_ctx = naming.new()
   let content = "-- name: OnlyName\nSELECT 1;"
 
-  let assert Error(error) =
+  let assert Ok(queries) =
     parse_file("bad.sql", model.PostgreSQL, naming_ctx, content)
-  let msg = query_parser.error_to_string(error)
-  string.contains(msg, "expected") |> should.be_true()
-  string.contains(msg, ":one") |> should.be_true()
-  string.contains(msg, ":exec") |> should.be_true()
+  // No valid annotation → no queries parsed.
+  list.length(queries) |> should.equal(0)
 }
 
 pub fn invalid_command_test() {
@@ -926,14 +927,15 @@ pub fn parse_block_annotation_invalid_command_test() {
   string.contains(msg, "must be one of") |> should.be_true()
 }
 
-pub fn parse_block_annotation_missing_command_test() {
+pub fn parse_block_annotation_missing_command_is_comment_test() {
+  // `/* name: OnlyName */` (no colon-prefixed command) is treated as a
+  // regular SQL comment, not as an annotation.
   let naming_ctx = naming.new()
   let content = "/* name: OnlyName */\nSELECT 1;"
 
-  let assert Error(error) =
+  let assert Ok(queries) =
     parse_file("block.sql", model.PostgreSQL, naming_ctx, content)
-  let msg = query_parser.error_to_string(error)
-  string.contains(msg, "/* name:") |> should.be_true()
+  list.length(queries) |> should.equal(0)
 }
 
 pub fn parse_block_annotation_missing_sql_body_test() {
@@ -1269,4 +1271,64 @@ SELECT id FROM authors WHERE id = ?1 OR parent_id = ?1;"
     parse_file("q.sql", model.SQLite, naming_ctx, content)
   let assert [query] = queries
   query.param_count |> should.equal(1)
+}
+
+// ============================================================
+// Issue #503: '-- name:' inside query body treated as comment
+// ============================================================
+
+pub fn name_comment_in_query_body_is_ignored_test() {
+  // A SQL comment containing '-- name:' without a valid command
+  // should be treated as a regular comment, not a new annotation.
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetUserNotes :many
+SELECT id, content
+FROM notes
+WHERE user_id = $1
+-- name: This is just a comment explaining the column name
+ORDER BY created_at DESC;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+  // Should produce exactly one query, not two
+  let assert [query] = queries
+  query.name |> should.equal("GetUserNotes")
+  query.command |> should.equal(runtime.QueryMany)
+  // The ORDER BY should be part of the query body (lowercased by lexer)
+  string.contains(query.sql, "order by") |> should.be_true()
+}
+
+pub fn name_comment_with_colon_but_invalid_command_is_error_test() {
+  // `-- name: Foo :invalid` has a colon-prefixed command that doesn't
+  // match any valid command — this should still be an error because the
+  // user clearly intended an annotation.
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: Foo :invalid
+SELECT 1;"
+
+  let result = parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+  result |> should.be_error()
+}
+
+pub fn multiple_queries_with_name_comment_between_test() {
+  // Two valid queries separated by a non-annotation `-- name:` comment
+  // inside the first query body.
+  let naming_ctx = naming.new()
+  let content =
+    "-- name: GetNotes :many
+SELECT id
+-- name: this explains the column
+FROM notes;
+
+-- name: GetUsers :many
+SELECT id FROM users;"
+
+  let assert Ok(queries) =
+    parse_file("q.sql", model.PostgreSQL, naming_ctx, content)
+  let assert [q1, q2] = queries
+  q1.name |> should.equal("GetNotes")
+  string.contains(q1.sql, "from notes") |> should.be_true()
+  q2.name |> should.equal("GetUsers")
 }


### PR DESCRIPTION
## Summary

- SQL comments containing `-- name:` without a valid colon-prefixed command (e.g. `:many`, `:one`) are now treated as regular SQL comments instead of being misinterpreted as query annotations
- Intentional annotations with invalid commands (e.g. `-- name: Foo :invalid`) still produce errors

## Changes

### `query_parser.gleam`
- `parse_annotation()`: After splitting the annotation payload into parts, check if the second part starts with `:`. If it does, validate the command normally. If it doesn't (or there aren't exactly 2 parts), return `Ok(None)` to treat the line as a regular comment.

### `query_parser_test.gleam`
- Updated `invalid_annotation_format_test` → `annotation_without_command_is_treated_as_comment_test`: `-- name: OnlyName` is now `Ok([])` not `Error`
- Updated `parse_block_annotation_missing_command_test` → `parse_block_annotation_missing_command_is_comment_test`: same for block comments
- Added `name_comment_in_query_body_is_ignored_test`: verifies `-- name:` inside a query body doesn't split the query
- Added `name_comment_with_colon_but_invalid_command_is_error_test`: verifies `-- name: Foo :invalid` still errors
- Added `multiple_queries_with_name_comment_between_test`: verifies query boundaries work correctly with comments

Closes #503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query annotations now require a colon-prefixed command (e.g., `:query`) to be recognized as valid. Annotations without proper command syntax are treated as regular SQL comments instead of causing parse errors, allowing greater flexibility in SQL file formatting.

* **Tests**
  * Updated and expanded test coverage to verify handling of improperly formatted query annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->