### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-04-30
+
 ### Changed
 
 - **verify / generate**: `sqlode.slice(...)` is now rejected at

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.18.0"
+version = "0.19.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }


### PR DESCRIPTION
### Changed

- **verify / generate**: `sqlode.slice(...)` is now rejected at
  static-analysis time when the block targets `sqlite` or `mysql`,
  with a structured `UnsupportedSliceForEngine(query_name, engine)`
  diagnostic. Previously the same configuration shipped runtime code
  that panicked the moment a `runtime.SqlArray` reached
  `value_to_sqlight` / `value_to_shork`. Closing the loop on the
  static side means unsupported array/native-adapter combinations
  fail at `sqlode generate` / `sqlode verify` instead of at request
  time. PostgreSQL behaviour is unchanged. README documents the
  raw-runtime / inline-placeholder fallbacks for queries that
  genuinely need IN-clause expansion against SQLite / MySQL. (#531)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.19.0
  * Updated package metadata to reflect new version
  * Added release documentation to changelog dated April 30, 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->