### PR TITLE
fix(runtime)!: validate slices input in expand_slice_placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **runtime**: `expand_slice_placeholders_checked` and the
+  `ExpandError` type (`SliceLengthNegative` / `SliceIndexOutOfRange`)
+  expose validation failures as a `Result` instead of panicking. Use
+  this from custom adapters or hand-rolled `RawQuery` consumers that
+  want to surface bookkeeping mistakes without crashing the process;
+  the codegen-driven path keeps using the panicking
+  `expand_slice_placeholders`. (#546)
+
+### Changed
+
+- **Breaking (runtime)**: `expand_slice_placeholders` now panics at
+  the start of the call when `slices` is malformed: a negative slice
+  length, or a slice index outside `[1, total_params]`. The previous
+  behaviour silently produced broken output — a negative length was
+  rounded to its absolute value and emitted that many placeholders,
+  while an out-of-range index left the corresponding
+  `__sqlode_slice_<idx>__` marker in the SQL for the engine to
+  reject. Failing visibly catches codegen / adapter bookkeeping
+  mistakes near their cause. The panic message names the offending
+  index and the bound that was violated. (#546)
+
 ## [0.22.0] - 2026-05-05
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -105,6 +105,14 @@ error_context_lost = "off"
 # see the generated callers, so `unused_exports` would mis-flag them
 # as dead. The module is one of the three SemVer-tracked top-level
 # entry points listed in #520.
+#
+# `expand_slice_placeholders` also rejects malformed `slices` input
+# (negative length, index outside `[1, total_params]`) with a
+# structured panic. The silently-accepted invalid input would emit
+# broken SQL the engine can't parse, which is harder to diagnose than
+# a panic. Callers who need the non-panicking variant use
+# `expand_slice_placeholders_checked`.
 "src/sqlode/runtime.gleam" = [
   "unused_exports",
+  "avoid_panic",
 ]

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -151,6 +151,27 @@ pub fn expand_slice_placeholders(
   total_params: Int,
   style: PlaceholderStyle,
 ) -> String {
+  case validate_slices(slices, total_params) {
+    Ok(_) -> Nil
+    Error(SliceLengthNegative(index, length)) ->
+      panic as {
+        "sqlode.expand_slice_placeholders: slice length must be >= 0 (got index="
+        <> int.to_string(index)
+        <> ", length="
+        <> int.to_string(length)
+        <> ")"
+      }
+    Error(SliceIndexOutOfRange(index, total)) ->
+      panic as {
+        "sqlode.expand_slice_placeholders: slice index must be in 1.."
+        <> int.to_string(total)
+        <> " (got index="
+        <> int.to_string(index)
+        <> ", total_params="
+        <> int.to_string(total)
+        <> ")"
+      }
+  }
   let #(_, mapping) =
     int.range(
       from: 1,
@@ -203,5 +224,59 @@ fn render_placeholder(style: PlaceholderStyle, index: Int) -> String {
     DollarNumbered -> "$" <> int.to_string(index)
     QuestionNumbered -> "?" <> int.to_string(index)
     QuestionPositional -> "?"
+  }
+}
+
+/// Why `expand_slice_placeholders_checked` rejected its input.
+///
+/// - `SliceLengthNegative` covers a `slices` entry whose length is
+///   negative. Lengths must be `>= 0` (zero is permitted; the
+///   placeholder list collapses to `NULL` per the SQL `IN ()` rewrite
+///   convention).
+/// - `SliceIndexOutOfRange` covers a `slices` entry whose 1-based
+///   index falls outside `[1, total_params]`. Indices outside that
+///   window can never match the loop's `orig_idx` and are silently
+///   ignored otherwise.
+pub type ExpandError {
+  SliceLengthNegative(index: Int, length: Int)
+  SliceIndexOutOfRange(index: Int, total_params: Int)
+}
+
+/// Like `expand_slice_placeholders`, but returns the validation
+/// failure as a `Result` instead of panicking. Use this when `slices`
+/// or `total_params` come from a custom adapter / hand-rolled
+/// `RawQuery` and the caller wants to surface bookkeeping mistakes
+/// without crashing the process.
+///
+/// On success the returned string is identical to
+/// `expand_slice_placeholders(sql, slices, total_params, style)`.
+pub fn expand_slice_placeholders_checked(
+  sql: String,
+  slices: List(#(Int, Int)),
+  total_params: Int,
+  style: PlaceholderStyle,
+) -> Result(String, ExpandError) {
+  case validate_slices(slices, total_params) {
+    Error(e) -> Error(e)
+    Ok(_) -> Ok(expand_slice_placeholders(sql, slices, total_params, style))
+  }
+}
+
+fn validate_slices(
+  slices: List(#(Int, Int)),
+  total_params: Int,
+) -> Result(Nil, ExpandError) {
+  case slices {
+    [] -> Ok(Nil)
+    [#(idx, len), ..rest] ->
+      case len < 0 {
+        True -> Error(SliceLengthNegative(index: idx, length: len))
+        False ->
+          case idx < 1 || idx > total_params {
+            True ->
+              Error(SliceIndexOutOfRange(index: idx, total_params: total_params))
+            False -> validate_slices(rest, total_params)
+          }
+      }
   }
 }

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -205,3 +205,90 @@ pub fn expand_slice_placeholders_mysql_with_placeholder_literal_test() {
     "SELECT '? is a placeholder' AS note, id FROM t WHERE id IN (?, ?, ?)",
   )
 }
+
+// ---------------------------------------------------------------------------
+// Validation: malformed slices input must not silently produce broken
+// SQL. The panicking variant fails loudly; the `_checked` variant
+// surfaces the same condition as a typed error.
+// ---------------------------------------------------------------------------
+
+pub fn expand_slice_placeholders_checked_negative_length_returns_error_test() {
+  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
+  let result =
+    runtime.expand_slice_placeholders_checked(
+      sql,
+      [#(1, -3)],
+      1,
+      runtime.QuestionPositional,
+    )
+  result
+  |> should.equal(Error(runtime.SliceLengthNegative(index: 1, length: -3)))
+}
+
+pub fn expand_slice_placeholders_checked_index_out_of_range_returns_error_test() {
+  let sql = "SELECT * FROM t WHERE id = " <> runtime.param_marker(1)
+  let result =
+    runtime.expand_slice_placeholders_checked(
+      sql,
+      [#(99, 2)],
+      1,
+      runtime.QuestionPositional,
+    )
+  result
+  |> should.equal(
+    Error(runtime.SliceIndexOutOfRange(index: 99, total_params: 1)),
+  )
+}
+
+pub fn expand_slice_placeholders_checked_index_zero_returns_error_test() {
+  // 1-based indices: zero is out of range too.
+  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(0) <> ")"
+  let result =
+    runtime.expand_slice_placeholders_checked(
+      sql,
+      [#(0, 1)],
+      1,
+      runtime.QuestionPositional,
+    )
+  result
+  |> should.equal(
+    Error(runtime.SliceIndexOutOfRange(index: 0, total_params: 1)),
+  )
+}
+
+pub fn expand_slice_placeholders_checked_zero_length_collapses_to_null_test() {
+  // Length 0 is a legitimate degenerate case: expands to NULL so that
+  // `WHERE x IN (NULL)` evaluates to NULL (always-false). Validate this
+  // continues to work via the checked path.
+  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
+  let result =
+    runtime.expand_slice_placeholders_checked(
+      sql,
+      [#(1, 0)],
+      1,
+      runtime.QuestionPositional,
+    )
+  result
+  |> should.equal(Ok("SELECT * FROM t WHERE id IN (NULL)"))
+}
+
+pub fn expand_slice_placeholders_checked_valid_slices_match_panicking_variant_test() {
+  // For valid input the checked variant must produce byte-identical
+  // output to the panicking variant.
+  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
+  let panicking =
+    runtime.expand_slice_placeholders(
+      sql,
+      [#(1, 3)],
+      1,
+      runtime.QuestionPositional,
+    )
+  let checked =
+    runtime.expand_slice_placeholders_checked(
+      sql,
+      [#(1, 3)],
+      1,
+      runtime.QuestionPositional,
+    )
+  checked |> should.equal(Ok(panicking))
+}


### PR DESCRIPTION
## Summary

`runtime.expand_slice_placeholders` previously accepted malformed `slices` input silently:

- a negative slice length (`#(idx, -3)`) iterated `int.range(from, to)` in reverse and emitted `len.abs` placeholders, leaving the binder to discover the arity mismatch later
- an out-of-range slice index (`#(99, 2)` with `total_params = 1`) was silently dropped, so any `__sqlode_slice_99__` marker the SQL referenced survived into the prepared statement for the engine to reject

This PR rejects both shapes at the start of the function with a structured panic, and adds `expand_slice_placeholders_checked` (the `Result`-returning sibling) for callers that want to surface the same conditions as a typed error instead of crashing.

## Changes

- `src/sqlode/runtime.gleam`:
  - `expand_slice_placeholders` now panics with a named message when `len < 0` or when `idx < 1 || idx > total_params`. The panic message includes the offending `index` and the relevant bound so the cause is visible without re-running.
  - `ExpandError(SliceLengthNegative | SliceIndexOutOfRange)` and `expand_slice_placeholders_checked` added: same validation, returned as `Result` instead of `panic`. Use this from custom adapters or hand-rolled `RawQuery` consumers.
  - `validate_slices/2` (private) shared between the two entry points.
- `test/runtime_test.gleam` — five regression tests covering the new validation paths plus a check that valid input matches the panicking variant byte-for-byte.
- `gleam.toml` — added `avoid_panic` to the existing `src/sqlode/runtime.gleam` ignore list (next to `unused_exports`) with a doc comment explaining why the panic is intentional.
- `CHANGELOG.md` — `[Unreleased]` documents both the breaking change and the additive `_checked` variant.

## Design Decisions

- **Panic + `_checked` parallel.** Issue #546 listed three options. Going with both panicking and `_checked` covers (a) the common codegen-driven path that relies on the panic for early surfacing, and (b) the custom-adapter / hand-rolled path that wants to handle errors explicitly. Mirrors the `_checked` pattern that `datastream` already uses.
- **Validate first, then existing logic.** The validation runs as a single pass at the top of the function before the renumbering loop. Keeping the existing fold body untouched minimises risk and makes the diff readable.
- **Length 0 is allowed.** A zero-length slice expands to `NULL` per the existing `IN (NULL)` rewrite. Validated by `expand_slice_placeholders_checked_zero_length_collapses_to_null_test` so a future regression flips the test red.
- **`ExpandError` constructors carry the offending values.** Both variants record `index` and the relevant bound (`length` or `total_params`) so downstream error rendering can produce a useful message without going back to the input.

## Limitations

- Duplicate `orig_idx` values across different `slices` entries are still accepted (current `list.find` keeps only the first match). Issue #546 listed this as an optional extra; deferred to a follow-up because no consumer hits it today and the bookkeeping needed to detect it (a seen-set fold) belongs in a separate PR.

Closes #546