### PR TITLE
fix(verify): add missing checks to match generate pipeline

### DIFF
--- a/src/sqlode/generate.gleam
+++ b/src/sqlode/generate.gleam
@@ -692,7 +692,7 @@ fn disambiguate_query_params(query: model.AnalyzedQuery) -> model.AnalyzedQuery 
   model.AnalyzedQuery(..query, params: list.reverse(renamed_reversed))
 }
 
-fn apply_column_renames(
+pub fn apply_column_renames(
   queries: List(model.AnalyzedQuery),
   renames: List(model.ColumnRename),
 ) -> List(model.AnalyzedQuery) {

--- a/src/sqlode/verify.gleam
+++ b/src/sqlode/verify.gleam
@@ -23,6 +23,7 @@ import gleam/result
 import gleam/string
 import simplifile
 import sqlode/config
+import sqlode/generate
 import sqlode/model
 import sqlode/naming
 import sqlode/query_analyzer
@@ -87,11 +88,20 @@ fn verify_block(
       case load_and_analyze(naming_ctx, block, catalog) {
         Error(detail) -> [Finding(block_out: out, detail: detail)]
         Ok(analyzed) ->
-          enforce_query_parameter_limit(
-            out,
-            analyzed,
-            block.gleam.query_parameter_limit,
-          )
+          case analyzed {
+            [] -> [
+              Finding(
+                block_out: out,
+                detail: "no queries were generated — query files are empty or contain no valid annotations",
+              ),
+            ]
+            _ ->
+              enforce_query_parameter_limit(
+                out,
+                analyzed,
+                block.gleam.query_parameter_limit,
+              )
+          }
       }
   }
 }
@@ -147,6 +157,9 @@ fn load_and_analyze(
       |> result.map_error(query_validation.error_to_string)
     model.Raw -> Ok(Nil)
   })
+  let analyzed =
+    generate.apply_column_renames(analyzed, block.overrides.column_renames)
+  let analyzed = generate.disambiguate_param_names(analyzed)
   Ok(analyzed)
 }
 

--- a/test/fixtures/verify_empty_query.sql
+++ b/test/fixtures/verify_empty_query.sql
@@ -1,0 +1,1 @@
+-- (no queries)

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -335,6 +335,7 @@ pub fn verify_execresult_under_raw_runtime_is_allowed_test() {
   let report = verify.verify_config(cfg)
   report.findings |> should.equal([])
 }
+
 // Note: the non-PostgreSQL array-parameter check
 // (`validate_array_engine_support`) is also shared with `generate`
 // via `sqlode/query_validation`. We do not add a fixture-based
@@ -345,3 +346,24 @@ pub fn verify_execresult_under_raw_runtime_is_allowed_test() {
 // array-typed params on a non-PostgreSQL engine, both `generate`
 // and `verify` will reject it with an identical message through
 // the shared validator.
+
+// ============================================================
+// Issue #504: verify must detect empty query lists
+// ============================================================
+
+pub fn verify_rejects_empty_query_file_test() {
+  // A query file with no valid annotations should produce a finding,
+  // matching what `generate` would report as NoQueriesGenerated.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block(
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_empty_query.sql",
+        "src/verify_empty_query_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "no queries") |> should.be_true()
+}


### PR DESCRIPTION
## Summary

- Add empty query list detection to `verify`, matching `generate`'s `NoQueriesGenerated` check
- Apply `apply_column_renames` and `disambiguate_param_names` transformations in verify's analysis pipeline
- Make `apply_column_renames` public in `generate.gleam` so `verify` can reuse it

## Changes

### `verify.gleam`
- `verify_block()`: Check for empty analyzed query list after `load_and_analyze`, producing a finding instead of silently passing
- `load_and_analyze()`: Call `generate.apply_column_renames()` and `generate.disambiguate_param_names()` after validation, mirroring the generate pipeline

### `generate.gleam`
- `apply_column_renames()`: Changed from `fn` to `pub fn` so verify can reuse it

### Test fixtures
- Added `test/fixtures/verify_empty_query.sql`: Empty query file for testing

### `verify_test.gleam`
- Added `verify_rejects_empty_query_file_test`: Verifies empty query files produce a finding

Closes #504