### PR TITLE
fix(lexer): consistently lowercase IGNORE / ABORT / FAIL keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **lexer / generated SQL**: `INSERT OR IGNORE` / `INSERT OR ABORT`
+  / `INSERT OR FAIL` no longer render as the mixed-case
+  `insert or IGNORE / ABORT / FAIL ...` string. The conflict-resolution
+  keywords `IGNORE`, `ABORT`, and `FAIL` were not in the recognized SQL
+  keyword list, so they survived as preserved-case `Ident` tokens
+  while their `INSERT` / `OR` / `INTO` siblings normalised to
+  lowercase via the `Keyword` token path. Promoting the three to
+  keywords restores consistent lowercasing across the rendered SQL
+  string in `RawQuery.sql` / `runtime.QueryInfo.sql` and matches the
+  treatment already given to `replace` / `rollback`. Pattern matchers
+  in `query_analyzer/token_utils.is_insert_or_action_token` now
+  accept both the new `Keyword` form and the legacy `Ident` form so
+  callers that hand-build token streams continue to work. Note: this
+  fix normalises the three specific words the issue identified;
+  full source-case preservation across all keywords would require an
+  architectural change to how the lexer stores `Keyword` tokens
+  (currently the lowercased canonical form) and is left as a
+  follow-up. (#513)
+
 ### Changed
 
 - **naming**: `singularize` (and therefore `table_type_name`) now

--- a/src/sqlode/lexer.gleam
+++ b/src/sqlode/lexer.gleam
@@ -643,7 +643,20 @@ fn is_sql_keyword(word: String) -> Bool {
     | "some"
     | "array"
     | "of"
-    | "collate" -> True
+    | "collate"
+    | // Issue #513: SQLite / MySQL conflict-resolution keywords
+      // (`INSERT OR IGNORE`, `INSERT OR ABORT`, `INSERT OR FAIL`,
+      // MySQL's bare `INSERT IGNORE`). Without these the surrounding
+      // `INSERT` / `OR` / `INTO` lowercase via the `Keyword` token
+      // path while `IGNORE` / `ABORT` / `FAIL` survive as `Ident`
+      // (preserved-case), producing the `insert or IGNORE into ...`
+      // mixed casing the issue reports. None of these is a
+      // realistic identifier name, so promoting them to keywords is
+      // safe and restores consistent lowercasing across the
+      // generated SQL string.
+      "ignore"
+    | "abort"
+    | "fail" -> True
     _ -> False
   }
 }

--- a/src/sqlode/query_analyzer/token_utils.gleam
+++ b/src/sqlode/query_analyzer/token_utils.gleam
@@ -289,9 +289,17 @@ pub fn strip_insert_or_action(tokens: List(lexer.Token)) -> List(lexer.Token) {
 }
 
 fn is_insert_or_action_token(token: lexer.Token) -> Bool {
+  // Issue #513: `ignore`, `abort`, and `fail` are now recognised SQL
+  // keywords (so they normalise to lowercase in rendered SQL like
+  // their `replace` / `rollback` siblings) and arrive here as
+  // `Keyword(...)` rather than `Ident(...)`. The `Ident` arm below
+  // is kept for legacy callers that build the token stream by hand.
   case token {
     lexer.Keyword("replace") -> True
     lexer.Keyword("rollback") -> True
+    lexer.Keyword("ignore") -> True
+    lexer.Keyword("abort") -> True
+    lexer.Keyword("fail") -> True
     lexer.Ident(t) ->
       t == "ignore"
       || t == "IGNORE"

--- a/test/lexer_test.gleam
+++ b/test/lexer_test.gleam
@@ -1,4 +1,5 @@
 import gleam/list
+import gleam/option
 import gleeunit
 import gleeunit/should
 import sqlode/lexer.{
@@ -597,4 +598,55 @@ pub fn unterminated_dollar_quoted_string_does_not_panic_test() {
 pub fn only_operators_input_does_not_panic_test() {
   let tokens = lexer.tokenize("= > < <= >= <>", model.PostgreSQL)
   tokens |> list.is_empty |> should.be_false
+}
+
+// --- Issue #513: keyword case consistency ---
+
+/// `INSERT OR IGNORE / ABORT / FAIL` previously rendered as `insert
+/// or IGNORE / ABORT / FAIL` because `IGNORE` / `ABORT` / `FAIL`
+/// were not in the keyword list and survived as preserved-case
+/// `Ident`s while their `INSERT` / `OR` / `INTO` siblings lowercased
+/// via the `Keyword` token path. They are now keywords and lowercase
+/// uniformly with the rest of the rendered SQL.
+pub fn insert_or_ignore_renders_consistently_lowercased_test() {
+  let opts =
+    lexer.TokenRenderOptions(
+      uppercase_keywords: False,
+      preserve_quotes: True,
+      engine: option.None,
+    )
+  let rendered =
+    "INSERT OR IGNORE INTO post_tags (post_id, tag) VALUES (?, ?)"
+    |> lexer.tokenize(model.SQLite)
+    |> lexer.tokens_to_string(opts)
+  rendered
+  |> should.equal("insert or ignore into post_tags(post_id, tag) values(?, ?)")
+}
+
+pub fn insert_or_abort_renders_consistently_lowercased_test() {
+  let opts =
+    lexer.TokenRenderOptions(
+      uppercase_keywords: False,
+      preserve_quotes: True,
+      engine: option.None,
+    )
+  let rendered =
+    "INSERT OR ABORT INTO t VALUES (1)"
+    |> lexer.tokenize(model.SQLite)
+    |> lexer.tokens_to_string(opts)
+  rendered |> should.equal("insert or abort into t values(1)")
+}
+
+pub fn insert_or_fail_renders_consistently_lowercased_test() {
+  let opts =
+    lexer.TokenRenderOptions(
+      uppercase_keywords: False,
+      preserve_quotes: True,
+      engine: option.None,
+    )
+  let rendered =
+    "INSERT OR FAIL INTO t VALUES (1)"
+    |> lexer.tokenize(model.SQLite)
+    |> lexer.tokens_to_string(opts)
+  rendered |> should.equal("insert or fail into t values(1)")
 }


### PR DESCRIPTION
## Summary

Fixes Issue #513. `INSERT OR IGNORE / ABORT / FAIL ...` previously
rendered into `RawQuery.sql` and `runtime.QueryInfo.sql` as the
mixed-case string `insert or IGNORE / ABORT / FAIL ...` because the
three conflict-resolution keywords were not in the recognized SQL
keyword list. They survived as preserved-case `Ident` tokens while
their `INSERT` / `OR` / `INTO` siblings normalised to lowercase via
the `Keyword` token path.

Promote `ignore`, `abort`, and `fail` to recognised SQL keywords so
the rendered SQL is consistently lowercased — matching the treatment
already given to `replace` / `rollback`. The user's `INSERT OR
IGNORE INTO post_tags(...)` reproduction now renders as
`insert or ignore into post_tags(...)`.

## Changes

- `src/sqlode/lexer.gleam`: append `ignore`, `abort`, `fail` to
  `is_sql_keyword`. None is a realistic identifier name, so promoting
  them is safe (no overlap with column/table-name use).
- `src/sqlode/query_analyzer/token_utils.gleam`:
  `is_insert_or_action_token` now matches `Keyword("ignore")` /
  `Keyword("abort")` / `Keyword("fail")` (the new lexer output)
  alongside the legacy `Ident("IGNORE"|"ABORT"|"FAIL"|...)` arms,
  which are kept so callers that hand-build token streams continue
  to work.
- `test/lexer_test.gleam`: three new regression tests pin the
  rendered SQL for `INSERT OR IGNORE / ABORT / FAIL` to the
  consistently-lowercased form.
- `CHANGELOG.md`: documents under `### Fixed` in Unreleased,
  including the architectural caveat below.

## Design Decisions

- **Targeted keyword promotion, not architectural source-case
  preservation.** The issue suggested two fixes:
  1. Preserve the source casing as-written (recommended).
  2. Normalise all reserved keywords uniformly.

  Option 1 would require changing the `Keyword(String)` token to
  carry the original case alongside the canonical lowercase form,
  which touches 400+ pattern-match sites across the codebase. That
  is a larger refactor than is justified by a UX/cosmetic issue.
  Option 2 — promote the missing keywords so they normalise like
  the rest — fixes the specific reproduction without any
  architectural risk and is what this PR implements.
- **Conservative keyword list.** Per the existing comment on `type`
  (intentionally NOT a keyword because of common column-name use),
  only words that are unambiguously SQL syntax are added.
  `ignore` / `abort` / `fail` are unambiguous in their SQLite /
  MySQL conflict-resolution role and are essentially never used as
  identifier names.
- **Both legacy and new matcher arms.** `is_insert_or_action_token`
  continues to accept the `Ident` forms (`"IGNORE"` / `"Ignore"` /
  `"ignore"` / etc.) so any internal or third-party code that
  builds token streams by hand keeps working without coordinated
  changes. The new `Keyword(...)` arms cover the lexer output going
  forward.

## Test Plan

- [x] `gleam format --check src/ test/` — clean.
- [x] `gleam test` — 1067 passes (3 new regression tests for #513).
- [x] `gleam run -m glinter` — no issues.
- [x] Walked the failing test cases when `is_insert_or_action_token`
  was missing the `Keyword` arms (analyzer rejected the new lexer
  output) and confirmed they pass after the matcher update.

Closes #513
