### PR TITLE
fix(integration): drop slice queries from SQLite extended fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **integration tests**: drop the `GetAuthorsByIds` and
+  `GetAuthorsByIdsAndNames` queries from the SQLite extended fixture
+  (`test/fixtures/sqlite_extended_query.sql`) and the matching tests
+  from `integration_test/fixtures/sqlite_extended_test.gleam`. Both
+  queries used `sqlode.slice()` against the SQLite engine, which v0.19.0
+  (#531 / #533) made an explicit `UnsupportedSliceForEngine` validation
+  error. The integration lane was the last consumer of that
+  combination, so the v0.19.0 release CI failed at
+  `bash integration_test/run.sh` and never reached `gleam publish` or
+  the GitHub release step. PostgreSQL slice coverage is unchanged and
+  is regression-tested by `verify_test.gleam`.
+
 ## [0.19.0] - 2026-04-30
 
 ### Changed

--- a/integration_test/fixtures/sqlite_extended_test.gleam
+++ b/integration_test/fixtures/sqlite_extended_test.gleam
@@ -137,42 +137,11 @@ pub fn update_bio_nullable_to_null_test() {
   Nil
 }
 
-// ---- Test sqlode.slice (WHERE IN with list param) ----
-pub fn get_authors_by_ids_slice_test() {
-  let db = setup_db()
-
-  // Insert 3 authors
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Alice", bio: Some("A")),
-    )
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Bob", bio: Some("B")),
-    )
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Charlie", bio: Some("C")),
-    )
-
-  // Fetch authors with IDs 1 and 3
-  let assert Ok(authors) =
-    sqlight_adapter.get_authors_by_ids(
-      db,
-      params.GetAuthorsByIdsParams(ids: [1, 3]),
-    )
-  let assert True = {
-    case authors {
-      [a1, a2] -> a1.name == "Alice" && a2.name == "Charlie"
-      _ -> False
-    }
-  }
-
-  Nil
-}
+// sqlode.slice() WHERE IN coverage was removed from this SQLite-engine
+// fixture in v0.20.0: PR #533 (v0.19.0) made sqlode.slice() a
+// validation error on SQLite because the sqlight adapter cannot bind
+// array values at runtime. PostgreSQL slice support is regression-
+// tested by test/verify_test.gleam.
 
 // ---- Test JOIN (multi-table query) ----
 pub fn get_post_with_author_join_test() {
@@ -219,52 +188,6 @@ pub fn get_post_with_author_not_found_test() {
       db,
       params.GetPostWithAuthorParams(id: 999),
     )
-
-  Nil
-}
-
-// ---- Test multiple slices in one query ----
-pub fn get_authors_by_ids_and_names_test() {
-  let db = setup_db()
-
-  // Insert 4 authors
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Alice", bio: Some("A")),
-    )
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Bob", bio: Some("B")),
-    )
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Charlie", bio: Some("C")),
-    )
-  let assert Ok(_) =
-    sqlight_adapter.create_author(
-      db,
-      params.CreateAuthorParams(name: "Diana", bio: Some("D")),
-    )
-
-  // Fetch authors where id IN [1,2,3] AND name IN ["Alice", "Charlie"]
-  // Should only match Alice (id=1) and Charlie (id=3)
-  let assert Ok(authors) =
-    sqlight_adapter.get_authors_by_ids_and_names(
-      db,
-      params.GetAuthorsByIdsAndNamesParams(ids: [1, 2, 3], names: [
-        "Alice",
-        "Charlie",
-      ]),
-    )
-  let assert True = {
-    case authors {
-      [a1, a2] -> a1.name == "Alice" && a2.name == "Charlie"
-      _ -> False
-    }
-  }
 
   Nil
 }

--- a/test/fixtures/sqlite_extended_query.sql
+++ b/test/fixtures/sqlite_extended_query.sql
@@ -10,8 +10,13 @@ UPDATE authors SET bio = ?1 WHERE id = ?2;
 -- name: UpdateBioNullable :exec
 UPDATE authors SET bio = sqlode.narg(new_bio) WHERE id = sqlode.arg(author_id);
 
--- name: GetAuthorsByIds :many
-SELECT id, name, bio FROM authors WHERE id IN (sqlode.slice(ids));
+-- sqlode.slice() is rejected on SQLite as of v0.19.0 (PR #533): the
+-- sqlight adapter cannot bind array values at runtime. The previous
+-- GetAuthorsByIds / GetAuthorsByIdsAndNames queries that exercised
+-- IN-clause expansion via sqlode.slice() were removed from this
+-- SQLite-engine fixture for that reason. The slice macro stays
+-- supported on PostgreSQL and is regression-tested by
+-- verify_test.gleam:verify_allows_slice_macro_on_postgresql_test.
 
 -- name: CreatePost :exec
 INSERT INTO posts (title, body, author_id) VALUES (?1, ?2, ?3);
@@ -20,9 +25,6 @@ INSERT INTO posts (title, body, author_id) VALUES (?1, ?2, ?3);
 SELECT posts.id, posts.title, posts.body, authors.name
 FROM posts JOIN authors ON posts.author_id = authors.id
 WHERE posts.id = ?1;
-
--- name: GetAuthorsByIdsAndNames :many
-SELECT id, name, bio FROM authors WHERE id IN (sqlode.slice(ids)) AND name IN (sqlode.slice(names));
 
 -- name: ListAuthors :many
 SELECT id, name, bio FROM authors ORDER BY name;


### PR DESCRIPTION
## Summary

The `v0.19.0` tag was pushed but `release.yml` failed at `Build and verify` (run [25143313532](https://github.com/nao1215/sqlode/actions/runs/25143313532)) and never reached `gleam publish` or the GitHub release step. This PR unblocks the next release by reconciling the SQLite extended integration fixture with the verify-time check that v0.19.0 itself shipped.

## Root cause

PR #533 (v0.19.0) made `sqlode.slice()` an explicit `UnsupportedSliceForEngine` validation error on the SQLite and MySQL engines because the `sqlight` and `shork` adapters cannot bind `runtime.SqlArray` values. The check is correct.

What slipped through is that `test/fixtures/sqlite_extended_query.sql` still declared two slice-using queries against the SQLite engine:

- `GetAuthorsByIds` — `WHERE id IN (sqlode.slice(ids))`
- `GetAuthorsByIdsAndNames` — `id` and `name` slices in one query

`integration_test/cases.sh::case_sqlite_extended` runs `sqlode generate` against that fixture, so the new validator now fires before any code is produced:

```
Error: Query "GetAuthorsByIds": sqlode.slice() is not supported for engine "sqlite". ...
##[error]Process completed with exit code 1.
```

`release.yml` runs the same script via `bash integration_test/run.sh` in the `Build and verify` job, which is why the tag was pushed but `publish` and `release` (both `needs: build`) never ran.

## Changes

- **`test/fixtures/sqlite_extended_query.sql`** — drop `GetAuthorsByIds` and `GetAuthorsByIdsAndNames`. Inline note points at the v0.19.0 rejection rule.
- **`integration_test/fixtures/sqlite_extended_test.gleam`** — drop `get_authors_by_ids_slice_test` and `get_authors_by_ids_and_names_test`. The remaining file still covers `:execlastid`, `:execrows`, `sqlode.narg`, JOIN, and nullable result columns.
- **`CHANGELOG.md`** — `[Unreleased]` entry under `### Fixed`.

## What this PR does NOT do

- It does **not** re-tag `v0.19.0`. The next release on top of this fix is intended to ship as `v0.20.0`, leaving `v0.19.0` as a numbering gap (no hex package, no GitHub release) so the published timeline stays append-only.
- It does **not** add a new PostgreSQL `slice` integration case. PostgreSQL slice support is already regression-tested by `verify_test.gleam::verify_allows_slice_macro_on_postgresql_test`, so the integration lane does not need to grow a new case to compensate.

## Verification

- `gleam format --check src/ test/` — clean
- `gleam check` — clean
- `gleam test` — 1073 passed, no failures
- `gleam run -m glinter` — No issues found
- `bash integration_test/run.sh case_sqlite_extended` — `7 passed, no failures` (down from 9, since two slice tests are now gone) → reproduces a clean run of the previously-failing CI step locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved integration test failures for SQLite related to unsupported slice operations that became incompatible with v0.19.0 validation. PostgreSQL functionality remains unchanged.

* **Chores**
  * Updated changelog and test documentation to reflect SQLite slice operation limitations while maintaining PostgreSQL support coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->