### PR TITLE
fix(codegen): include received value in enum/set decoder failure message

### DIFF
--- a/src/sqlode/codegen/common.gleam
+++ b/src/sqlode/codegen/common.gleam
@@ -25,25 +25,25 @@ pub fn render_enum_or_set_decoder(
   fallback: fn(model.ScalarType) -> String,
 ) -> String {
   case scalar_type {
-    // `decode.failure` requires a zero value of the target decoder's
-    // output type, not `String`. For ENUMs we call the generated
-    // `<name>_default()` helper (the first declared variant); for SETs
-    // `[]` is a natural empty fallback and Gleam infers the element
-    // type from the Ok branch.
+    // `decode.failure` requires a placeholder of the target type for
+    // type inference — it is never returned to callers. For ENUMs we
+    // call the generated `<name>_default()` helper; for SETs `[]` is
+    // a natural empty fallback. The error message includes the
+    // actual received value so schema-drift mismatches are diagnosable.
     model.EnumType(enum_name) ->
       "decode.then(decode.string, fn(s) { case models."
       <> type_mapping.enum_from_string_fn(enum_name)
       <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure(models."
       <> type_mapping.enum_default_fn(enum_name)
-      <> "(), \"valid "
+      <> "(), \"known "
       <> enum_name
-      <> " value\") } })"
+      <> " variant, got '\" <> s <> \"'\") } })"
     model.SetType(set_name) ->
       "decode.then(decode.string, fn(s) { case models."
       <> type_mapping.set_from_string_fn(set_name)
-      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure([], \"valid "
+      <> "(s) { Ok(v) -> decode.success(v) Error(_) -> decode.failure([], \"known "
       <> set_name
-      <> " set\") } })"
+      <> " set value, got '\" <> s <> \"'\") } })"
     _ -> fallback(scalar_type)
   }
 }

--- a/src/sqlode/codegen/models.gleam
+++ b/src/sqlode/codegen/models.gleam
@@ -182,10 +182,10 @@ fn render_enum_type(enum_def: model.EnumDef) -> String {
     builder.line("}"),
     builder.blank(),
     // `<name>_default()` is the first variant in declaration order.
-    // Used as the `decode.failure` fallback for generated decoders —
-    // `decode.failure` requires a zero of the target type, and hard-
-    // coding the first variant keeps the generated code
-    // type-checked without the caller needing to pick one at runtime.
+    // Used solely as the type-inference placeholder for
+    // `decode.failure` — this value is NEVER returned to callers.
+    // When `decode.failure` fires, the decoder produces a decode
+    // error and the placeholder is discarded by `decode.run`.
     builder.line("pub fn " <> default_fn <> "() -> " <> type_name <> " {"),
     builder.line("  " <> first_variant),
     builder.line("}"),


### PR DESCRIPTION
## Summary

- Improve enum and set decoder error messages to include the actual received value, making schema-drift mismatches diagnosable
- Clarify `_default()` function documentation to explain it is a type-inference placeholder only, never returned to callers

## Changes

### `common.gleam`
- Enum decoder error: `"valid status value"` → `"known status variant, got '" <> s <> "'"`
- Set decoder error: `"valid role set"` → `"known role set value, got '" <> s <> "'"`
- Updated code comments to clarify placeholder semantics

### `models.gleam`
- Updated `_default()` function comment to explicitly state the value is never returned to callers

## Design Decisions

- `decode.failure` in Gleam's stdlib does produce a decode error (the placeholder is discarded by `decode.run`), so the decoder does NOT silently succeed. However, the previous error message (`"valid status value"`) provided no indication of what value was actually received, making schema-drift bugs hard to diagnose. The fix includes the received string in the error.

Closes #505