### PR TITLE
chore(release): prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-30
+
+### Removed
+
+- **docs/verify**: drop the "verification roadmap" promise of a
+  future DB-backed analysis phase. The static `sqlode verify` (schema
+  parsing + query analysis + `query_parameter_limit`) covers what
+  users actually need; running `EXPLAIN` / prepared-query validation
+  against a real database adds operational complexity (driver
+  dependency, container management, multi-engine support) without a
+  concrete pain point driving it. The README's "Verification
+  roadmap" subsection and the "DB-backed analyser is on the roadmap"
+  cell in the sqlc comparison table are removed; the doc-comment in
+  `src/sqlode/internal/verify.gleam` no longer references the
+  abandoned multi-phase plan. (#528)
+
 ### Added
 
 - **overrides**: explicit `encode` / `decode` codec hooks for custom

--- a/README.md
+++ b/README.md
@@ -834,14 +834,6 @@ Per-block policies `verify` honours:
 - `strict_views` — promote view-resolution warnings to findings (same as `generate`).
 - `query_parameter_limit` — per-query cap on inferred parameters, mirroring sqlc's option. Unset means no limit.
 
-### Verification roadmap
-
-Today's command covers the static phase of Issue #395. Future phases are additive — new findings show up in the existing `Report` without breaking the CLI contract:
-
-1. Static analysis (shipped) — schema + query parsing, analyser pass, `query_parameter_limit`.
-2. DB-backed analysis — a `database` / `analyzer` config that runs queries through `EXPLAIN` against a real database to catch view drift and engine-specific typing the local analyser misses.
-3. Execution-lane validation — running generated code against an ephemeral test DB as part of `verify`.
-
 ## Migrating from sqlc
 
 sqlode follows sqlc conventions, so most SQL files move over untouched. The differences:
@@ -852,7 +844,7 @@ sqlode follows sqlc conventions, so most SQL files move over untouched. The diff
 | Config | `sqlc.yaml` / `sqlc.json` | `sqlode.yaml` (v2 format only), also accepts `sqlc.yaml` / `sqlc.yml` / `sqlc.json` on autodiscovery |
 | Generate | `sqlc generate` | `sqlode generate` |
 | Init | `sqlc init` | `sqlode init` |
-| Vet/Verify | `sqlc vet`, `sqlc verify` | `sqlode verify` (static analysis + `query_parameter_limit`); DB-backed analyser is on the [verification roadmap](#verification-roadmap) |
+| Vet/Verify | `sqlc vet`, `sqlc verify` | `sqlode verify` (static analysis + `query_parameter_limit`) |
 | Target language | Go, Python, Kotlin, etc. | Gleam |
 | Runtime | Generated code is self-contained | Generated code imports `sqlode/runtime` by default; set `vendor_runtime: true` to vendor a copy and drop the runtime dependency (see [Self-contained generation](#self-contained-generation-vendor_runtime)) |
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.19.0"
+version = "0.20.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }

--- a/src/sqlode/internal/verify.gleam
+++ b/src/sqlode/internal/verify.gleam
@@ -7,13 +7,6 @@
 //// uses, collects every failure it can see, and layers additional
 //// static checks on top (today: `query_parameter_limit`
 //// enforcement). It never writes files.
-////
-//// The command is intended as the first phase of the Issue #395
-//// verification roadmap — later phases will add DB-backed analysis
-//// (`database` / `analyzer` config concepts) and execution-lane
-//// validation. Keeping the static surface here means those later
-//// phases can grow `Finding` with new variants without reshaping
-//// the command wiring.
 
 import filepath
 import gleam/int


### PR DESCRIPTION
### Removed

- **docs/verify**: drop the "verification roadmap" promise of a
  future DB-backed analysis phase. The static `sqlode verify` (schema
  parsing + query analysis + `query_parameter_limit`) covers what
  users actually need; running `EXPLAIN` / prepared-query validation
  against a real database adds operational complexity (driver
  dependency, container management, multi-engine support) without a
  concrete pain point driving it. The README's "Verification
  roadmap" subsection and the "DB-backed analyser is on the roadmap"
  cell in the sqlc comparison table are removed; the doc-comment in
  `src/sqlode/internal/verify.gleam` no longer references the
  abandoned multi-phase plan. (#528)

### Added

- **overrides**: explicit `encode` / `decode` codec hooks for custom
  type overrides (issue #529). Opaque domain types
  (`pub opaque type UserId { UserId(Int) }`) are now usable from
  generated code without relaxing their wrapper invariant — declaring
  `encode: user_id_to_int` and `decode: int_to_user_id` on the
  override pipes parameter values through the user's encode function
  before the runtime primitive encoder, and composes the user's
  decode function on top of the underlying primitive decoder via
  `decode.map(...)`. Hooks are resolved relative to the module of
  `gleam_type` (so `gleam_type: "myapp/types.UserId"` plus
  `encode: "user_id_to_int"` emits `types.user_id_to_int(value)` at
  the call site), and the pair is required as a unit — providing
  only one half is rejected at config-load time. The transparent-
  alias warning is suppressed when codec hooks are supplied; the
  README's "Custom type aliases" subsection now documents both
  paths. The new `model.CodecHooks` type and the `codec` field on
  `TypeOverride` and `ScalarType.CustomType` are internal-only
  (`internal_modules`); `*.gleam` consumers see no API change. (#529)
- **ci/runtime**: JavaScript-target test lane. The cross-target laws
  in `sqlode/runtime` (Value encoders, `prepare`, marker-based
  placeholder / slice expansion across PostgreSQL `$N`, SQLite `?N`,
  and MySQL `?` styles, plus the literal/comment-preservation edge
  cases) are now exercised on Node by a dedicated entry point
  (`test/sqlode_js_test.gleam`). Both `ci.yml` (the `Build
  (JavaScript)` job) and `release.yml` (the `Build and verify` job)
  invoke `gleam run -m sqlode_js_test --target javascript`, and
  `just all` does the same locally via the new `just test-javascript`
  recipe. The dedicated entry exists because gleeunit's JavaScript
  auto-discovery would otherwise transitively load `glint`, whose
  current generated JavaScript fails to parse on Node — the file
  documents the rationale and the call list mirrors every
  `runtime_test` function so the JavaScript lane stays in parity
  with the Erlang lane for the runtime surface generated code calls
  into. (#527)

### Fixed

- **integration tests**: drop the `GetAuthorsByIds` and
  `GetAuthorsByIdsAndNames` queries from the SQLite extended fixture
  (`test/fixtures/sqlite_extended_query.sql`) and the matching tests
  from `integration_test/fixtures/sqlite_extended_test.gleam`. Both
  queries used `sqlode.slice()` against the SQLite engine, which v0.19.0
  (#531 / #533) made an explicit `UnsupportedSliceForEngine` validation
  error. The integration lane was the last consumer of that
  combination, so the v0.19.0 release CI failed at
  `bash integration_test/run.sh` and never reached `gleam publish` or
  the GitHub release step. PostgreSQL slice coverage is unchanged and
  is regression-tested by `verify_test.gleam`.
