### PR TITLE
fix(naming): treat Latin mass-noun plurals as already-singular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **naming**: `singularize` (and therefore `table_type_name`) now
+  treats `media`, `data`, `criteria`, `agenda`, `schemata`, `bacteria`,
+  and `phenomena` as already-singular mass nouns rather than rewriting
+  them to their formal Latin singular (`Medium`, `Datum`, `Criterion`,
+  `Agendum`, `Schema`, `Bacterium`, `Phenomenon`). A `media` table
+  generates a Gleam type called `Media`, not `Medium` — matching what
+  most modern English speakers expect. Projects that genuinely want the
+  Latin form can still keep the source name singular (e.g. `medium`)
+  in the schema. (#514)
+
 ## [0.14.0] - 2026-04-27
 
 ### Fixed

--- a/src/sqlode/naming.gleam
+++ b/src/sqlode/naming.gleam
@@ -162,10 +162,15 @@ pub fn singularize(word: String) -> String {
     "geese" -> apply_case(word, "goose")
     "teeth" -> apply_case(word, "tooth")
     "feet" -> apply_case(word, "foot")
-    "data" -> apply_case(word, "datum")
-    "media" -> apply_case(word, "medium")
-    "criteria" -> apply_case(word, "criterion")
     // Uncountable / already singular
+    //
+    // Issue #514: Latin-style plurals (`media`, `data`, `criteria`, …)
+    // are mass nouns or already-singular in modern English usage. The
+    // formally correct singulars (`Medium`, `Datum`, `Criterion`)
+    // surprise every Gleam user picking these as table names. Treat
+    // them as already singular so a `media` table generates `Media`,
+    // not `Medium`. Per-table type-name overrides remain a follow-up
+    // for projects that genuinely want the Latin form.
     "news"
     | "series"
     | "species"
@@ -184,7 +189,14 @@ pub fn singularize(word: String) -> String {
     | "virus"
     | "focus"
     | "consensus"
-    | "corpus" -> word
+    | "corpus"
+    | "data"
+    | "media"
+    | "criteria"
+    | "agenda"
+    | "schemata"
+    | "bacteria"
+    | "phenomena" -> word
     _ -> singularize_regular(word, lower)
   }
 }

--- a/test/naming_test.gleam
+++ b/test/naming_test.gleam
@@ -228,6 +228,30 @@ pub fn singularize_irregular_test() {
   naming.singularize("children") |> should.equal("child")
 }
 
+/// Issue #514: Latin-style plurals (`media`, `data`, `criteria`, …)
+/// are mass nouns or already-singular in modern English usage. The
+/// formally correct singulars (`Medium`, `Datum`, `Criterion`)
+/// surprise every Gleam user picking these as table names. They are
+/// now treated as already-singular so a `media` table generates a
+/// `Media` type rather than `Medium`.
+pub fn singularize_latin_mass_nouns_treated_as_singular_test() {
+  naming.singularize("media") |> should.equal("media")
+  naming.singularize("data") |> should.equal("data")
+  naming.singularize("criteria") |> should.equal("criteria")
+  naming.singularize("agenda") |> should.equal("agenda")
+  naming.singularize("schemata") |> should.equal("schemata")
+  naming.singularize("bacteria") |> should.equal("bacteria")
+  naming.singularize("phenomena") |> should.equal("phenomena")
+}
+
+/// And the resulting type name when fed through the table-name
+/// pipeline is the modern-English-friendly form (no surprise `Medium`).
+pub fn table_type_name_for_media_table_is_media_test() {
+  let ctx = naming.new()
+  naming.table_type_name(ctx, "media", False) |> should.equal("Media")
+  naming.table_type_name(ctx, "data", False) |> should.equal("Data")
+}
+
 // Edge case tests — empty strings, single chars, unicode, numbers only
 
 pub fn pascal_case_empty_string_test() {


### PR DESCRIPTION
## Summary

Fixes Issue #514. `naming.singularize` previously rewrote
`media` → `medium`, `data` → `datum`, `criteria` → `criterion`
because that is the formally correct Latin singular. In modern
English usage these are mass nouns or already-singular forms, and
every Gleam user picking `media` (or `data`) as a SQL table name
expects a generated type called `Media`, not `Medium`.

Move them — plus `agenda`, `schemata`, `bacteria`, `phenomena`,
all flagged in the issue — into the uncountable / already-singular
bucket so `table_type_name(ctx, "media", emit_exact_table_names: False)`
returns `"Media"`.

## Changes

- `src/sqlode/naming.gleam`: drop the `media`/`data`/`criteria`
  case arms from the irregular-plurals dispatch, append them plus
  `agenda`/`schemata`/`bacteria`/`phenomena` to the uncountable
  list.
- `test/naming_test.gleam`: two new tests — one pins each new
  uncountable spelling at the `singularize` layer, one pins the
  end-to-end `table_type_name` outcome (`media` → `Media`,
  `data` → `Data`).
- `CHANGELOG.md`: documents under `### Changed` in the Unreleased
  section.

## Design Decisions

- **Treat as already-singular, not as a separate "uncountable"
  category.** The codepath that handles `news`/`series`/`status`
  already returns the input unchanged; mass nouns fit the same
  semantics — `singularize("media") == "media"` is the correct
  output. No new branch is introduced.
- **No config-side override.** The issue suggested a per-table
  `type_overrides` map under `sqlode.yaml`. That's a larger
  surface change (config schema + plumbing into codegen) and is
  orthogonal to fixing the seven words that almost every project
  hits. Leave the override hook as a follow-up if a project needs
  `Medium` back.
- **Keep `people`/`children` etc.** Those are unambiguously plural
  in English and the formal singular is what users want. Only the
  Latin set in the issue is reclassified.

## Test Plan

- [x] `gleam format --check src/ test/` — clean.
- [x] `gleam test` — 1064 passes (2 new tests for #514).
- [x] `gleam run -m glinter` — no issues.

Closes #514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected type naming behavior for mass nouns. Terms like "data," "media," and "criteria" are now treated as singular forms rather than converting to Latin singulars, producing more intuitive English-friendly type names (e.g., `Media` instead of `Medium`). Documentation includes guidance on retaining Latin forms if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->