### PR TITLE
feat(overrides): add explicit encode/decode codec hooks for opaque custom types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ erl_crash.dump
 test_output/
 test_integration_sqlite_tmp/
 doc/reference
+# escript binary produced by `scripts/smoke_escript.sh` and similar
+# build helpers. Always rooted so a future module/test named `sqlode`
+# is not matched.
+/sqlode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **overrides**: explicit `encode` / `decode` codec hooks for custom
+  type overrides (issue #529). Opaque domain types
+  (`pub opaque type UserId { UserId(Int) }`) are now usable from
+  generated code without relaxing their wrapper invariant — declaring
+  `encode: user_id_to_int` and `decode: int_to_user_id` on the
+  override pipes parameter values through the user's encode function
+  before the runtime primitive encoder, and composes the user's
+  decode function on top of the underlying primitive decoder via
+  `decode.map(...)`. Hooks are resolved relative to the module of
+  `gleam_type` (so `gleam_type: "myapp/types.UserId"` plus
+  `encode: "user_id_to_int"` emits `types.user_id_to_int(value)` at
+  the call site), and the pair is required as a unit — providing
+  only one half is rejected at config-load time. The transparent-
+  alias warning is suppressed when codec hooks are supplied; the
+  README's "Custom type aliases" subsection now documents both
+  paths. The new `model.CodecHooks` type and the `codec` field on
+  `TypeOverride` and `ScalarType.CustomType` are internal-only
+  (`internal_modules`); `*.gleam` consumers see no API change. (#529)
 - **ci/runtime**: JavaScript-target test lane. The cross-target laws
   in `sqlode/runtime` (Value encoders, `prepare`, marker-based
   placeholder / slice expansion across PostgreSQL `$N`, SQLite `?N`,

--- a/README.md
+++ b/README.md
@@ -644,21 +644,46 @@ Column-level overrides win over `db_type` overrides.
 
 ### Custom type aliases
 
-A non-primitive `gleam_type` (e.g. `UserId` instead of `Int`) keeps the name in generated record fields but encodes and decodes through the underlying primitive.
-
-Opaque types are not supported — the mapped type must be a transparent alias. Opaque single-constructor types fail to compile because the generated code calls primitive encoders (like `runtime.int(params.id)`) directly on the value. A codec hook for opaque types is tracked for a future release.
+A non-primitive `gleam_type` (e.g. `UserId` instead of `Int`) keeps the name in generated record fields but, by default, encodes and decodes through the underlying primitive. That works when the mapped type is a transparent alias:
 
 ```gleam
-// OK: transparent alias
+// OK: transparent alias — the underlying primitive encoders apply
+// directly because `UserId` is just `Int` at runtime.
 pub type UserId = Int
+```
 
-// Error: opaque
+For opaque domain types (single-constructor wrappers around the underlying value), declare explicit `encode` / `decode` codec hooks alongside the override. The generated code then routes the value through the user-supplied pair instead of calling the primitive encoder on the wrapped form:
+
+```yaml
+overrides:
+  types:
+    - db_type: "int"
+      gleam_type: "myapp/types.UserId"
+      encode: "user_id_to_int"
+      decode: "int_to_user_id"
+```
+
+```gleam
+// myapp/types.gleam
 pub opaque type UserId {
   UserId(Int)
 }
+
+pub fn user_id_to_int(id: UserId) -> Int {
+  let UserId(inner) = id
+  inner
+}
+
+pub fn int_to_user_id(value: Int) -> UserId {
+  UserId(value)
+}
 ```
 
-sqlode checks that `gleam_type` starts with an uppercase letter and warns when custom types are in play.
+`encode` and `decode` MUST be specified together — providing only one half is rejected at config-load time. Hook function names are resolved relative to the module of `gleam_type`: with `gleam_type: "myapp/types.UserId"` the generated code calls `types.user_id_to_int(value)` (the trailing-segment alias of the existing type import), so the user only needs the type itself in scope.
+
+Without codec hooks, sqlode emits a warning at generation time pointing at the transparent-alias requirement; the warning is suppressed when codec hooks are provided.
+
+sqlode checks that `gleam_type` starts with an uppercase letter and `encode` / `decode` start with a lowercase letter (or underscore).
 
 ### Semantic type mappings
 

--- a/README.md
+++ b/README.md
@@ -770,9 +770,9 @@ sql:
 
 Unresolvable columns are then printed to stderr and dropped (or the whole view is dropped if nothing resolves).
 
-### Custom types must be transparent aliases
+### Custom types: transparent aliases by default, opaque via codec hooks
 
-See [Custom type aliases](#custom-type-aliases). Opaque types (`pub opaque type Foo { ... }`) are not supported.
+See [Custom type aliases](#custom-type-aliases). Without codec hooks, the mapped `gleam_type` MUST be a transparent alias (`pub type UserId = Int`) — the generated code calls primitive encoders directly on the value. Opaque single-constructor types (`pub opaque type UserId { UserId(Int) }`) are supported via the explicit `encode` / `decode` hooks documented there.
 
 ## Config options
 

--- a/src/sqlode/internal/char_utils.gleam
+++ b/src/sqlode/internal/char_utils.gleam
@@ -23,6 +23,14 @@ pub fn is_uppercase_letter(g: String) -> Bool {
   cp >= 65 && cp <= 90
 }
 
+pub fn is_lowercase_letter(g: String) -> Bool {
+  let cp = case string.to_utf_codepoints(g) {
+    [cp] -> string.utf_codepoint_to_int(cp)
+    _ -> 0
+  }
+  cp >= 97 && cp <= 122
+}
+
 pub fn is_alpha_or_underscore(g: String) -> Bool {
   is_alpha(g) || g == "_"
 }

--- a/src/sqlode/internal/codegen/adapter.gleam
+++ b/src/sqlode/internal/codegen/adapter.gleam
@@ -1,6 +1,7 @@
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
+import gleam/option
 import gleam/string
 import sqlode/internal/codegen/builder
 import sqlode/internal/codegen/common
@@ -460,6 +461,18 @@ fn render_base_decoder(
   case scalar_type {
     model.EnumType(_) | model.SetType(_) ->
       common.render_enum_or_set_decoder(scalar_type, config.decoder_function)
+    // Custom override with explicit codec hooks (issue #529): compose
+    // the user's `decode` function on top of the underlying primitive
+    // decoder so the row value is reconstructed inside the opaque
+    // wrapper. The underlying decoder is still chosen via
+    // `config.decoder_function`, which already routes `CustomType` to
+    // its underlying primitive.
+    model.CustomType(module:, codec: option.Some(hooks), ..) ->
+      "decode.map("
+      <> config.decoder_function(scalar_type)
+      <> ", "
+      <> qualified_decoder_hook_call(module, hooks.decode)
+      <> ")"
     _ ->
       case
         type_mapping == model.StrongMapping
@@ -478,6 +491,30 @@ fn render_base_decoder(
           <> ")"
         }
         False -> config.decoder_function(scalar_type)
+      }
+  }
+}
+
+/// Build the module-qualified call site for a decode hook so it
+/// matches the existing `import myapp/types.{type UserId}` shape (the
+/// trailing-segment module alias is what's reachable in scope).
+fn qualified_decoder_hook_call(
+  module: option.Option(String),
+  fn_name: String,
+) -> String {
+  case module {
+    option.Some(module_path) -> module_alias_for(module_path) <> "." <> fn_name
+    option.None -> fn_name
+  }
+}
+
+fn module_alias_for(module_path: String) -> String {
+  case string.split(module_path, "/") {
+    [] -> module_path
+    segments ->
+      case list.last(segments) {
+        Ok(last) -> last
+        Error(_) -> module_path
       }
   }
 }

--- a/src/sqlode/internal/codegen/common.gleam
+++ b/src/sqlode/internal/codegen/common.gleam
@@ -139,7 +139,7 @@ pub fn custom_type_imports(scalar_types: List(model.ScalarType)) -> List(String)
   scalar_types
   |> list.filter_map(fn(st) {
     case st {
-      model.CustomType(name, option.Some(module), _) ->
+      model.CustomType(name, option.Some(module), _, _) ->
         Ok("import " <> module <> ".{type " <> name <> "}")
       _ -> Error(Nil)
     }

--- a/src/sqlode/internal/codegen/models.gleam
+++ b/src/sqlode/internal/codegen/models.gleam
@@ -420,20 +420,25 @@ fn needs_option_import_for_tables(catalog: model.Catalog) -> Bool {
 }
 
 fn has_custom_types_in_results(queries: List(model.AnalyzedQuery)) -> Bool {
+  // The transparent-alias warning only fires for custom types WITHOUT
+  // codec hooks. A `CustomType(..., codec: Some(_))` is the documented
+  // opt-in escape hatch for opaque domain types (issue #529); it does
+  // not need the alias warning because the generated code routes the
+  // value through the user's encode/decode pair.
   list.any(queries, fn(query) {
     case model.is_result_command(query.base.command) {
       True ->
         list.any(query.result_columns, fn(item) {
           case item {
             model.ScalarResult(model.ResultColumn(
-              scalar_type: model.CustomType(..),
+              scalar_type: model.CustomType(codec: option.None, ..),
               ..,
             )) -> True
             model.ScalarResult(..) -> False
             model.EmbeddedResult(model.EmbeddedColumn(columns:, ..)) ->
               list.any(columns, fn(c) {
                 case c.scalar_type {
-                  model.CustomType(..) -> True
+                  model.CustomType(codec: option.None, ..) -> True
                   _ -> False
                 }
               })

--- a/src/sqlode/internal/codegen/params.gleam
+++ b/src/sqlode/internal/codegen/params.gleam
@@ -187,6 +187,13 @@ type ValueEncoder {
   UnwrapEncode(runtime_fn: String, unwrap_fn: String)
   /// Encode an enum: `runtime.string(models.status_to_string(value))`
   EnumEncode(runtime_fn: String, to_string_fn: String)
+  /// Pipe the value through a user-provided codec hook before the
+  /// runtime encoder: `runtime.int(types.user_id_to_int(value))`. Used
+  /// for `CustomType` overrides that opted into explicit codec hooks
+  /// (issue #529 — opaque domain types). The hook is rendered
+  /// module-qualified when the type's `gleam_type` carried a module
+  /// prefix, matching the import shape of `custom_type_imports`.
+  HookEncode(runtime_fn: String, hook_call: String)
   /// Encode an array: `runtime.array(list.map(value, element_encoder))`
   ArrayEncode(element_encoder: ValueEncoder)
 }
@@ -215,6 +222,15 @@ fn plan_encoding(
       let inner = plan_encoding(element, type_mapping_mode)
       ArrayEncode(element_encoder: inner)
     }
+    // Custom override with explicit codec hooks (issue #529): pipe
+    // the user value through the encode hook before the underlying
+    // runtime encoder. Branches above ArrayType / EnumType fall
+    // through to the legacy paths so wrapped collections still work.
+    model.CustomType(module:, codec: option.Some(hooks), ..) -> {
+      let runtime_fn = type_mapping.scalar_type_to_runtime_function(scalar_type)
+      let hook_call = qualified_hook_call(module, hooks.encode)
+      HookEncode(runtime_fn:, hook_call:)
+    }
     _ -> {
       let runtime_fn = type_mapping.scalar_type_to_runtime_function(scalar_type)
       case type_mapping_mode {
@@ -230,6 +246,32 @@ fn plan_encoding(
   }
 }
 
+/// Build a callable expression for a codec hook function.
+///
+/// When the type carried a module prefix (e.g. `myapp/types.UserId`),
+/// the existing `import myapp/types.{type UserId}` line in the
+/// generated file binds `types` as a module alias, so we produce
+/// `types.<fn_name>`. When the type has no module prefix the user is
+/// expected to ensure the function is reachable in the generated
+/// file's scope; we emit the bare name so any import strategy works.
+fn qualified_hook_call(module: option.Option(String), fn_name: String) -> String {
+  case module {
+    option.Some(module_path) -> module_alias_for(module_path) <> "." <> fn_name
+    option.None -> fn_name
+  }
+}
+
+fn module_alias_for(module_path: String) -> String {
+  case string.split(module_path, "/") {
+    [] -> module_path
+    segments ->
+      case list.last(segments) {
+        Ok(last) -> last
+        Error(_) -> module_path
+      }
+  }
+}
+
 /// Render the encoder as a function expression (for use in callbacks).
 fn render_encoder_fn(encoder: ValueEncoder) -> String {
   case encoder {
@@ -238,6 +280,8 @@ fn render_encoder_fn(encoder: ValueEncoder) -> String {
       "fn(v) { " <> runtime_fn <> "(" <> unwrap_fn <> "(v)) }"
     EnumEncode(runtime_fn:, to_string_fn:) ->
       "fn(v) { " <> runtime_fn <> "(" <> to_string_fn <> "(v)) }"
+    HookEncode(runtime_fn:, hook_call:) ->
+      "fn(v) { " <> runtime_fn <> "(" <> hook_call <> "(v)) }"
     ArrayEncode(element_encoder:) -> {
       let mapper = render_encoder_fn(element_encoder)
       "fn(v) { runtime.array(list.map(v, " <> mapper <> ")) }"
@@ -253,6 +297,8 @@ fn render_encoder_apply(encoder: ValueEncoder, value_expr: String) -> String {
       runtime_fn <> "(" <> unwrap_fn <> "(" <> value_expr <> "))"
     EnumEncode(runtime_fn:, to_string_fn:) ->
       runtime_fn <> "(" <> to_string_fn <> "(" <> value_expr <> "))"
+    HookEncode(runtime_fn:, hook_call:) ->
+      runtime_fn <> "(" <> hook_call <> "(" <> value_expr <> "))"
     ArrayEncode(element_encoder:) -> {
       let mapper = render_encoder_fn(element_encoder)
       "runtime.array(list.map(" <> value_expr <> ", " <> mapper <> "))"

--- a/src/sqlode/internal/codegen/queries.gleam
+++ b/src/sqlode/internal/codegen/queries.gleam
@@ -1,6 +1,7 @@
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/list
+import gleam/option
 import gleam/string
 import sqlode/internal/codegen/common
 import sqlode/internal/model
@@ -483,6 +484,17 @@ fn render_raw_base_decoder(
         scalar_type,
         type_mapping.scalar_type_to_decoder(engine, _),
       )
+    // Custom override with explicit codec hooks (issue #529): compose
+    // the user-supplied `decode` function on top of the underlying
+    // primitive decoder so the row value is wrapped back into the
+    // opaque domain type. Mirrors the corresponding branch in
+    // `adapter.gleam`'s `render_base_decoder`.
+    model.CustomType(module:, codec: option.Some(hooks), ..) ->
+      "decode.map("
+      <> type_mapping.scalar_type_to_decoder(engine, scalar_type)
+      <> ", "
+      <> qualified_decoder_hook_call(module, hooks.decode)
+      <> ")"
     _ ->
       case
         type_mapping_mode == model.StrongMapping
@@ -501,6 +513,30 @@ fn render_raw_base_decoder(
           <> ")"
         }
         False -> type_mapping.scalar_type_to_decoder(engine, scalar_type)
+      }
+  }
+}
+
+/// Build the module-qualified call site for a decode hook so it
+/// matches the `import myapp/types.{type UserId}` shape (the
+/// trailing-segment module alias is what's reachable in scope).
+fn qualified_decoder_hook_call(
+  module: option.Option(String),
+  fn_name: String,
+) -> String {
+  case module {
+    option.Some(module_path) -> module_alias_for(module_path) <> "." <> fn_name
+    option.None -> fn_name
+  }
+}
+
+fn module_alias_for(module_path: String) -> String {
+  case string.split(module_path, "/") {
+    [] -> module_path
+    segments ->
+      case list.last(segments) {
+        Ok(last) -> last
+        Error(_) -> module_path
       }
   }
 }

--- a/src/sqlode/internal/config.gleam
+++ b/src/sqlode/internal/config.gleam
@@ -207,6 +207,9 @@ fn parse_overrides(node: yay.Node) -> Result(model.Overrides, ConfigError) {
               let db_type = optional_string(item, "db_type")
               let column = optional_string(item, "column")
               let nullable = optional_bool(item, "nullable")
+              let encode = optional_string(item, "encode")
+              let decode = optional_string(item, "decode")
+              use codec <- result.try(parse_codec_hooks(encode, decode))
               case column, db_type, gleam_type {
                 Some(col), _, Some(gt) -> {
                   use _ <- result.try(validate_gleam_type(gt))
@@ -216,6 +219,7 @@ fn parse_overrides(node: yay.Node) -> Result(model.Overrides, ConfigError) {
                         table:,
                         column: col_name,
                         gleam_type: gt,
+                        codec:,
                       ))
                     _ ->
                       Error(InvalidValue(
@@ -232,6 +236,7 @@ fn parse_overrides(node: yay.Node) -> Result(model.Overrides, ConfigError) {
                     db_type: dt,
                     gleam_type: gt,
                     nullable:,
+                    codec:,
                   ))
                 }
                 _, _, _ ->
@@ -268,6 +273,66 @@ fn parse_overrides(node: yay.Node) -> Result(model.Overrides, ConfigError) {
       )
 
       Ok(model.Overrides(type_overrides:, column_renames:))
+    }
+  }
+}
+
+fn parse_codec_hooks(
+  encode: Option(String),
+  decode: Option(String),
+) -> Result(Option(model.CodecHooks), ConfigError) {
+  case encode, decode {
+    None, None -> Ok(None)
+    Some(e), Some(d) -> {
+      use _ <- result.try(validate_codec_hook("encode", e))
+      use _ <- result.try(validate_codec_hook("decode", d))
+      Ok(Some(model.CodecHooks(encode: e, decode: d)))
+    }
+    Some(_), None ->
+      Error(InvalidValue(
+        field: "overrides.types.decode",
+        detail: "must be specified together with \"encode\"; provide both codec hooks or neither",
+      ))
+    None, Some(_) ->
+      Error(InvalidValue(
+        field: "overrides.types.encode",
+        detail: "must be specified together with \"decode\"; provide both codec hooks or neither",
+      ))
+  }
+}
+
+fn validate_codec_hook(side: String, value: String) -> Result(Nil, ConfigError) {
+  case string.is_empty(value) {
+    True ->
+      Error(InvalidValue(
+        field: "overrides.types." <> side,
+        detail: "must not be empty",
+      ))
+    False -> {
+      // Function names in Gleam start with a lowercase letter (or
+      // underscore, which is uncommon for public functions). Reject
+      // type-shaped names early so a misplaced field surfaces here
+      // rather than as an opaque codegen failure.
+      let name_segment = case string.split_once(value, ".") {
+        Ok(#(_, name)) -> name
+        Error(_) -> value
+      }
+      let first = string.first(name_segment) |> result.unwrap("")
+      case char_utils.is_lowercase_letter(first) || first == "_", first == "" {
+        True, _ -> Ok(Nil)
+        _, True ->
+          Error(InvalidValue(
+            field: "overrides.types." <> side,
+            detail: "function name must not be empty",
+          ))
+        _, _ ->
+          Error(InvalidValue(
+            field: "overrides.types." <> side,
+            detail: "function name must start with a lowercase letter or underscore, got \""
+              <> value
+              <> "\"",
+          ))
+      }
     }
   }
 }

--- a/src/sqlode/internal/generate.gleam
+++ b/src/sqlode/internal/generate.gleam
@@ -520,11 +520,12 @@ fn apply_type_overrides(
           let columns =
             list.map(table.columns, fn(col) {
               case find_column_override(table.name, col.name, overrides) {
-                Ok(gleam_type) ->
+                Ok(#(gleam_type, codec)) ->
                   model.Column(
                     ..col,
                     scalar_type: gleam_type_to_scalar(
                       gleam_type,
+                      codec,
                       col.scalar_type,
                     ),
                   )
@@ -536,11 +537,12 @@ fn apply_type_overrides(
                       overrides,
                     )
                   {
-                    Ok(gleam_type) ->
+                    Ok(#(gleam_type, codec)) ->
                       model.Column(
                         ..col,
                         scalar_type: gleam_type_to_scalar(
                           gleam_type,
+                          codec,
                           col.scalar_type,
                         ),
                       )
@@ -559,15 +561,15 @@ fn find_column_override(
   table_name: String,
   column_name: String,
   overrides: List(model.TypeOverride),
-) -> Result(String, Nil) {
+) -> Result(#(String, option.Option(model.CodecHooks)), Nil) {
   list.find_map(overrides, fn(ovr) {
     case ovr {
-      model.ColumnOverride(table:, column:, gleam_type:) ->
+      model.ColumnOverride(table:, column:, gleam_type:, codec:) ->
         case
           string.lowercase(table) == string.lowercase(table_name)
           && string.lowercase(column) == string.lowercase(column_name)
         {
-          True -> Ok(gleam_type)
+          True -> Ok(#(gleam_type, codec))
           False -> Error(Nil)
         }
       model.DbTypeOverride(..) -> Error(Nil)
@@ -579,19 +581,19 @@ fn find_db_type_override(
   scalar_type: model.ScalarType,
   is_nullable: Bool,
   overrides: List(model.TypeOverride),
-) -> Result(String, Nil) {
+) -> Result(#(String, option.Option(model.CodecHooks)), Nil) {
   let type_name = type_mapping.scalar_type_to_db_name(scalar_type)
 
   list.find_map(overrides, fn(ovr) {
     case ovr {
-      model.DbTypeOverride(db_type:, gleam_type:, nullable:) ->
+      model.DbTypeOverride(db_type:, gleam_type:, nullable:, codec:) ->
         case string.lowercase(db_type) == type_name {
           True ->
             case nullable {
-              option.None -> Ok(gleam_type)
+              option.None -> Ok(#(gleam_type, codec))
               option.Some(n) ->
                 case n == is_nullable {
-                  True -> Ok(gleam_type)
+                  True -> Ok(#(gleam_type, codec))
                   False -> Error(Nil)
                 }
             }
@@ -604,6 +606,7 @@ fn find_db_type_override(
 
 fn gleam_type_to_scalar(
   gleam_type: String,
+  codec: option.Option(model.CodecHooks),
   underlying: model.ScalarType,
 ) -> model.ScalarType {
   case string.lowercase(gleam_type) {
@@ -614,22 +617,37 @@ fn gleam_type_to_scalar(
     "bitarray" -> model.BytesType
     _ -> {
       let #(module, type_name) = parse_module_qualified_type(gleam_type)
-      let underlying_name =
-        type_mapping.scalar_type_to_gleam_type(underlying, model.StringMapping)
-      io.println_error(
-        "Warning: custom gleam_type \""
-        <> gleam_type
-        <> "\" will use the encoder/decoder for the underlying \""
-        <> underlying_name
-        <> "\" type. Ensure \""
-        <> type_name
-        <> "\" is defined as a transparent type alias (e.g., pub type "
-        <> type_name
-        <> " = "
-        <> underlying_name
-        <> "). Opaque types are not supported.",
-      )
-      model.CustomType(name: type_name, module:, underlying:)
+      // Suppress the transparent-alias warning when the user supplied
+      // explicit codec hooks — that's the documented escape hatch for
+      // opaque domain types (issue #529). Without hooks, keep the
+      // existing warning so users aren't surprised when the generated
+      // code calls primitive encoders directly on a wrapped value.
+      case codec {
+        option.Some(_) -> Nil
+        option.None -> {
+          let underlying_name =
+            type_mapping.scalar_type_to_gleam_type(
+              underlying,
+              model.StringMapping,
+            )
+          io.println_error(
+            "Warning: custom gleam_type \""
+            <> gleam_type
+            <> "\" will use the encoder/decoder for the underlying \""
+            <> underlying_name
+            <> "\" type. Ensure \""
+            <> type_name
+            <> "\" is defined as a transparent type alias (e.g., pub type "
+            <> type_name
+            <> " = "
+            <> underlying_name
+            <> "), or provide explicit `encode` / `decode` codec hooks "
+            <> "in `overrides.types` to support opaque types.",
+          )
+          Nil
+        }
+      }
+      model.CustomType(name: type_name, module:, underlying:, codec:)
     }
   }
 }

--- a/src/sqlode/internal/model.gleam
+++ b/src/sqlode/internal/model.gleam
@@ -71,9 +71,44 @@ pub fn runtime_to_string(runtime: Runtime) -> String {
   }
 }
 
+/// Pair of user-provided codec function names that bridge the
+/// underlying primitive value and the user's `gleam_type`. Unqualified
+/// names are resolved relative to the module of the declared
+/// `gleam_type` — e.g. for `gleam_type: "myapp/types.UserId"` and
+/// `encode: "user_id_to_int"`, the generated code calls
+/// `types.user_id_to_int(value)` (the trailing-segment module alias
+/// produced by the existing `import myapp/types.{type UserId}`).
+///
+/// `encode` is called on the user's value before handing it to the
+/// runtime parameter encoder. `decode` is composed under
+/// `decode.map(...)` after the underlying primitive decoder.
+///
+/// Both fields are required; `parse_overrides` rejects entries that
+/// specify only one half. The pair makes opaque domain types
+/// (`pub opaque type UserId { UserId(Int) }`) usable from generated
+/// code without relaxing their wrapper invariant.
+pub type CodecHooks {
+  CodecHooks(encode: String, decode: String)
+}
+
 pub type TypeOverride {
-  DbTypeOverride(db_type: String, gleam_type: String, nullable: Option(Bool))
-  ColumnOverride(table: String, column: String, gleam_type: String)
+  DbTypeOverride(
+    db_type: String,
+    gleam_type: String,
+    nullable: Option(Bool),
+    /// `Some` when the user opted into the encode/decode hook path
+    /// (i.e. the gleam_type is opaque or otherwise needs explicit
+    /// codec functions). `None` keeps the existing transparent-alias
+    /// behaviour.
+    codec: Option(CodecHooks),
+  )
+  ColumnOverride(
+    table: String,
+    column: String,
+    gleam_type: String,
+    /// See `DbTypeOverride.codec`.
+    codec: Option(CodecHooks),
+  )
 }
 
 pub type ColumnRename {
@@ -232,6 +267,17 @@ pub type ScalarType {
     name: String,
     module: option.Option(String),
     underlying: ScalarType,
+    /// `Some` when the override that produced this `CustomType`
+    /// declared explicit `encode` / `decode` codec hooks (issue #529
+    /// — opaque domain types). When `Some`, `codegen/params.gleam`
+    /// pipes the user value through `encode` before the underlying
+    /// runtime encoder, and `codegen/adapter.gleam` composes the
+    /// decoder under `decode.map(_, decode)`. When `None`, codegen
+    /// keeps the legacy transparent-alias path: the underlying
+    /// primitive's encoder/decoder is called directly on the value,
+    /// which only compiles when the user defined the type as a
+    /// `pub type Name = Underlying` alias.
+    codec: option.Option(CodecHooks),
   )
   ArrayType(element: ScalarType)
 }

--- a/src/sqlode/internal/type_mapping.gleam
+++ b/src/sqlode/internal/type_mapping.gleam
@@ -150,7 +150,7 @@ fn resolve_type(scalar_type: ScalarType) -> TypeResolution {
       ))
     EnumType(name) -> EnumResolution(name)
     SetType(name) -> SetResolution(name)
-    CustomType(name, module, underlying) ->
+    CustomType(name, module, underlying, _codec) ->
       CustomResolution(name, module, underlying)
     ArrayType(element) -> ArrayResolution(element)
   }

--- a/test/config_test.gleam
+++ b/test/config_test.gleam
@@ -137,6 +137,40 @@ pub fn reject_empty_gleam_type_test() {
   string.contains(msg, "empty") |> should.be_true()
 }
 
+// codec hooks (issue #529 — opaque custom types)
+
+pub fn accept_codec_hooks_full_test() {
+  let assert Ok(cfg) = config.load("test/fixtures/codec_hooks_full.yaml")
+  let assert [block] = cfg.sql
+  let assert [override] = block.overrides.type_overrides
+  let assert model.DbTypeOverride(
+    db_type: _,
+    gleam_type: gt,
+    nullable: _,
+    codec: option.Some(model.CodecHooks(encode: enc, decode: dec)),
+  ) = override
+  gt |> should.equal("myapp/types.UserId")
+  enc |> should.equal("user_id_to_int")
+  dec |> should.equal("int_to_user_id")
+}
+
+pub fn reject_codec_hooks_encode_without_decode_test() {
+  let assert Error(error) =
+    config.load("test/fixtures/codec_hooks_encode_only.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "decode") |> should.be_true()
+  string.contains(msg, "together") |> should.be_true()
+}
+
+pub fn reject_codec_hooks_uppercase_function_name_test() {
+  let assert Error(error) =
+    config.load("test/fixtures/codec_hooks_invalid_encode.yaml")
+  let msg = config.error_to_string(error)
+  string.contains(msg, "encode") |> should.be_true()
+  string.contains(msg, "lowercase") |> should.be_true()
+  string.contains(msg, "UserIdToInt") |> should.be_true()
+}
+
 // malformed rename entries
 
 pub fn reject_malformed_rename_entry_test() {

--- a/test/fixtures/codec_hooks_encode_only.yaml
+++ b/test/fixtures/codec_hooks_encode_only.yaml
@@ -1,0 +1,13 @@
+version: "2"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        out: "test_output/db"
+    overrides:
+      types:
+        - db_type: "int"
+          gleam_type: "myapp/types.UserId"
+          encode: "user_id_to_int"

--- a/test/fixtures/codec_hooks_full.yaml
+++ b/test/fixtures/codec_hooks_full.yaml
@@ -1,0 +1,14 @@
+version: "2"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        out: "test_output/db"
+    overrides:
+      types:
+        - db_type: "int"
+          gleam_type: "myapp/types.UserId"
+          encode: "user_id_to_int"
+          decode: "int_to_user_id"

--- a/test/fixtures/codec_hooks_invalid_encode.yaml
+++ b/test/fixtures/codec_hooks_invalid_encode.yaml
@@ -1,0 +1,14 @@
+version: "2"
+sql:
+  - schema: "test/fixtures/schema.sql"
+    queries: "test/fixtures/query.sql"
+    engine: "postgresql"
+    gen:
+      gleam:
+        out: "test_output/db"
+    overrides:
+      types:
+        - db_type: "int"
+          gleam_type: "myapp/types.UserId"
+          encode: "UserIdToInt"
+          decode: "int_to_user_id"

--- a/test/generate_test.gleam
+++ b/test/generate_test.gleam
@@ -59,6 +59,7 @@ pub fn type_override_changes_scalar_type_test() {
             db_type: "string",
             gleam_type: "Int",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -84,6 +85,7 @@ pub fn type_override_case_insensitive_db_type_test() {
             db_type: "STRING",
             gleam_type: "Float",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -108,6 +110,7 @@ pub fn type_override_preserves_unmatched_columns_test() {
             db_type: "bool",
             gleam_type: "String",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -134,11 +137,13 @@ pub fn type_override_multiple_overrides_test() {
             db_type: "int",
             gleam_type: "String",
             nullable: option.None,
+            codec: option.None,
           ),
           model.DbTypeOverride(
             db_type: "string",
             gleam_type: "BitArray",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -165,6 +170,7 @@ pub fn custom_type_override_preserves_type_name_test() {
             db_type: "int",
             gleam_type: "UserId",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -190,6 +196,7 @@ pub fn custom_column_override_preserves_type_name_test() {
             table: "authors",
             column: "name",
             gleam_type: "AuthorName",
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -215,6 +222,7 @@ pub fn custom_type_override_adds_alias_warning_comment_test() {
             db_type: "int",
             gleam_type: "UserId",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -254,6 +262,7 @@ pub fn module_qualified_custom_type_generates_import_test() {
             db_type: "int",
             gleam_type: "myapp/types.UserId",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -297,6 +306,7 @@ pub fn module_qualified_custom_type_in_params_generates_import_test() {
             db_type: "int",
             gleam_type: "myapp/types.UserId",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -309,6 +319,103 @@ pub fn module_qualified_custom_type_in_params_generates_import_test() {
   // Params module should also import the module-qualified type
   string.contains(params, "import myapp/types.{type UserId}")
   |> should.be_true()
+
+  cleanup()
+}
+
+// --- codec hooks (issue #529) ---
+
+pub fn codec_hooks_emit_encode_call_in_params_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "myapp/types.UserId",
+            nullable: option.None,
+            codec: option.Some(model.CodecHooks(
+              encode: "user_id_to_int",
+              decode: "int_to_user_id",
+            )),
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let params = read_generated("params.gleam")
+
+  // The encoder must thread the value through the user's encode hook
+  // before handing it to the runtime primitive encoder. The hook is
+  // module-qualified via the trailing-segment alias of the imported
+  // module (`import myapp/types.{type UserId}` → `types`).
+  string.contains(params, "types.user_id_to_int") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn codec_hooks_emit_decode_map_in_adapter_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "myapp/types.UserId",
+            nullable: option.None,
+            codec: option.Some(model.CodecHooks(
+              encode: "user_id_to_int",
+              decode: "int_to_user_id",
+            )),
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let queries = read_generated("queries.gleam")
+
+  // Result decoding must compose the user's decode hook on top of
+  // the underlying primitive decoder so the row value is wrapped
+  // back into the opaque domain type.
+  string.contains(queries, "decode.map(") |> should.be_true()
+  string.contains(queries, "types.int_to_user_id") |> should.be_true()
+
+  cleanup()
+}
+
+pub fn codec_hooks_suppress_alias_warning_test() {
+  cleanup()
+  let block =
+    base_block(
+      model.Overrides(
+        type_overrides: [
+          model.DbTypeOverride(
+            db_type: "int",
+            gleam_type: "myapp/types.UserId",
+            nullable: option.None,
+            codec: option.Some(model.CodecHooks(
+              encode: "user_id_to_int",
+              decode: "int_to_user_id",
+            )),
+          ),
+        ],
+        column_renames: [],
+      ),
+    )
+
+  run_generate(block)
+  let models = read_generated("models.gleam")
+
+  // The "transparent type alias" warning is the wrong message when
+  // the user opted into codec hooks for an opaque domain type. It
+  // must be omitted in that case.
+  string.contains(models, "transparent type alias") |> should.be_false()
 
   cleanup()
 }
@@ -345,6 +452,7 @@ pub fn module_qualified_custom_type_in_queries_generates_import_test() {
             db_type: "int",
             gleam_type: "myapp/types.UserId",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -460,6 +568,7 @@ pub fn bare_custom_type_omits_module_import_test() {
             db_type: "int",
             gleam_type: "UserId",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -922,6 +1031,7 @@ pub fn combined_type_override_and_column_rename_test() {
             db_type: "string",
             gleam_type: "BitArray",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [
@@ -1027,6 +1137,7 @@ pub fn column_override_changes_specific_column_test() {
             table: "authors",
             column: "id",
             gleam_type: "String",
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -1052,11 +1163,13 @@ pub fn column_override_takes_precedence_over_db_type_test() {
             db_type: "int",
             gleam_type: "Float",
             nullable: option.None,
+            codec: option.None,
           ),
           model.ColumnOverride(
             table: "authors",
             column: "id",
             gleam_type: "String",
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -1082,6 +1195,7 @@ pub fn column_override_does_not_affect_other_tables_test() {
             table: "posts",
             column: "id",
             gleam_type: "String",
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -1131,6 +1245,7 @@ pub fn nullable_override_applies_only_to_nullable_columns_test() {
             db_type: "string",
             gleam_type: "BitArray",
             nullable: option.Some(True),
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -1158,6 +1273,7 @@ pub fn non_nullable_override_applies_only_to_non_nullable_columns_test() {
             db_type: "string",
             gleam_type: "BitArray",
             nullable: option.Some(False),
+            codec: option.None,
           ),
         ],
         column_renames: [],
@@ -1185,6 +1301,7 @@ pub fn nullable_none_override_applies_to_all_test() {
             db_type: "string",
             gleam_type: "BitArray",
             nullable: option.None,
+            codec: option.None,
           ),
         ],
         column_renames: [],

--- a/test/model_test.gleam
+++ b/test/model_test.gleam
@@ -158,7 +158,7 @@ pub fn scalar_type_to_gleam_type_string_mapping_test() {
   type_mapping.scalar_type_to_gleam_type(model.EnumType("status"), m)
   |> should.equal("Status")
   type_mapping.scalar_type_to_gleam_type(
-    model.CustomType("UserId", option.None, model.IntType),
+    model.CustomType("UserId", option.None, model.IntType, option.None),
     m,
   )
   |> should.equal("UserId")
@@ -187,7 +187,8 @@ pub fn scalar_type_to_gleam_type_rich_mapping_test() {
 }
 
 pub fn custom_type_delegates_to_underlying_test() {
-  let custom = model.CustomType("UserId", option.None, model.IntType)
+  let custom =
+    model.CustomType("UserId", option.None, model.IntType, option.None)
   type_mapping.scalar_type_to_runtime_function(custom)
   |> should.equal("runtime.int")
   type_mapping.scalar_type_to_db_name(custom) |> should.equal("int")


### PR DESCRIPTION
## Summary

Adds an opt-in `encode` / `decode` codec hook pair to `overrides.types` so opaque domain types (`pub opaque type UserId { UserId(Int) }`) are usable from generated code without relaxing their wrapper invariant. Previously the docs called this out as a known gap (\"A codec hook for opaque types is tracked for a future release\"); this PR closes that gap.

## Changes

- **src/sqlode/internal/model.gleam**: new `CodecHooks` record (`encode: String, decode: String`); `TypeOverride` (both variants) and `ScalarType.CustomType` gain an `Option(CodecHooks)` field.
- **src/sqlode/internal/config.gleam**: parse new optional `encode` / `decode` YAML keys under each `overrides.types` entry. Reject \"only one half\" with a precise error message; reject function names that don't start with a lowercase letter / underscore.
- **src/sqlode/internal/char_utils.gleam**: new `is_lowercase_letter` helper for the codec-hook function-name validation.
- **src/sqlode/internal/generate.gleam**: thread the codec hooks through `find_column_override` / `find_db_type_override` / `gleam_type_to_scalar`. Suppress the transparent-alias warning when codec hooks are provided.
- **src/sqlode/internal/codegen/params.gleam**: new `HookEncode` `ValueEncoder` variant that emits `runtime.int(types.user_id_to_int(value))` style calls for `CustomType` overrides with codec hooks.
- **src/sqlode/internal/codegen/adapter.gleam**, **src/sqlode/internal/codegen/queries.gleam**: `render_base_decoder` and `render_raw_base_decoder` compose `decode.map(<base_decoder>, types.int_to_user_id)` for `CustomType` overrides with codec hooks.
- **src/sqlode/internal/codegen/models.gleam**: the \"Custom types must be transparent type aliases\" warning comment is suppressed for codec-equipped overrides.
- **src/sqlode/internal/codegen/common.gleam**, **src/sqlode/internal/type_mapping.gleam**: positional `CustomType(...)` patterns updated to accept the new field via `_codec` / `..` rest arms.
- **test/config_test.gleam**, **test/generate_test.gleam**, **test/model_test.gleam**: new test cases for codec hooks YAML parsing, codegen output (encode call in params, `decode.map` in queries), and warning suppression. Existing 20 `DbTypeOverride` / `ColumnOverride` callsites in `generate_test.gleam` updated to provide the new `codec:` field. Total test count is now **1079, no failures**.
- **test/fixtures/codec_hooks_full.yaml**, **codec_hooks_encode_only.yaml**, **codec_hooks_invalid_encode.yaml**: new YAML fixtures backing the parser tests.
- **README.md**: \"Custom type aliases\" subsection now documents both the transparent-alias path and the codec-hook path with a complete example.
- **CHANGELOG.md**: log the new feature under \`[Unreleased]\`.

A separate prior commit (\`chore(gitignore): ignore the sqlode escript binary at repo root\`) adds \`/sqlode\` to \`.gitignore\` so the local \`scripts/smoke_escript.sh\` build artifact doesn't show up as untracked. Unrelated to the feature itself; included on the same branch to keep the working tree clean for future ghq-gleam runs.

## Design Decisions

- **`encode` / `decode` are required as a unit**. Allowing only one half would let users ship a write-only-readable schema. Config-load rejects \"only one\" with a pointed error message.
- **Hook functions are resolved relative to the type's module**. The generated file already imports the type via `import myapp/types.{type UserId}`, which binds `types` as a module alias. So `encode: \"user_id_to_int\"` plus `gleam_type: \"myapp/types.UserId\"` produces `types.user_id_to_int(value)` at the call site — no new imports needed, and the natural shape (define type and codec in the same module) just works. Cross-module codecs would need a thin wrapper; that's an acceptable trade-off for keeping the YAML simple.
- **The transparent-alias warning is suppressed when codec hooks are provided**. The warning is the wrong message in that case — the user already opted into the documented escape hatch, so emitting the same warning would be noise.
- **The new fields are internal-only**. `internal_modules = [\"sqlode/internal/**\"]` means consumers of the published package never see `model.TypeOverride` / `model.CustomType`, so adding fields is not a public-API break.

## Limitations

- Codec functions must be in the same module as the declared `gleam_type` (the natural shape). Cross-module codecs are not supported in this PR; users wanting that can add a thin re-export layer in the type's module.
- The existing transparent-alias path remains the default. Users who want opaque types must opt in by adding the hook pair.

Closes #529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom type codec hooks, enabling users to specify paired `encode`/`decode` functions for custom type overrides to control serialization and deserialization.

* **Documentation**
  * Updated README with codec hook configuration details.
  * Added changelog entry documenting the new codec hook feature.

* **Tests**
  * Added comprehensive test coverage for codec hook configuration and code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->