### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-04-29
+
 ### Changed
 
 - **glinter `unused_exports` flipped from `"off"` back to `"error"`**,

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.17.0"
+version = "0.18.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }


### PR DESCRIPTION
### Changed

- **glinter `unused_exports` flipped from `"off"` back to `"error"`**,
  closing the follow-up tracked in v0.17.0's release notes for #520.
  After the `internal/*` move, 15 `pub` items in internal modules
  had no in-tree caller. Most were demoted to module-private (`fn` /
  `type`); a few were dead code from earlier IR shapes
  (`StructuredQuery` / `RichQuery` types in `query_ir`,
  `infer_insert_params` and its helpers in `query_analyzer`,
  `parse_placeholder_index` and `find_set_patterns` in
  `token_utils`) and were deleted outright. `sqlode/runtime` keeps
  its `pub` items intentional — they are consumed by
  sqlode-generated code in downstream packages, which `glinter`
  cannot see, so the file is added to `[tools.glinter.ignore]` for
  this rule. The `internal_modules` boundary already protected the
  hex API surface; this PR makes the in-tree contract match. (#520)
