### PR TITLE
feat(codegen): run gleam format on generated output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **codegen**: `sqlode generate` now runs `gleam format` on the
+  generated files as the last step of the pipeline. Previously every
+  record constructor and `decode.field(...)` chain landed on a single
+  line that could exceed 200 characters, masking diffs and pointing
+  `git blame` at one line per record. The CLI prints
+  `Formatted generated code` on success and a non-fatal warning to
+  stderr if `gleam` is missing or the formatter exits non-zero — the
+  written files remain valid either way. (#543)
+
 ## [0.21.0] - 2026-05-04
 
 ### Documentation

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -6,6 +6,7 @@ import gleam/result
 import gleam/string
 import glint
 import simplifile
+import sqlode/internal/formatter
 import sqlode/internal/generate
 import sqlode/internal/verify
 import sqlode/internal/version
@@ -243,6 +244,7 @@ fn run_generate(flag_value: String) -> Nil {
             <> " files",
           )
           list.each(written, fn(path) { io.println("  Generated: " <> path) })
+          format_generated_files(written)
         }
         Error(error) -> {
           io.println_error("Error: " <> generate.error_to_string(error))
@@ -250,6 +252,20 @@ fn run_generate(flag_value: String) -> Nil {
         }
       }
     }
+  }
+}
+
+/// Run `gleam format` on the just-written files so the generated
+/// records and decoder chains break across lines instead of running
+/// past the project's line-width ruler. Treated as best-effort: the
+/// files have already been written and are syntactically correct, so
+/// a missing `gleam` binary or a non-zero formatter exit is reported
+/// as a warning and the command still exits 0. (#543)
+fn format_generated_files(written: List(String)) -> Nil {
+  case formatter.format_files(written) {
+    Ok(Nil) -> io.println("  Formatted generated code")
+    Error(error) ->
+      io.println_error("  Warning: " <> formatter.error_to_string(error))
   }
 }
 

--- a/src/sqlode/internal/formatter.gleam
+++ b/src/sqlode/internal/formatter.gleam
@@ -1,0 +1,83 @@
+//// Run `gleam format` on generated source files.
+////
+//// `sqlode generate` writes Gleam files whose contents are emitted as
+//// long, single-line records / decoder chains. The compiled output is
+//// correct but is hard to review (a single record line can exceed
+//// 200 chars). Running `gleam format` on the written files restores
+//// the project-standard line width and matches what the sibling
+//// `oaspec` generator already does at the end of its codegen run.
+////
+//// The CLI is BEAM-only by design (escript), so this module's only
+//// real implementation lives behind Erlang FFI. The JavaScript
+//// target carries a no-op so `gleam build --target javascript`
+//// stays green — the JS lane never invokes `sqlode generate`.
+
+import gleam/int
+import gleam/string
+
+/// Errors from formatting operations.
+pub type FormatError {
+  /// `gleam` was not found on `PATH`. The user has installed sqlode
+  /// but not the Gleam toolchain — surface an actionable message
+  /// instead of a generic exec failure.
+  GleamNotFound
+  /// `gleam format` ran but exited non-zero. `output` carries the
+  /// captured stdout+stderr so a syntax error in the generated file
+  /// is visible without re-running by hand.
+  FormatFailed(exit_code: Int, output: String)
+}
+
+@target(erlang)
+/// Format the given files in place by invoking `gleam format <files>`.
+/// Files (rather than directories) are passed so neighbouring source
+/// in the user's project that sqlode did not generate is left
+/// untouched.
+pub fn format_files(files: List(String)) -> Result(Nil, FormatError) {
+  case files {
+    [] -> Ok(Nil)
+    _ ->
+      case find_executable("gleam") {
+        Error(Nil) -> Error(GleamNotFound)
+        Ok(gleam_path) -> {
+          let #(exit_code, output) =
+            run_executable(gleam_path, ["format", ..files])
+          case exit_code {
+            0 -> Ok(Nil)
+            code -> Error(FormatFailed(exit_code: code, output: output))
+          }
+        }
+      }
+  }
+}
+
+@target(javascript)
+pub fn format_files(_files: List(String)) -> Result(Nil, FormatError) {
+  Ok(Nil)
+}
+
+/// Convert a format error to a human-readable string for CLI output.
+pub fn error_to_string(error: FormatError) -> String {
+  case error {
+    GleamNotFound ->
+      "gleam command not found in PATH. Install Gleam to format generated code."
+    FormatFailed(code, output) -> {
+      let trimmed = string.trim(output)
+      case trimmed {
+        "" -> "gleam format failed with exit code " <> int.to_string(code)
+        _ ->
+          "gleam format failed with exit code "
+          <> int.to_string(code)
+          <> ": "
+          <> trimmed
+      }
+    }
+  }
+}
+
+@target(erlang)
+@external(erlang, "sqlode_ffi", "find_executable")
+fn find_executable(name: String) -> Result(String, Nil)
+
+@target(erlang)
+@external(erlang, "sqlode_ffi", "run_executable")
+fn run_executable(executable: String, args: List(String)) -> #(Int, String)

--- a/src/sqlode_ffi.erl
+++ b/src/sqlode_ffi.erl
@@ -6,7 +6,7 @@
 %% type for.
 -module(sqlode_ffi).
 
--export([is_stdout_terminal/0, no_color_env/0]).
+-export([is_stdout_terminal/0, no_color_env/0, find_executable/1, run_executable/2]).
 
 %% Returns true iff `standard_io` is connected to an interactive
 %% terminal. When stdout is redirected to a file or pipe (as in
@@ -34,4 +34,41 @@ no_color_env() ->
             {error, nil};
         Value ->
             {ok, list_to_binary(Value)}
+    end.
+
+%% Locate an executable on `PATH`. Returns `{ok, Path}` (binary) on
+%% success or `{error, nil}` when no match is found, matching the
+%% Gleam `Result(String, Nil)` shape. Used by the codegen formatter
+%% step to find the `gleam` binary before invoking `gleam format`.
+-spec find_executable(binary()) -> {ok, binary()} | {error, nil}.
+find_executable(Name) ->
+    case os:find_executable(binary_to_list(Name)) of
+        false -> {error, nil};
+        Path -> {ok, list_to_binary(Path)}
+    end.
+
+%% Run an executable with the given list of arguments and capture its
+%% combined stdout+stderr. Returns `{ExitCode, Output}` so callers can
+%% surface `gleam format`'s diagnostic output verbatim when the run
+%% fails — exit code alone is opaque if a generated file has a syntax
+%% error. Uses `spawn_executable` (no shell) to avoid argument-quoting
+%% pitfalls. The hard 60s timeout protects the CLI from a hung
+%% formatter; a large generated tree finishes well under that.
+-spec run_executable(binary(), list(binary())) -> {integer(), binary()}.
+run_executable(Executable, Args) ->
+    Port = open_port(
+        {spawn_executable, binary_to_list(Executable)},
+        [exit_status, stderr_to_stdout, binary, {args, [binary_to_list(A) || A <- Args]}]
+    ),
+    collect_exit(Port, <<>>).
+
+collect_exit(Port, Acc) ->
+    receive
+        {Port, {data, Chunk}} when is_binary(Chunk) ->
+            collect_exit(Port, <<Acc/binary, Chunk/binary>>);
+        {Port, {exit_status, Code}} ->
+            {Code, Acc}
+    after 60000 ->
+        catch port_close(Port),
+        {1, <<Acc/binary, "(timed out after 60s)">>}
     end.

--- a/test/formatter_test.gleam
+++ b/test/formatter_test.gleam
@@ -1,0 +1,123 @@
+import gleam/list
+import gleam/string
+import gleeunit/should
+import simplifile
+import sqlode/internal/formatter
+
+const test_dir = "test_output/formatter_test"
+
+fn cleanup() {
+  let _delete_result = simplifile.delete(test_dir)
+  Nil
+}
+
+fn setup() {
+  cleanup()
+  let assert Ok(_) = simplifile.create_directory_all(test_dir)
+  Nil
+}
+
+// --- format_files: happy path ---
+
+pub fn format_files_breaks_long_record_lines_test() {
+  setup()
+
+  // Mirror the shape the issue calls out: a wide record on a single
+  // line. `gleam format` should break it across multiple lines once
+  // the formatter step runs.
+  let unformatted_source =
+    "pub type Reading { Reading(id: Int, station_id: String, temp_c: Float, humidity: Float, pressure: Float, observed_at: String, short_id: String) }
+"
+  let path = test_dir <> "/long_record.gleam"
+  let assert Ok(_) = simplifile.write(path, unformatted_source)
+
+  let assert Ok(Nil) = formatter.format_files([path])
+
+  let assert Ok(formatted) = simplifile.read(path)
+  let max_line_width =
+    formatted
+    |> string.split("\n")
+    |> list.map(string.length)
+    |> list.fold(0, fn(acc, n) {
+      case n > acc {
+        True -> n
+        False -> acc
+      }
+    })
+  // The original line is 152 chars; the gleam default is 80. The
+  // formatter must break the record across lines so no single line
+  // stays past the ruler.
+  { max_line_width < 100 }
+  |> should.be_true
+
+  cleanup()
+}
+
+pub fn format_files_empty_list_is_noop_test() {
+  // No files to format must succeed without invoking the binary —
+  // otherwise an empty `--out` directory would error spuriously.
+  let assert Ok(Nil) = formatter.format_files([])
+}
+
+pub fn format_files_propagates_syntax_errors_test() {
+  setup()
+
+  let bad_source = "pub fn !!!not gleam\n"
+  let path = test_dir <> "/bad.gleam"
+  let assert Ok(_) = simplifile.write(path, bad_source)
+
+  case formatter.format_files([path]) {
+    Ok(Nil) -> should.fail()
+    Error(formatter.GleamNotFound) -> should.fail()
+    Error(formatter.FormatFailed(exit_code:, output:)) -> {
+      // Non-zero exit and the captured stderr should mention the file
+      // so users can find the offending generated source.
+      { exit_code != 0 } |> should.be_true
+      { string.contains(output, "bad.gleam") || string.length(output) > 0 }
+      |> should.be_true
+    }
+  }
+
+  cleanup()
+}
+
+// --- error_to_string ---
+
+pub fn error_to_string_gleam_not_found_test() {
+  formatter.error_to_string(formatter.GleamNotFound)
+  |> string.contains("gleam command not found")
+  |> should.be_true
+}
+
+pub fn error_to_string_format_failed_includes_exit_code_test() {
+  formatter.error_to_string(formatter.FormatFailed(exit_code: 7, output: ""))
+  |> string.contains("exit code 7")
+  |> should.be_true
+}
+
+pub fn error_to_string_format_failed_appends_output_when_present_test() {
+  let message =
+    formatter.error_to_string(formatter.FormatFailed(
+      exit_code: 1,
+      output: "syntax error at line 3",
+    ))
+  message
+  |> string.contains("exit code 1")
+  |> should.be_true
+  message
+  |> string.contains("syntax error at line 3")
+  |> should.be_true
+}
+
+pub fn error_to_string_format_failed_omits_blank_output_test() {
+  let message =
+    formatter.error_to_string(formatter.FormatFailed(
+      exit_code: 1,
+      output: "   \n  ",
+    ))
+  // Whitespace-only output should not produce a trailing ": " with
+  // nothing after it.
+  message
+  |> string.ends_with(": ")
+  |> should.be_false
+}


### PR DESCRIPTION
## Summary

`sqlode generate` now pipes each generated file through `gleam format` as the last step of the codegen pipeline. Previously, every record constructor and `decode.field(...)` chain landed on a single line that could exceed 200 characters, masking review diffs and pointing `git blame` at one line per record. This mirrors the format step that `oaspec` already performs.

## Changes

- `src/sqlode/internal/formatter.gleam` (new): `format_files(List(String)) -> Result(Nil, FormatError)` invokes `gleam format <files>` via Erlang FFI; JavaScript target gets a no-op so `gleam build --target javascript` stays green.
- `src/sqlode_ffi.erl`: adds `find_executable/1` and `run_executable/2`. The latter uses `spawn_executable` with `stderr_to_stdout` so the captured combined output can carry a useful error message back when `gleam format` rejects a file. 60s hard timeout on the port wait.
- `src/sqlode/cli.gleam`: `run_generate` calls `format_generated_files` after `generate.run` succeeds. On success the CLI prints `  Formatted generated code`. On failure it prints a warning to stderr and exits 0.
- `test/formatter_test.gleam` (new): covers the long-line-shortening happy path, empty-list no-op, syntax-error propagation, and four `error_to_string` shapes.
- `CHANGELOG.md`: adds an Unreleased entry.

## Design Decisions

- **Files, not directories.** `format_files` accepts the exact paths returned by `writer.write_all` so neighbouring source in the user's project that sqlode did not generate is left untouched. (oaspec passes directories, which can sweep over user-owned files.)
- **Best-effort, exit 0 on format failure.** The generated files are syntactically correct and on disk before the formatter runs. Failing the entire `generate` command on a cosmetic post-step would break workflows where `gleam` is mid-upgrade or temporarily unavailable. The warning still goes to stderr so CI logs surface the regression.
- **JS no-op rather than module-level `@target(erlang)`.** `cli.gleam` itself compiles for both targets (it imports `formatter`), so the public `format_files` needs to exist on JS. The CLI is BEAM-only by design (escript), so the JS lane never reaches this code path in practice.
- **Stdout+stderr capture.** Returning `#(Int, String)` from the FFI lets `error_to_string` surface the formatter's diagnostic verbatim instead of just an opaque exit code — matters most when a future generator change emits invalid Gleam.

Closes #543