### PR TITLE
feat(runtime): allow sqlode/runtime to compile for the JavaScript target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,18 @@ jobs:
         env:
           MYSQL_URL: mysql://root:root@localhost:3306/sqlode_integration
         run: sh integration_test/run.sh case_mysql_real
+
+  build-javascript:
+    name: Build (JavaScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          gleam-version: "1.15"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: gleam deps download
+      - run: gleam build --target javascript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- JavaScript target compilation for `sqlode/runtime` and generated
+  modules. `gleam.toml` no longer pins `target = "erlang"`; the four
+  Erlang FFI declarations in `sqlode.gleam` and `sqlode/cli.gleam`
+  (`init:stop/1`, `sqlode_ffi:is_stdout_terminal/0`,
+  `sqlode_ffi:no_color_env/0`) are gated with `@target(erlang)` and
+  paired with no-op JavaScript bodies, so the CLI surface still
+  compiles on JavaScript without referencing absent BEAM primitives.
+  The CLI itself is intentionally BEAM-only at runtime — `escript`
+  is BEAM territory and the supported drivers (`pog`, `shork`,
+  `sqlight`) all run on the BEAM. Generated modules and
+  `sqlode/runtime` are now importable from a JavaScript-target Gleam
+  app, which lets a consumer pair the same compile-time-safe SQL →
+  row decoder shape with a fetch-based driver (Cloudflare D1,
+  serverless Postgres, etc.). CI now runs a `Build (JavaScript)`
+  job that verifies the package compiles cleanly under
+  `gleam build --target javascript`. (#519)
+
 ## [0.15.0] - 2026-04-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Supported engines (raw and native): PostgreSQL (`pog`), MySQL 8.0 (`shork`), SQL
 
 First time here? [`doc/tutorials/getting-started-sqlite.md`](doc/tutorials/getting-started-sqlite.md) walks through a SQLite project end to end, and [`examples/sqlite-basic/`](examples/sqlite-basic/) is the runnable version of the same tutorial. The rest of this README is reference material.
 
+## Targets
+
+- **CLI** (`sqlode generate` etc.): BEAM only (escript). The supported drivers — `pog`, `shork`, `sqlight` — are BEAM-native, so this is intentional.
+- **`sqlode/runtime`**: cross-target. Pure value transformation (`prepare(query, params)` → `#(String, List(Value))`) with no FFI. Importable from a JavaScript-target Gleam app.
+- **Generated modules**: cross-target. They depend only on `sqlode/runtime` and the driver chosen by the consumer; the JS-target story is gated by whether a JavaScript-callable driver is available downstream.
+
 ## Getting started
 
 ### Install

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,5 @@
 name = "sqlode"
 version = "0.15.0"
-target = "erlang"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }

--- a/src/sqlode.gleam
+++ b/src/sqlode.gleam
@@ -63,5 +63,11 @@ fn classify_invocation(args: List(String)) -> String {
   }
 }
 
+@target(erlang)
 @external(erlang, "init", "stop")
 fn exit(status: Int) -> Nil
+
+@target(javascript)
+fn exit(_status: Int) -> Nil {
+  Nil
+}

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -61,11 +61,23 @@ pub fn decide_color_emission(
   is_terminal && !no_color_active
 }
 
+@target(erlang)
 @external(erlang, "sqlode_ffi", "is_stdout_terminal")
 fn is_stdout_terminal() -> Bool
 
+@target(javascript)
+fn is_stdout_terminal() -> Bool {
+  False
+}
+
+@target(erlang)
 @external(erlang, "sqlode_ffi", "no_color_env")
 fn no_color_env() -> Result(String, Nil)
+
+@target(javascript)
+fn no_color_env() -> Result(String, Nil) {
+  Error(Nil)
+}
 
 /// Candidate config filenames searched, in order, when --config is not
 /// given. The first match wins; if two or more files exist the command
@@ -433,8 +445,14 @@ FROM authors
 WHERE id = " <> get_placeholder <> ";\n" <> "\n" <> "-- name: ListAuthors :many\n" <> "SELECT id, name\n" <> "FROM authors\n" <> "ORDER BY name;\n" <> "\n" <> "-- name: CreateAuthor :exec\n" <> "INSERT INTO authors (name, bio)\n" <> "VALUES (sqlode.arg(author_name), sqlode.narg(bio));\n"
 }
 
+@target(erlang)
 /// Exit the process with the given status code, flushing I/O before shutdown.
 /// Uses init:stop/1 which triggers a graceful OTP shutdown instead of the
 /// abrupt erlang:halt/1.
 @external(erlang, "init", "stop")
 fn halt(code: Int) -> Nil
+
+@target(javascript)
+fn halt(_code: Int) -> Nil {
+  Nil
+}


### PR DESCRIPTION
## Summary

Drop the `target = \"erlang\"` constraint from `gleam.toml` and gate
the four Erlang FFI declarations (`init:stop/1`,
`sqlode_ffi:is_stdout_terminal/0`, `sqlode_ffi:no_color_env/0`)
with `@target(erlang)` paired with no-op JavaScript bodies. After
this change a downstream Gleam app can `import sqlode/runtime`
from a JavaScript-target context and feed the `prepare` output to
its own fetch-based driver. Closes #519.

## Changes

- \`gleam.toml\`: drop \`target = \"erlang\"\`.
- \`src/sqlode.gleam\`: gate the \`init:stop\` FFI on the \`exit/1\`
  helper with \`@target(erlang)\` and add a no-op JavaScript body.
- \`src/sqlode/cli.gleam\`: same treatment for \`is_stdout_terminal\`
  (returns \`False\` on JS so colour emission stays off),
  \`no_color_env\` (returns \`Error(Nil)\` on JS), and the second
  \`init:stop\` FFI exposed as \`halt/1\`.
- \`.github/workflows/ci.yml\`: add a \`Build (JavaScript)\` job that
  runs \`gleam build --target javascript\` on Node 22.
- \`README.md\`: add a \"Targets\" section that calls out the BEAM-only
  CLI vs cross-target \`sqlode/runtime\` and generated modules.
- \`CHANGELOG.md\`: \`[Unreleased]\` entry under \`### Added\`.

## Design Decisions

- **JavaScript bodies are no-ops, not panics**. The CLI is the only
  surface that calls \`exit\`/\`halt\`/\`is_stdout_terminal\`/\`no_color_env\`
  and the CLI is intentionally BEAM-only at runtime. Returning
  sensible defaults on JavaScript (\`False\` for terminal, \`Error(Nil)\`
  for env, \`Nil\` for the exit functions) lets the CLI surface
  type-check on JavaScript without having to gate every CLI helper
  with \`@target(erlang)\` — that would cascade into every caller.
- **Build, not test, on the JavaScript CI step**. The runtime is the
  only thing we want to verify cross-compiles; the existing test
  suite touches CLI/codegen surfaces and simplifile / ShellSpec
  fixtures that don't make sense to run twice. \`gleam build --target
  javascript\` proves the package compiles cleanly without forcing
  an unrelated test partition.

## Limitations

- The CLI itself remains BEAM-only at runtime — \`gleescript\` is BEAM
  territory and the supported drivers (\`pog\`, \`shork\`, \`sqlight\`)
  are BEAM-native. JS-target consumers get \`sqlode/runtime\` and the
  generated modules; the rest of the package still requires Erlang
  to actually execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * JavaScript compilation target support now available for the runtime library and generated modules, enabling use in JavaScript-target Gleam projects.
  * CI pipeline includes JavaScript build verification.

* **Documentation**
  * Added documentation on cross-target compatibility, detailing target-specific capabilities and usage guidance for Erlang and JavaScript targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->