### PR TITLE
ci(runtime): exercise sqlode/runtime on the JavaScript target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,12 @@ jobs:
           node-version: "22"
       - run: gleam deps download
       - run: gleam build --target javascript
+      # Run the cross-target runtime laws on Node so JavaScript-target
+      # regressions in placeholder / slice expansion or Value encoding
+      # are caught here (#527). The dedicated entry point exists
+      # because gleeunit's JavaScript auto-discovery would otherwise
+      # transitively load `glint`, whose generated JavaScript fails to
+      # parse on Node — see test/sqlode_js_test.gleam for the full
+      # rationale.
+      - name: Runtime tests (JavaScript)
+        run: gleam run -m sqlode_js_test --target javascript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
           otp-version: "27"
           gleam-version: "1.15"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install rebar3
         run: |
           wget -q https://s3.amazonaws.com/rebar3/rebar3 -O /usr/local/bin/rebar3
@@ -51,6 +55,17 @@ jobs:
 
       - name: Unit tests
         run: gleam test
+
+      # Mirror the JavaScript-target gate on `ci.yml`'s `build-javascript`
+      # job (#527) so a tag-driven release cannot ship a commit that
+      # would have failed the JavaScript runtime laws on PR. See
+      # test/sqlode_js_test.gleam for the rationale behind the
+      # dedicated entry point.
+      - name: Build (JavaScript)
+        run: gleam build --target javascript
+
+      - name: Runtime tests (JavaScript)
+        run: gleam run -m sqlode_js_test --target javascript
 
       - name: ShellSpec tests
         run: shellspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **ci/runtime**: JavaScript-target test lane. The cross-target laws
+  in `sqlode/runtime` (Value encoders, `prepare`, marker-based
+  placeholder / slice expansion across PostgreSQL `$N`, SQLite `?N`,
+  and MySQL `?` styles, plus the literal/comment-preservation edge
+  cases) are now exercised on Node by a dedicated entry point
+  (`test/sqlode_js_test.gleam`). Both `ci.yml` (the `Build
+  (JavaScript)` job) and `release.yml` (the `Build and verify` job)
+  invoke `gleam run -m sqlode_js_test --target javascript`, and
+  `just all` does the same locally via the new `just test-javascript`
+  recipe. The dedicated entry exists because gleeunit's JavaScript
+  auto-discovery would otherwise transitively load `glint`, whose
+  current generated JavaScript fails to parse on Node — the file
+  documents the rationale and the call list mirrors every
+  `runtime_test` function so the JavaScript lane stays in parity
+  with the Erlang lane for the runtime surface generated code calls
+  into. (#527)
+
 ### Fixed
 
 - **integration tests**: drop the `GetAuthorsByIds` and

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.13.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.19.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]

--- a/justfile
+++ b/justfile
@@ -21,6 +21,15 @@ build:
 test:
   gleam test
 
+# JavaScript-target runtime tests. Mirrors the `Build (JavaScript)`
+# job in CI / release.yml. Uses a hand-rolled entry point because
+# gleeunit's JavaScript auto-discovery transitively pulls in `glint`,
+# whose generated JavaScript fails to parse on Node — see
+# `test/sqlode_js_test.gleam`.
+test-javascript:
+  gleam build --target javascript
+  gleam run -m sqlode_js_test --target javascript
+
 # Run the glinter (https://github.com/pairshaped/glinter) static
 # analysis. Configuration lives under `[tools.glinter]` in
 # `gleam.toml`; with `warnings_as_errors = true` set there, this task
@@ -56,5 +65,6 @@ all:
   gleam build --warnings-as-errors
   gleam run -m glinter
   gleam test
+  just test-javascript
   just integration-prepare
   shellspec

--- a/test/sqlode_js_test.gleam
+++ b/test/sqlode_js_test.gleam
@@ -1,0 +1,60 @@
+//// JavaScript-target test entry point for `sqlode/runtime`.
+////
+//// The default `gleam test --target javascript` lane fails on this
+//// repository because `gleeunit`'s JavaScript runner auto-discovers
+//// every `*_test.mjs` file under `build/dev/javascript/sqlode/test/`
+//// and `cli_test.mjs` transitively pulls in `glint.mjs`, whose
+//// generated JavaScript currently fails to parse on Node
+//// (`SyntaxError: Identifier '$2' has already been declared` near
+//// `let $2 = $list.partition(...)` — a known compiler-emitted code
+//// shape on this glint version). The CLI is BEAM-only by design
+//// (escript), so the failure is in dependency wiring, not in
+//// `sqlode/runtime` semantics.
+////
+//// To still gate releases on the cross-target runtime contract, this
+//// module is a hand-rolled JavaScript-only test entry that calls
+//// every `runtime_test` function explicitly. It bypasses gleeunit's
+//// auto-discovery and therefore loads only `runtime_test`,
+//// `sqlode/runtime`, and `gleeunit/should` at run time — none of
+//// which depend on `glint`. The same `runtime_test` functions still
+//// run on Erlang under the standard `gleam test` lane.
+////
+//// Run locally:
+////   gleam run -m sqlode_js_test --target javascript
+////
+//// Add new entries here whenever a new `runtime_test` function lands
+//// so the JavaScript lane keeps full parity with the Erlang lane for
+//// the runtime surface generated code calls into.
+
+import gleam/io
+import runtime_test
+
+pub fn main() {
+  io.println("=== sqlode/runtime laws on the JavaScript target ===")
+
+  // --- Value encoders -----------------------------------------------------
+  runtime_test.null_value_test()
+  runtime_test.string_value_test()
+  runtime_test.int_value_test()
+  runtime_test.float_value_test()
+  runtime_test.bool_value_test()
+  runtime_test.bytes_value_test()
+  runtime_test.array_value_test()
+  runtime_test.array_empty_test()
+  runtime_test.array_nested_types_test()
+
+  // --- prepare(): placeholder + slice expansion ---------------------------
+  runtime_test.prepare_no_slices_test()
+  runtime_test.prepare_with_slices_test()
+  runtime_test.prepare_mixed_params_test()
+  runtime_test.prepare_mysql_slice_expands_to_positional_test()
+  runtime_test.prepare_mysql_mixed_params_and_slice_test()
+  runtime_test.prepare_sqlite_reads_style_from_raw_query_test()
+
+  // --- expand_slice_placeholders edge cases -------------------------------
+  runtime_test.expand_slice_placeholders_preserves_string_literal_with_placeholder_text_test()
+  runtime_test.expand_slice_placeholders_preserves_comment_with_placeholder_text_test()
+  runtime_test.expand_slice_placeholders_mysql_with_placeholder_literal_test()
+
+  io.println("All 18 runtime laws passed on the JavaScript target.")
+}


### PR DESCRIPTION
## Summary

Adds a JavaScript-target test lane that exercises every cross-target law in `sqlode/runtime` (Value encoders, `prepare`, marker-based placeholder / slice expansion, literal/comment-preservation edge cases) so JavaScript-target regressions are caught on PR and on tag rather than after a downstream user files an issue against generated code.

Closes #527.

## Changes

### Issue #527 (commit 1)

- **`test/sqlode_js_test.gleam`** — new dedicated entry point. Calls every `runtime_test` function explicitly so the JavaScript lane stays in parity with the Erlang lane for the runtime surface that generated code calls into.
- **`.github/workflows/ci.yml`** — `Build (JavaScript)` job adds a `Runtime tests (JavaScript)` step.
- **`.github/workflows/release.yml`** — `Build and verify` job adds `setup-node@v4`, a `Build (JavaScript)` step, and the same `Runtime tests (JavaScript)` step. Closes the gap noted in the comment at the top of that job that says any check on `ci.yml` and `just all` must be mirrored here.
- **`justfile`** — new `test-javascript` recipe; `just all` calls it after the Erlang test step.
- **`CHANGELOG.md`** — `[Unreleased] / Added` entry.

### Drive-by fix (commit 2)

- **`integration_test/warmup/manifest.toml`** — refreshed via `just integration-refresh`. The lock had not been touched since v0.13.0 and pinned `sqlode = 0.13.0`, so on the current main (v0.19.0) any `just integration-prepare` / `just all` failed with `IncompatibleLockedVersion`. The failure existed for any contributor running `just all` since v0.13.0, but only became blocking now because adding `just test-javascript` to `just all` exercises the local quality gate end-to-end.

## Why a dedicated entry point instead of `gleam test --target javascript`

`gleam test --target javascript` fails on this repository because gleeunit's JavaScript runner auto-discovers every `*_test.mjs` file under `build/dev/javascript/sqlode/test/` and Node loads each one. `cli_test` transitively pulls in `glint`, whose current generated JavaScript fails to parse on Node:

```
file:///.../build/dev/javascript/glint/glint.mjs:1932
  let $2 = $list.partition(
      ^
SyntaxError: Identifier '$2' has already been declared
```

The CLI is BEAM-only by design (escript), so this failure is a dependency-wiring concern, not a runtime-semantics concern. Calling each `runtime_test` function explicitly bypasses the auto-discovery and loads only `runtime_test`, `sqlode/runtime`, and `gleeunit/should` at run time — none of which depend on `glint`. The full rationale lives at the top of `test/sqlode_js_test.gleam` so the next contributor who adds a runtime test knows to extend the JavaScript call list.

## Acceptance criteria coverage

| Criterion | Where |
|---|---|
| CI runs JavaScript tests, not only `gleam build --target javascript` | `ci.yml` `Build (JavaScript)` job adds `Runtime tests (JavaScript)` step |
| runtime parity bugs are caught by tests before release | the same step is mirrored on `release.yml`'s `Build and verify` job, which gates `publish` and `release` (both use `needs: build`) |
| release gating uses the same JavaScript verification contract as CI | mirror is verbatim — same module, same flag |

## Verification

- `just all` — passes end-to-end (format, check, build, glinter, unit tests = 1073 passed, JavaScript build, JavaScript runtime tests = 18 passed, integration-prepare, shellspec = 27 examples / 0 failures).
- `gleam run -m sqlode_js_test --target javascript` — `All 18 runtime laws passed on the JavaScript target.`
- No new Gleam dependencies were added.
