### PR TITLE
fix(verify): reject sqlode.slice() on non-PostgreSQL engines (#531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **verify / generate**: `sqlode.slice(...)` is now rejected at
+  static-analysis time when the block targets `sqlite` or `mysql`,
+  with a structured `UnsupportedSliceForEngine(query_name, engine)`
+  diagnostic. Previously the same configuration shipped runtime code
+  that panicked the moment a `runtime.SqlArray` reached
+  `value_to_sqlight` / `value_to_shork`. Closing the loop on the
+  static side means unsupported array/native-adapter combinations
+  fail at `sqlode generate` / `sqlode verify` instead of at request
+  time. PostgreSQL behaviour is unchanged. README documents the
+  raw-runtime / inline-placeholder fallbacks for queries that
+  genuinely need IN-clause expansion against SQLite / MySQL. (#531)
+
 ## [0.18.0] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -513,6 +513,22 @@ pub type GetAuthorsByIdsParams {
 }
 ```
 
+> [!IMPORTANT]
+> `sqlode.slice(...)` is only supported on PostgreSQL because the
+> generated native SQLite (`sqlight`) and MySQL (`shork`) adapters
+> cannot bind array parameters at runtime. `sqlode generate` /
+> `sqlode verify` reject any block that targets `sqlite` or `mysql`
+> with a slice macro present.
+>
+> If you need IN-clause expansion against SQLite/MySQL, drop the
+> macro and either:
+>
+> - inline the placeholders yourself in the SQL and bind one
+>   parameter per element from your application code, or
+> - move the query to `runtime: raw` and call `runtime.prepare`
+>   followed by your driver's parameter-list call directly, where
+>   you control how the list flattens to scalar bindings.
+
 ### sqlode.embed example
 
 ```sql

--- a/src/sqlode/internal/generate.gleam
+++ b/src/sqlode/internal/generate.gleam
@@ -49,6 +49,7 @@ pub type GenerateError {
   WriteError(writer.WriteError)
   VendorRuntimeNotFound
   UnsupportedArrayForEngine(query_name: String, engine: String)
+  UnsupportedSliceForEngine(query_name: String, engine: String)
 }
 
 pub fn run(config_path: String) -> Result(List(String), GenerateError) {
@@ -502,6 +503,8 @@ fn wrap_validation_error(err: query_validation.ValidationError) -> GenerateError
       UnsupportedAnnotation(query_name:, command:, detail:)
     query_validation.UnsupportedArrayForEngine(query_name:, engine:) ->
       UnsupportedArrayForEngine(query_name:, engine:)
+    query_validation.UnsupportedSliceForEngine(query_name:, engine:) ->
+      UnsupportedSliceForEngine(query_name:, engine:)
   }
 }
 
@@ -949,6 +952,10 @@ pub fn error_to_string(error: GenerateError) -> String {
     UnsupportedArrayForEngine(query_name:, engine:) ->
       query_validation.error_to_string(
         query_validation.UnsupportedArrayForEngine(query_name:, engine:),
+      )
+    UnsupportedSliceForEngine(query_name:, engine:) ->
+      query_validation.error_to_string(
+        query_validation.UnsupportedSliceForEngine(query_name:, engine:),
       )
   }
 }

--- a/src/sqlode/internal/query_validation.gleam
+++ b/src/sqlode/internal/query_validation.gleam
@@ -27,6 +27,7 @@ pub type ValidationError {
   )
   UnsupportedAnnotation(query_name: String, command: String, detail: String)
   UnsupportedArrayForEngine(query_name: String, engine: String)
+  UnsupportedSliceForEngine(query_name: String, engine: String)
 }
 
 /// Reject two tokenized queries that declare the same annotation
@@ -108,9 +109,25 @@ pub fn validate_unsupported_annotations(
   }
 }
 
+fn is_slice_macro(item: model.Macro) -> Bool {
+  case item {
+    model.MacroSlice(..) -> True
+    _ -> False
+  }
+}
+
 /// Reject array parameters for engines that cannot carry them.
 /// Only PostgreSQL supports native array binding at the adapter
-/// layer today.
+/// layer today. Two shapes are rejected:
+///
+/// - inferred `ArrayType` parameters (e.g. a query reading a
+///   PostgreSQL `TEXT[]` column where the inferred parameter
+///   carries the array element type)
+/// - `sqlode.slice(...)` macro usage, which lowers to an
+///   `SqlArray` runtime value at execution time. The native
+///   SQLite (`sqlight`) and MySQL (`shork`) adapters panic on
+///   `SqlArray`, so the only safe path for those engines is the
+///   raw runtime, which the user must opt into explicitly.
 pub fn validate_array_engine_support(
   engine: model.Engine,
   queries: List(model.AnalyzedQuery),
@@ -118,7 +135,8 @@ pub fn validate_array_engine_support(
   case engine {
     model.PostgreSQL -> Ok(Nil)
     _ -> {
-      let has_array = fn(q: model.AnalyzedQuery) {
+      let engine_name = model.engine_to_string(engine)
+      let has_array_param = fn(q: model.AnalyzedQuery) {
         list.any(q.params, fn(p) {
           case p.scalar_type {
             model.ArrayType(_) -> True
@@ -126,13 +144,24 @@ pub fn validate_array_engine_support(
           }
         })
       }
-      case list.find(queries, has_array) {
+      let has_slice_macro = fn(q: model.AnalyzedQuery) {
+        list.any(q.base.macros, is_slice_macro)
+      }
+      case list.find(queries, has_array_param) {
         Ok(q) ->
           Error(UnsupportedArrayForEngine(
             query_name: q.base.name,
-            engine: model.engine_to_string(engine),
+            engine: engine_name,
           ))
-        Error(_) -> Ok(Nil)
+        Error(_) ->
+          case list.find(queries, has_slice_macro) {
+            Ok(q) ->
+              Error(UnsupportedSliceForEngine(
+                query_name: q.base.name,
+                engine: engine_name,
+              ))
+            Error(_) -> Ok(Nil)
+          }
       }
     }
   }
@@ -179,6 +208,14 @@ pub fn error_to_string(error: ValidationError) -> String {
       <> "\": array parameters are not supported for engine \""
       <> engine
       <> "\". Arrays are only supported with PostgreSQL"
+    UnsupportedSliceForEngine(query_name:, engine:) ->
+      "Query \""
+      <> query_name
+      <> "\": sqlode.slice() is not supported for engine \""
+      <> engine
+      <> "\". The native "
+      <> engine
+      <> " adapter cannot bind array values at runtime; either switch the block to PostgreSQL, drop the slice macro and inline the IN-clause placeholders, or move the query to runtime: raw and bind the expanded list yourself"
   }
 }
 

--- a/test/fixtures/verify_slice_query.sql
+++ b/test/fixtures/verify_slice_query.sql
@@ -1,0 +1,2 @@
+-- name: GetAuthorsByIds :many
+SELECT id, name FROM authors WHERE id IN (sqlode.slice(ids));

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -28,9 +28,25 @@ fn make_block(
   out: String,
   query_parameter_limit: option.Option(Int),
 ) -> model.SqlBlock {
+  make_block_for_engine(
+    model.PostgreSQL,
+    schema_path,
+    query_path,
+    out,
+    query_parameter_limit,
+  )
+}
+
+fn make_block_for_engine(
+  engine: model.Engine,
+  schema_path: String,
+  query_path: String,
+  out: String,
+  query_parameter_limit: option.Option(Int),
+) -> model.SqlBlock {
   model.SqlBlock(
     name: option.None,
-    engine: model.PostgreSQL,
+    engine: engine,
     schema: [schema_path],
     queries: [query_path],
     gleam: model.GleamOutput(
@@ -346,6 +362,66 @@ pub fn verify_execresult_under_raw_runtime_is_allowed_test() {
 // array-typed params on a non-PostgreSQL engine, both `generate`
 // and `verify` will reject it with an identical message through
 // the shared validator.
+
+// ============================================================
+// Issue #531: reject sqlode.slice() on non-PostgreSQL engines
+// ============================================================
+
+pub fn verify_rejects_slice_macro_on_sqlite_test() {
+  // sqlode.slice() lowers to a runtime SqlArray; the native SQLite
+  // adapter (`sqlight`) panics on that, so verify must catch the
+  // mismatch before the user reaches runtime.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block_for_engine(
+        model.SQLite,
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_slice_query.sql",
+        "src/verify_slice_sqlite_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "GetAuthorsByIds") |> should.be_true()
+  string.contains(finding.detail, "sqlode.slice()") |> should.be_true()
+  string.contains(finding.detail, "sqlite") |> should.be_true()
+}
+
+pub fn verify_rejects_slice_macro_on_mysql_test() {
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block_for_engine(
+        model.MySQL,
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_slice_query.sql",
+        "src/verify_slice_mysql_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  let assert [finding] = report.findings
+  string.contains(finding.detail, "GetAuthorsByIds") |> should.be_true()
+  string.contains(finding.detail, "sqlode.slice()") |> should.be_true()
+  string.contains(finding.detail, "mysql") |> should.be_true()
+}
+
+pub fn verify_allows_slice_macro_on_postgresql_test() {
+  // PostgreSQL is the supported engine for slice / array binding;
+  // verify must NOT flag the same query when the block targets it.
+  let cfg =
+    model.Config(version: 2, sql: [
+      make_block_for_engine(
+        model.PostgreSQL,
+        "test/fixtures/verify_ok_schema.sql",
+        "test/fixtures/verify_slice_query.sql",
+        "src/verify_slice_postgres_out",
+        option.None,
+      ),
+    ])
+  let report = verify.verify_config(cfg)
+  report.findings |> should.equal([])
+}
 
 // ============================================================
 // Issue #504: verify must detect empty query lists


### PR DESCRIPTION
## Summary

Reject `sqlode.slice(...)` at static-analysis time when the block targets `sqlite` or `mysql`, so the known-broken `runtime.SqlArray` → `value_to_sqlight` / `value_to_shork` panic path can no longer ship into generated code. Closes #531.

## Changes

- `src/sqlode/internal/query_validation.gleam`
  - new `UnsupportedSliceForEngine(query_name, engine)` variant on `ValidationError`
  - `validate_array_engine_support` now also walks `q.base.macros` looking for `MacroSlice` and reports the new variant when the engine is `mysql` or `sqlite`
  - new `error_to_string` arm with the workaround instructions (raw runtime / inline placeholders / switch to PostgreSQL)
- `src/sqlode/internal/generate.gleam` — propagate the new variant through `GenerateError` and `wrap_validation_error` / `error_to_string` so `sqlode generate` reports the same diagnostic as `sqlode verify`.
- `test/fixtures/verify_slice_query.sql` — minimal slice-using query.
- `test/verify_test.gleam` — three new tests:
  - `verify_rejects_slice_macro_on_sqlite_test`
  - `verify_rejects_slice_macro_on_mysql_test`
  - `verify_allows_slice_macro_on_postgresql_test` (regression — PostgreSQL must stay clean)
  - factor a `make_block_for_engine` helper out of `make_block` so existing tests keep their PostgreSQL default
- `README.md` — IMPORTANT callout under the `sqlode.slice` example explaining the engine restriction and listing the supported fallback paths.
- `CHANGELOG.md` — `[Unreleased]` entry under Changed.

## Design Decisions

- **Reject in `validate_array_engine_support`, not the codegen.** The existing array-parameter check is already at the same lifecycle point (post-analyze, pre-generate) and is shared between `verify` and `generate`. Plugging the slice case into the same validator means both commands surface an identical diagnostic and the verify gate stays a trustworthy pre-generation CI check.
- **New variant rather than overloading `UnsupportedArrayForEngine`.** The two failure modes describe different shapes (an inferred `ArrayType` parameter vs a `MacroSlice` in the query macros). Keeping them separate lets the error message tell the user which surface produced the rejection — the workaround for a slice macro (drop the macro / move to raw runtime) is materially different from the workaround for an inferred array column.
- **Did not remove the runtime panics in `value_to_sqlight` / `value_to_shork`.** Those stay as a defence-in-depth: a downstream caller can still construct a `runtime.SqlArray` by hand on a raw-runtime path, and the existing panics still surface that programmer error loudly. The static check just makes sure generated code never has a path that quietly compiles into one of those panics.
- **Did not introduce a new `Macro`-listing helper on `model`.** The macro shape is a list with a tiny variant set; a private `is_slice_macro` predicate inside `query_validation` is enough.

Closes #531
