### PR TITLE
refactor(internal): close #520 follow-up — flip glinter unused_exports to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **glinter `unused_exports` flipped from `"off"` back to `"error"`**,
+  closing the follow-up tracked in v0.17.0's release notes for #520.
+  After the `internal/*` move, 15 `pub` items in internal modules
+  had no in-tree caller. Most were demoted to module-private (`fn` /
+  `type`); a few were dead code from earlier IR shapes
+  (`StructuredQuery` / `RichQuery` types in `query_ir`,
+  `infer_insert_params` and its helpers in `query_analyzer`,
+  `parse_placeholder_index` and `find_set_patterns` in
+  `token_utils`) and were deleted outright. `sqlode/runtime` keeps
+  its `pub` items intentional — they are consumed by
+  sqlode-generated code in downstream packages, which `glinter`
+  cannot see, so the file is added to `[tools.glinter.ignore]` for
+  this rule. The `internal_modules` boundary already protected the
+  hex API surface; this PR makes the in-tree contract match. (#520)
+
 ## [0.17.0] - 2026-04-28
 
 ### Changed

--- a/gleam.toml
+++ b/gleam.toml
@@ -54,7 +54,7 @@ module_complexity = "off"
 # tracked as a follow-up to #520. The `internal_modules` entry above
 # already removes those items from the public hex API contract,
 # which is the headline win the issue asked for.
-unused_exports = "off"
+unused_exports = "error"
 # `case True/False` is equivalent to `bool.guard` for control flow;
 # both forms read fine in their respective contexts and the rule is a
 # pure stylistic preference. Keeping it on would force a single shape
@@ -97,5 +97,14 @@ error_context_lost = "off"
   "avoid_panic",
   "missing_type_annotation",
   "short_variable_name",
+  "unused_exports",
+]
+# `sqlode/runtime` is consumed by sqlode-generated code in downstream
+# user packages — every public type and function in this module is
+# intentional API surface for those external callers. glinter cannot
+# see the generated callers, so `unused_exports` would mis-flag them
+# as dead. The module is one of the three SemVer-tracked top-level
+# entry points listed in #520.
+"src/sqlode/runtime.gleam" = [
   "unused_exports",
 ]

--- a/src/sqlode/internal/capabilities.gleam
+++ b/src/sqlode/internal/capabilities.gleam
@@ -49,7 +49,7 @@ pub fn fully_supported_query_commands() -> List(runtime.QueryCommand) {
 /// Query annotations that the parser accepts for sqlc source
 /// compatibility but that generation currently refuses with an
 /// `UnsupportedAnnotation` error.
-pub fn planned_query_commands() -> List(runtime.QueryCommand) {
+fn planned_query_commands() -> List(runtime.QueryCommand) {
   [
     runtime.QueryBatchOne,
     runtime.QueryBatchMany,
@@ -80,7 +80,7 @@ pub fn supported_placeholder_styles() -> List(#(model.Engine, String)) {
 /// because the generated code never needs a driver; `native` mode
 /// requires a driver and is enumerated here so docs and the manifest
 /// stop relying on the flat "supported engines" list to imply parity.
-pub type EngineSupport {
+type EngineSupport {
   EngineSupport(
     engine: model.Engine,
     raw: Bool,
@@ -92,7 +92,7 @@ pub type EngineSupport {
   )
 }
 
-pub fn engine_runtime_support() -> List(EngineSupport) {
+fn engine_runtime_support() -> List(EngineSupport) {
   [
     EngineSupport(
       engine: model.PostgreSQL,

--- a/src/sqlode/internal/char_utils.gleam
+++ b/src/sqlode/internal/char_utils.gleam
@@ -7,7 +7,7 @@ pub fn is_digit(g: String) -> Bool {
   }
 }
 
-pub fn is_alpha(g: String) -> Bool {
+fn is_alpha(g: String) -> Bool {
   let cp = case string.to_utf_codepoints(g) {
     [cp] -> string.utf_codepoint_to_int(cp)
     _ -> 0

--- a/src/sqlode/internal/query_analyzer/column_inferencer.gleam
+++ b/src/sqlode/internal/query_analyzer/column_inferencer.gleam
@@ -290,10 +290,10 @@ fn derive_source_table_from_tokens(tokens: List(lexer.Token)) -> Option(String) 
   }
 }
 
-/// Token-based column inference, exposed so callers (notably the CTE
-/// virtual-table builder in `query_analyzer`) can reuse the SELECT
-/// resolver without re-lexing or constructing a synthetic ParsedQuery.
-pub fn infer_columns_from_tokens(
+/// Token-based column inference. Used internally by the CTE
+/// virtual-table builder and by `infer_columns_from_tokens_scoped`
+/// itself; both stay inside this module so it is not exported.
+fn infer_columns_from_tokens(
   query_name: String,
   tokens: List(lexer.Token),
   catalog: model.Catalog,
@@ -310,7 +310,7 @@ pub fn infer_columns_from_tokens(
 /// its own token scope and augments the catalog before resolution, so
 /// nested subqueries pick up sibling virtual tables without extra work
 /// from the caller.
-pub fn infer_columns_from_tokens_scoped(
+fn infer_columns_from_tokens_scoped(
   query_name: String,
   tokens: List(lexer.Token),
   catalog: model.Catalog,

--- a/src/sqlode/internal/query_analyzer/param_inferencer.gleam
+++ b/src/sqlode/internal/query_analyzer/param_inferencer.gleam
@@ -15,32 +15,8 @@ import sqlode/internal/query_analyzer/placeholder
 import sqlode/internal/query_analyzer/token_utils
 import sqlode/internal/query_ir
 
-pub fn infer_insert_params(
-  _ctx: AnalyzerContext,
-  engine: model.Engine,
-  tokens: List(lexer.Token),
-  catalog: model.Catalog,
-) -> List(#(Int, model.Column)) {
-  case token_utils.find_insert_parts(tokens) {
-    Some(parts) ->
-      map_insert_columns(
-        engine,
-        catalog,
-        parts.table_name,
-        parts.columns,
-        parts.values,
-        1,
-        dict.new(),
-        [],
-      )
-      |> list.reverse
-    None -> []
-  }
-}
-
-/// Structured IR variant of `infer_insert_params`. Consumes the
-/// pre-parsed `InsertStatement` directly instead of re-scanning
-/// the token list.
+/// Structured IR variant. Consumes the pre-parsed `InsertStatement`
+/// directly instead of re-scanning the token list.
 pub fn infer_insert_params_from_ir(
   engine: model.Engine,
   statement: query_ir.SqlStatement,

--- a/src/sqlode/internal/query_analyzer/placeholder.gleam
+++ b/src/sqlode/internal/query_analyzer/placeholder.gleam
@@ -40,7 +40,7 @@ pub fn unique(
   list.reverse(result)
 }
 
-pub fn placeholder_index_for_token(
+fn placeholder_index_for_token(
   engine: model.Engine,
   token: String,
   occurrence: Int,
@@ -123,18 +123,11 @@ pub fn resolve_index(
   }
 }
 
-pub fn sequential_placeholder(engine: model.Engine) -> Bool {
+fn sequential_placeholder(engine: model.Engine) -> Bool {
   case engine {
     model.PostgreSQL -> False
     model.MySQL | model.SQLite -> True
   }
-}
-
-pub fn is_placeholder_token(value: String) -> Bool {
-  string.starts_with(value, "$")
-  || string.starts_with(value, ":")
-  || string.starts_with(value, "@")
-  || string.starts_with(value, "?")
 }
 
 fn build_occurrences(

--- a/src/sqlode/internal/query_analyzer/token_utils.gleam
+++ b/src/sqlode/internal/query_analyzer/token_utils.gleam
@@ -1,4 +1,3 @@
-import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
@@ -244,7 +243,7 @@ fn split_commas_loop(
 // INSERT parsing helpers
 // ============================================================
 
-pub type InsertParts {
+type InsertParts {
   InsertParts(
     table_name: String,
     columns: List(String),
@@ -253,7 +252,7 @@ pub type InsertParts {
 }
 
 /// Find INSERT INTO table (columns) VALUES (values) structure in tokens.
-pub fn find_insert_parts(tokens: List(lexer.Token)) -> Option(InsertParts) {
+fn find_insert_parts(tokens: List(lexer.Token)) -> Option(InsertParts) {
   find_insert_loop(tokens)
 }
 
@@ -684,69 +683,6 @@ fn find_type_cast_loop(
       find_type_cast_loop(rest, [TypeCast(placeholder: p, cast_type: t), ..acc])
 
     [_, ..rest] -> find_type_cast_loop(rest, acc)
-  }
-}
-
-/// Parse a placeholder string like "$3" into its integer index.
-pub fn parse_placeholder_index(placeholder: String) -> Result(Int, Nil) {
-  placeholder
-  |> string.replace("$", "")
-  |> int.parse
-  |> option.from_result
-  |> option.to_result(Nil)
-}
-
-// ============================================================
-// SET clause pattern helpers (UPDATE ... SET col = placeholder)
-// ============================================================
-
-/// Find all column = placeholder patterns in SET clauses.
-pub fn find_set_patterns(tokens: List(lexer.Token)) -> List(EqualityMatch) {
-  find_set_clause(tokens, [])
-  |> list.reverse
-}
-
-fn find_set_clause(
-  tokens: List(lexer.Token),
-  acc: List(EqualityMatch),
-) -> List(EqualityMatch) {
-  case tokens {
-    [] -> acc
-    [lexer.Keyword("set"), ..rest] -> scan_set_assignments(rest, acc)
-    [_, ..rest] -> find_set_clause(rest, acc)
-  }
-}
-
-fn scan_set_assignments(
-  tokens: List(lexer.Token),
-  acc: List(EqualityMatch),
-) -> List(EqualityMatch) {
-  case tokens {
-    [] -> acc
-    // Stop at WHERE or other clauses
-    [lexer.Keyword(kw), ..]
-      if kw == "where" || kw == "returning" || kw == "from"
-    -> acc
-    // column = placeholder
-    [lexer.Ident(c), lexer.Operator("="), lexer.Placeholder(p), ..rest] ->
-      scan_set_assignments(rest, [
-        EqualityMatch(
-          column_name: naming.normalize_identifier(c),
-          table_qualifier: None,
-          placeholder: p,
-        ),
-        ..acc
-      ])
-    [lexer.QuotedIdent(c), lexer.Operator("="), lexer.Placeholder(p), ..rest] ->
-      scan_set_assignments(rest, [
-        EqualityMatch(
-          column_name: naming.normalize_identifier(c),
-          table_qualifier: None,
-          placeholder: p,
-        ),
-        ..acc
-      ])
-    [_, ..rest] -> scan_set_assignments(rest, acc)
   }
 }
 

--- a/src/sqlode/internal/query_ir.gleam
+++ b/src/sqlode/internal/query_ir.gleam
@@ -86,17 +86,6 @@ pub type JoinClause {
   )
 }
 
-/// `StructuredQuery` wraps `TokenizedQuery` with the structured IR.
-/// The raw token list is preserved for backward compatibility with
-/// code that hasn't migrated to the structured representation yet.
-pub type StructuredQuery {
-  StructuredQuery(
-    base: model.ParsedQuery,
-    tokens: List(lexer.Token),
-    statement: SqlStatement,
-  )
-}
-
 // ============================================================
 // Expression-aware IR — the rich semantic representation
 // ============================================================
@@ -353,13 +342,4 @@ pub type WindowSpec {
     order_by: List(OrderKey),
     frame: Option(List(lexer.Token)),
   )
-}
-
-// ------------------------------------------------------------
-// Rich-IR wrapper mirroring `StructuredQuery` for callers that
-// want the rich representation alongside the tokens.
-// ------------------------------------------------------------
-
-pub type RichQuery {
-  RichQuery(base: model.ParsedQuery, tokens: List(lexer.Token), stmt: Stmt)
 }


### PR DESCRIPTION
## Summary

Closes the follow-up tracked in v0.17.0's release notes for #520. After the v0.17.0 `internal/*` module move, 15 `pub` items in internal modules had no in-tree caller. This PR demotes or removes them, then flips `glinter`'s `unused_exports` rule from `"off"` back to `"error"` so future drift is caught at lint time.

## Changes

- `gleam.toml` — `unused_exports = "error"` (was `"off"`); add `src/sqlode/runtime.gleam` to `[tools.glinter.ignore]` because its `pub` types and functions are intentional API for the sqlode-generated code in downstream packages, which `glinter` cannot see.
- `src/sqlode/internal/capabilities.gleam` — demote `planned_query_commands` / `engine_runtime_support` to `fn`; demote `EngineSupport` type to private.
- `src/sqlode/internal/char_utils.gleam` — demote `is_alpha` to `fn`.
- `src/sqlode/internal/query_analyzer/column_inferencer.gleam` — demote `infer_columns_from_tokens` and `infer_columns_from_tokens_scoped` to `fn`. The forward-looking docstring claiming external CTE callers was aspirational; the actual callers are inside the same module.
- `src/sqlode/internal/query_analyzer/placeholder.gleam` — demote `placeholder_index_for_token` and `sequential_placeholder` to `fn`. Delete `is_placeholder_token` (genuinely dead).
- `src/sqlode/internal/query_analyzer/param_inferencer.gleam` — delete `infer_insert_params` (dead, supplanted by `infer_insert_params_from_ir`).
- `src/sqlode/internal/query_analyzer/token_utils.gleam` — delete `parse_placeholder_index` (dead), delete `find_set_patterns` and its private chain `find_set_clause` / `scan_set_assignments` (only consumer was the now-removed `infer_insert_params`); demote `find_insert_parts` and `InsertParts` type to private (only used inside this module).
- `src/sqlode/internal/query_ir.gleam` — delete `StructuredQuery` and `RichQuery` types (zero references; left over from earlier IR shapes).

## Design Decisions

- **`runtime.gleam` is the single ignore-listed file, not the whole `internal/*` tree.** Internal modules are already protected from external imports via `internal_modules = ["sqlode/internal/**", "sqlode/scripts/**"]`, but their `pub` items are still in scope for the lint rule — and demoting them is exactly what the rule is asking for. `runtime.gleam` is genuinely a public surface for generated code; it is the one file where `glinter` cannot see the real callers.
- **Demote vs. delete.** Items with at least one in-module caller demote to `fn`; items with zero callers anywhere get deleted. Demotion preserves the implementation in case a future internal caller is added; deletion only happens when the function/type is truly orphaned.
- **`StructuredQuery` / `RichQuery` deleted, not demoted.** Both types have zero references — no construction, no pattern matches, no field access. Demoting would just keep dead code under a private name; deletion is the honest cleanup.

## Test plan

- [x] `gleam build --warnings-as-errors`
- [x] `gleam run -m glinter` (0 errors, 0 warnings)
- [x] `gleam format --check src/ test/`
- [x] `gleam test` — 1070 passed

Closes #520.