### PR TITLE
fix(param-inference)!: drop Option for comparison-site nullable params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **param inference (BREAKING)**: A placeholder bound by an equality
+  / comparison / `LIKE` predicate (`WHERE col <op> ?`,
+  `UPDATE … SET col = ?`, `WHERE col [I]LIKE ?`) or an `IN` predicate
+  (`WHERE col IN (?)`) on a nullable schema column no longer inherits
+  the column's `nullable: True` flag. The generated parameter type
+  drops the `Option(_)` wrapper because:
+  - `WHERE col = ?` against `None` would emit `WHERE col = NULL`,
+    which never matches by SQL `=` semantics — surfacing `Some(_)` /
+    `None` choice at the call site invites bugs that always return
+    an empty result set.
+  - `UPDATE … SET col = ?` is the user supplying the new value;
+    clearing to NULL is expressed in SQL as a literal
+    `SET col = NULL`, not as a parameter. There is no callable
+    `None` case here.
+
+  INSERT VALUES sites (where `None` legitimately writes NULL on the
+  wire) keep the column's nullability — they go through a different
+  inference pass and are unaffected. Callers that previously wrote
+  `Some(value)` at every comparison-style call site now drop the
+  wrapper and pass the bare value; callers that passed `None` (an
+  unreachable code path under the old contract too) need to rewrite
+  to a separate `IS NULL` query, mirroring how SQL itself expresses
+  the same condition. (#512)
+
 ### Fixed
 
 - **lexer / generated SQL**: `INSERT OR IGNORE` / `INSERT OR ABORT`

--- a/integration_test/fixtures/mysql_real_test.gleam
+++ b/integration_test/fixtures/mysql_real_test.gleam
@@ -167,7 +167,8 @@ pub fn update_bio_reports_one_changed_row_test() {
   let assert Ok(rows) =
     mysql_adapter.update_author_bio(
       db,
-      params.UpdateAuthorBioParams(id:, bio: option.Some("new bio")),
+      // Issue #512: SET col = ? on a nullable column drops Option(_).
+      params.UpdateAuthorBioParams(id:, bio: "new bio"),
     )
   rows |> should.equal(1)
 

--- a/integration_test/fixtures/sqlite_extended_test.gleam
+++ b/integration_test/fixtures/sqlite_extended_test.gleam
@@ -72,7 +72,8 @@ pub fn update_author_bio_execrows_test() {
   let assert Ok(rows_affected) =
     sqlight_adapter.update_author_bio(
       db,
-      params.UpdateAuthorBioParams(bio: Some("New bio"), id: 1),
+      // Issue #512: SET col = ? on a nullable column drops Option(_).
+      params.UpdateAuthorBioParams(bio: "New bio", id: 1),
     )
   let assert True = rows_affected == 1
 
@@ -80,7 +81,7 @@ pub fn update_author_bio_execrows_test() {
   let assert Ok(zero_rows) =
     sqlight_adapter.update_author_bio(
       db,
-      params.UpdateAuthorBioParams(bio: Some("Nope"), id: 999),
+      params.UpdateAuthorBioParams(bio: "Nope", id: 999),
     )
   let assert True = zero_rows == 0
 

--- a/src/sqlode/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/query_analyzer/param_inferencer.gleam
@@ -802,6 +802,26 @@ fn scan_token_matches(
                 matching_tables: matching_tables,
               ))
             Ok(Some(#(_table, column))) ->
+              // Issue #512: a placeholder bound by `col <op> ?`
+              // (equality, comparison, LIKE/ILIKE) or by `col IN (?)`
+              // can never meaningfully be `NULL` on the wire.
+              //
+              //   * `WHERE col = ?` against `None` would emit
+              //     `WHERE col = NULL`, which never matches by SQL
+              //     `=` semantics — wrapping the parameter in
+              //     `Option(_)` invites callers to pass `None` and
+              //     silently get an always-empty result set.
+              //   * `UPDATE … SET col = ?` is the user supplying the
+              //     new value; clearing to NULL is expressed in SQL
+              //     as a literal `SET col = NULL`, not as a parameter.
+              //
+              // Force `nullable: False` regardless of the column's
+              // schema-level nullability so the generated parameter
+              // record drops the noisy `Some(...)` wrappers at every
+              // call site for these positions. INSERT VALUES sites
+              // (where `None` legitimately writes NULL) keep the
+              // column's nullability because they go through
+              // `infer_insert_params_from_ir`, not this scanner.
               scan_token_matches(
                 engine,
                 catalog,
@@ -810,7 +830,7 @@ fn scan_token_matches(
                 rest,
                 next_occurrence,
                 updated_seen,
-                [#(index, column), ..acc],
+                [#(index, model.Column(..column, nullable: False)), ..acc],
               )
             Ok(None) ->
               scan_token_matches(

--- a/test/complex_sql_test.gleam
+++ b/test/complex_sql_test.gleam
@@ -112,14 +112,15 @@ pub fn cte_window_case_analyzer_test() {
 
   // $1 is a cast timestamp (used in `p.created_at >= $1::timestamp`).
   // $2 is the cast int inside the scored_users arithmetic.
-  // $3 is the outer WHERE filter against the CTE-derived `score`,
-  // which is itself nullable (arithmetic with a casted parameter),
-  // so the inferred parameter type inherits the column's nullability.
+  // $3 is the outer WHERE filter against the CTE-derived `score`.
+  // Even though the CTE column is nullable, the parameter site is a
+  // `WHERE … = ?` comparison and `=` against `NULL` never matches by
+  // SQL semantics, so the parameter is non-nullable per issue #512.
   param_types(query.params)
   |> should.equal([
     #(1, model.DateTimeType, False, False),
     #(2, model.IntType, False, False),
-    #(3, model.IntType, True, False),
+    #(3, model.IntType, False, False),
   ])
 
   // Result columns come from the outer SELECT over `scored_users`.

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -3285,3 +3285,100 @@ pub fn update_set_arithmetic_cast_infers_type_pg_test() {
   delta_param.scalar_type |> should.equal(model.IntType)
   id_param.scalar_type |> should.equal(model.IntType)
 }
+
+// ============================================================
+// Issue #512: nullable column in `WHERE col = ?` / `UPDATE SET col = ?`
+// emits a non-nullable parameter.
+// ============================================================
+
+fn nullable_post_catalog() -> model.Catalog {
+  model.Catalog(enums: [], tables: [
+    model.Table(name: "posts", columns: [
+      model.Column(name: "id", scalar_type: model.StringType, nullable: False),
+      model.Column(
+        name: "parent_id",
+        scalar_type: model.StringType,
+        nullable: True,
+      ),
+      model.Column(
+        name: "tombstone_reason",
+        scalar_type: model.StringType,
+        nullable: True,
+      ),
+      model.Column(
+        name: "created_at",
+        scalar_type: model.IntType,
+        nullable: False,
+      ),
+    ]),
+  ])
+}
+
+/// `WHERE parent_id = ?` against a nullable column is documented in
+/// the issue: `=` against `NULL` never matches by SQL semantics, so a
+/// `None` argument is unreachable. The generated parameter must drop
+/// the `Option` wrapper.
+pub fn where_eq_against_nullable_column_emits_non_null_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = nullable_post_catalog()
+  let sql =
+    "-- name: ListReplies :many\nSELECT id FROM posts WHERE parent_id = ? AND tombstone_reason IS NULL ORDER BY created_at ASC;"
+  let assert Ok(queries) =
+    query_parser.parse_file("repro.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+  let assert [parent_id_param] = query.params
+
+  parent_id_param.scalar_type |> should.equal(model.StringType)
+  // Issue #512: WHERE col = ? cannot meaningfully take None.
+  parent_id_param.nullable |> should.equal(False)
+}
+
+/// `UPDATE … SET col = ?` against a nullable column is the second
+/// reproduction in the issue. The caller is supplying the new value;
+/// clearing to NULL is expressed as a literal `SET col = NULL`, not
+/// as a parameter.
+pub fn update_set_against_nullable_column_emits_non_null_param_test() {
+  let naming_ctx = naming.new()
+  let catalog = nullable_post_catalog()
+  let sql =
+    "-- name: TombstonePost :exec\nUPDATE posts SET tombstone_reason = ? WHERE id = ? AND tombstone_reason IS NULL;"
+  let assert Ok(queries) =
+    query_parser.parse_file("tombstone.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+  let assert [reason_param, id_param] = query.params
+
+  reason_param.scalar_type |> should.equal(model.StringType)
+  // Issue #512: SET col = ? on a nullable column drops Option.
+  reason_param.nullable |> should.equal(False)
+
+  // The id param targets a non-nullable column already; behaviour
+  // unchanged.
+  id_param.scalar_type |> should.equal(model.StringType)
+  id_param.nullable |> should.equal(False)
+}
+
+/// INSERT VALUES (?, ?) sites still respect column nullability — a
+/// caller supplying values to a nullable column may legitimately want
+/// `None` to write NULL on the wire. The fix is targeted at
+/// comparison-style sites only.
+pub fn insert_values_into_nullable_column_keeps_option_wrapper_test() {
+  let naming_ctx = naming.new()
+  let catalog = nullable_post_catalog()
+  let sql =
+    "-- name: CreateReply :exec\nINSERT INTO posts (id, parent_id, created_at) VALUES (?, ?, ?);"
+  let assert Ok(queries) =
+    query_parser.parse_file("create.sql", model.SQLite, naming_ctx, sql)
+  let assert Ok(analyzed) =
+    query_analyzer.analyze_queries(model.SQLite, catalog, naming_ctx, queries)
+  let assert [query] = analyzed
+  let assert [id_param, parent_id_param, created_at_param] = query.params
+
+  id_param.nullable |> should.equal(False)
+  // INSERT VALUES into a nullable column still surfaces Option(_).
+  parent_id_param.nullable |> should.equal(True)
+  created_at_param.nullable |> should.equal(False)
+}


### PR DESCRIPTION
## Summary

Fixes Issue #512. A placeholder bound by `col <op> ?` (equality,
comparison, `LIKE` / `ILIKE`) or `col IN (?)` on a nullable schema
column previously inherited the column's `nullable: True` flag,
producing a generated parameter typed `Option(T)` that callers had
to wrap in `Some(...)` at every site. The `None` case was
unreachable in both surfaces:

- `WHERE col = ?` against `None` would emit `WHERE col = NULL`,
  which never matches by SQL `=` semantics — surfacing the choice
  at the call site invites callers to pass `None` and silently get
  an always-empty result set.
- `UPDATE … SET col = ?` is the user supplying the new value;
  clearing to NULL is expressed in SQL as a literal
  `SET col = NULL`, not as a parameter.

Force `nullable: False` for these positions in `scan_token_matches`
(shared by `infer_equality_params` and `infer_in_params`) so the
generated record drops the noisy `Some(...)` wrappers at every
comparison-style call site.

INSERT VALUES sites — where `None` legitimately writes NULL on the
wire — go through `infer_insert_params_from_ir`, not this scanner,
and are unaffected.

## Changes

- `src/sqlode/query_analyzer/param_inferencer.gleam`:
  `scan_token_matches` now wraps the inferred `model.Column` with
  `nullable: False` before threading it into the inference list.
  Both equality / comparison / LIKE patterns and `IN (?)` patterns
  flow through this scanner, so the fix lands in one place.
- `test/complex_sql_test.gleam`:
  `cte_window_case_analyzer_test` previously pinned the old
  behaviour for `$3` (parameter inherits the CTE-derived column's
  nullability for an outer `WHERE col = ?`). Updated to assert
  `nullable: False` per the new contract, with the comment
  rewritten to explain why.
- `test/query_analyzer_test.gleam`: three new regression tests
  driven by the issue's exact reproduction:
  - `where_eq_against_nullable_column_emits_non_null_param_test` —
    `SELECT … WHERE parent_id = ?` against a nullable column emits
    `nullable: False`.
  - `update_set_against_nullable_column_emits_non_null_param_test` —
    `UPDATE … SET tombstone_reason = ?` against a nullable column
    emits `nullable: False`.
  - `insert_values_into_nullable_column_keeps_option_wrapper_test` —
    INSERT VALUES into a nullable column still surfaces
    `nullable: True` (the differentiating negative case).
- `CHANGELOG.md`: documents under `### Changed` (BREAKING) in
  Unreleased.

## Design Decisions

- **Single-site fix in `scan_token_matches`.** Both equality / LIKE
  patterns and `IN (?)` patterns share the same scanner, so
  rewriting the column at that one chokepoint covers the full
  surface the issue describes without touching the IR walker, the
  per-statement traversal, or the codegen.
- **INSERT VALUES untouched.** The issue is explicit that VALUES
  sites are different: the caller is supplying the row's value for
  a nullable column, and `None` legitimately writes NULL. Those
  flow through `infer_insert_params_from_ir` and never enter
  `scan_token_matches`, so the fix is naturally scoped.
- **No opt-out flag (yet).** The issue floated a per-param
  `-- @param 1 nullable` annotation for the rare `COALESCE(?, default)`
  case where a comparison parameter genuinely needs to accept NULL.
  Adding that annotation is a larger surface change (annotation
  parser, plumbing into the inference pass) and is orthogonal to
  fixing the default behaviour. Left as a follow-up if a real
  case shows up.

## Test Plan

- [x] `gleam format --check src/ test/` — clean.
- [x] `gleam test` — 1070 passes (3 new for #512).
- [x] `gleam run -m glinter` — no issues.
- [x] Walked the failing `cte_window_case_analyzer_test` to confirm
  `$3` is indeed a `WHERE col = ?` site (not a VALUES site) and
  the new `nullable: False` is correct per the issue's contract.

Closes #512
