### PR TITLE
feat(runtime): add raw_query_for_test helper for custom adapters and property tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **runtime**: `runtime.raw_query_for_test/7` — labelled-argument
+  helper for constructing a `RawQuery(p)` directly without going
+  through the codegen pipeline. Intended for custom-adapter authors
+  (in-memory test database, SQLite WASM, query-log middleware, ...)
+  and for property / regression tests against `prepare` /
+  `expand_slice_placeholders`. The README's new "Writing custom
+  adapters" section walks through the full pattern, and
+  `test/runtime_property_test.gleam` carries three worked examples
+  (single-param `SELECT`, three-style slice expansion, and the empty-
+  slice `IN (NULL)` rewrite). (#547)
 - **runtime**: `expand_slice_placeholders_checked` and the
   `ExpandError` type (`SliceLengthNegative` / `SliceIndexOutOfRange`)
   expose validation failures as a `Result` instead of panicking. Use

--- a/README.md
+++ b/README.md
@@ -923,6 +923,55 @@ sqlode follows sqlc conventions, so most SQL files move over untouched. The diff
 - `vet` and `verify` commands
 - `emit_json_tags` and other sqlc-specific emit options not listed above
 
+## Writing custom adapters
+
+`sqlode generate` produces adapters for the engines we ship native code
+for (PostgreSQL via `pog`, SQLite via `sqlight`, MySQL via raw / shork).
+For other backends — an in-memory test database, a SQLite-WASM build, a
+query-log middleware, etc. — wire the runtime against your own driver.
+
+The contract is small:
+
+1. Build a `runtime.RawQuery(p)` with the SQL string the engine expects,
+   the parameter encoder, and the slice metadata function.
+2. Call `runtime.prepare(query, params)` to get back the final SQL and
+   the flattened `List(Value)`.
+3. Hand `(sql, values)` to your driver.
+
+For tests and adapter wiring, use `runtime.raw_query_for_test/7` instead
+of poking the `RawQuery(...)` constructor directly. The named helper
+makes the intent obvious and is documented as test-only:
+
+```gleam
+import sqlode/runtime
+
+let query =
+  runtime.raw_query_for_test(
+    name: "GetUser",
+    sql: "SELECT * FROM users WHERE id = " <> runtime.param_marker(1),
+    command: runtime.QueryOne,
+    param_count: 1,
+    placeholder_style: runtime.DollarNumbered,
+    encode: fn(id) { [runtime.int(id)] },
+    slice_info: fn(_) { [] },
+  )
+let #(sql, values) = runtime.prepare(query, 42)
+// sql    == "SELECT * FROM users WHERE id = $1"
+// values == [SqlInt(42)]
+```
+
+`test/runtime_property_test.gleam` carries longer worked examples
+(slice expansion across all three placeholder styles, the `IN (NULL)`
+rewrite for empty slices). Each example is a self-contained
+`raw_query_for_test` invocation that exercises a real `prepare` codepath
+without touching the codegen pipeline.
+
+If your `slices` metadata might be malformed (negative length,
+out-of-range index), use `runtime.expand_slice_placeholders_checked`
+instead of `expand_slice_placeholders` — the panicking variant is
+correct for codegen-driven flows but the `_checked` variant is the
+right tool when the input comes from runtime sources.
+
 ## License
 
 [MIT](./LICENSE)

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -63,6 +63,44 @@ pub type RawQuery(p) {
   )
 }
 
+/// Construct a `RawQuery` directly. **Test-only**: production callers
+/// should always go through codegen-emitted `RawQuery` values, which
+/// `sqlode generate` produces from declarative SQL fixtures.
+///
+/// Use this helper when:
+///
+/// - writing a custom adapter (in-memory test database, SQLite WASM
+///   shim, query-log middleware, ...) that needs to exercise
+///   `prepare(query, params)` against a hand-rolled `RawQuery`
+///   without running the codegen pipeline; or
+/// - writing property / regression tests for the runtime surface
+///   (`prepare`, `expand_slice_placeholders`) without regenerating
+///   fixtures every time.
+///
+/// Behaviour is identical to invoking the `RawQuery(...)` constructor
+/// directly; the named helper exists so the intent (\"this is a
+/// hand-rolled RawQuery, not codegen output\") is obvious at the call
+/// site and discoverable via the docs.
+pub fn raw_query_for_test(
+  name name: String,
+  sql sql: String,
+  command command: QueryCommand,
+  param_count param_count: Int,
+  placeholder_style placeholder_style: PlaceholderStyle,
+  encode encode: fn(p) -> List(Value),
+  slice_info slice_info: fn(p) -> List(#(Int, Int)),
+) -> RawQuery(p) {
+  RawQuery(
+    name: name,
+    sql: sql,
+    command: command,
+    param_count: param_count,
+    placeholder_style: placeholder_style,
+    encode: encode,
+    slice_info: slice_info,
+  )
+}
+
 /// Prepare a raw query for execution by encoding parameters and expanding
 /// the engine-agnostic placeholder markers that the generator emits. The
 /// target placeholder dialect is read from `query.placeholder_style`, so

--- a/test/runtime_property_test.gleam
+++ b/test/runtime_property_test.gleam
@@ -1,0 +1,85 @@
+//// Worked examples of `runtime.raw_query_for_test` in use. Custom-adapter
+//// authors and property-test authors can lift the patterns here directly.
+////
+//// The helper is identical to invoking the `RawQuery(...)` constructor;
+//// it exists to make the intent ("hand-rolled RawQuery, not codegen
+//// output") obvious at the call site. Production code should always use
+//// codegen-emitted `RawQuery` values.
+
+import gleam/list
+import gleeunit/should
+import sqlode/runtime
+
+// ---------------------------------------------------------------------------
+// Example 1 — minimal RawQuery for a single-parameter SELECT, run through
+// `prepare` to obtain the final SQL and value list.
+// ---------------------------------------------------------------------------
+
+pub fn raw_query_for_test_minimal_prepare_test() {
+  let query =
+    runtime.raw_query_for_test(
+      name: "GetUser",
+      sql: "SELECT * FROM users WHERE id = " <> runtime.param_marker(1),
+      command: runtime.QueryOne,
+      param_count: 1,
+      placeholder_style: runtime.DollarNumbered,
+      encode: fn(id) { [runtime.int(id)] },
+      slice_info: fn(_) { [] },
+    )
+  let #(sql, values) = runtime.prepare(query, 42)
+  sql |> should.equal("SELECT * FROM users WHERE id = $1")
+  values |> should.equal([runtime.SqlInt(42)])
+}
+
+// ---------------------------------------------------------------------------
+// Example 2 — RawQuery exercising slice expansion across the three
+// placeholder styles. Demonstrates the equivariance the runtime
+// guarantees: same slice metadata, three different on-the-wire shapes.
+// ---------------------------------------------------------------------------
+
+pub fn raw_query_for_test_across_placeholder_styles_test() {
+  let make_query = fn(style) {
+    runtime.raw_query_for_test(
+      name: "GetByIds",
+      sql: "SELECT * FROM users WHERE id IN (" <> runtime.slice_marker(1) <> ")",
+      command: runtime.QueryMany,
+      param_count: 1,
+      placeholder_style: style,
+      encode: fn(ids) { list.map(ids, runtime.int) },
+      slice_info: fn(ids) { [#(1, list.length(ids))] },
+    )
+  }
+
+  let #(sql_pg, _) =
+    runtime.prepare(make_query(runtime.DollarNumbered), [10, 20])
+  sql_pg |> should.equal("SELECT * FROM users WHERE id IN ($1, $2)")
+
+  let #(sql_sqlite, _) =
+    runtime.prepare(make_query(runtime.QuestionNumbered), [10, 20])
+  sql_sqlite |> should.equal("SELECT * FROM users WHERE id IN (?1, ?2)")
+
+  let #(sql_mysql, _) =
+    runtime.prepare(make_query(runtime.QuestionPositional), [10, 20])
+  sql_mysql |> should.equal("SELECT * FROM users WHERE id IN (?, ?)")
+}
+
+// ---------------------------------------------------------------------------
+// Example 3 — RawQuery with a zero-length slice, exercising the
+// `IN (NULL)` rewrite without going through the codegen pipeline.
+// ---------------------------------------------------------------------------
+
+pub fn raw_query_for_test_zero_length_slice_collapses_to_null_test() {
+  let query =
+    runtime.raw_query_for_test(
+      name: "GetByIds",
+      sql: "SELECT * FROM users WHERE id IN (" <> runtime.slice_marker(1) <> ")",
+      command: runtime.QueryMany,
+      param_count: 1,
+      placeholder_style: runtime.DollarNumbered,
+      encode: fn(_) { [] },
+      slice_info: fn(_) { [#(1, 0)] },
+    )
+  let #(sql, values) = runtime.prepare(query, [])
+  sql |> should.equal("SELECT * FROM users WHERE id IN (NULL)")
+  values |> should.equal([])
+}


### PR DESCRIPTION
## Summary

Adds `runtime.raw_query_for_test/7` so custom-adapter authors and property-test authors can build a `RawQuery(p)` directly, without going through the codegen pipeline. Behaviour is identical to invoking the `RawQuery(...)` constructor; the named helper exists to make the intent (\"hand-rolled, not codegen output\") obvious at the call site and discoverable via the docs.

## Changes

- `src/sqlode/runtime.gleam` — `raw_query_for_test/7` with a labelled-argument signature mirroring the `RawQuery` record fields (`name`, `sql`, `command`, `param_count`, `placeholder_style`, `encode`, `slice_info`). Docstring calls out it is **test-only** and lists the two intended use cases (custom adapters, property / regression tests).
- `test/runtime_property_test.gleam` (new) — three worked examples:
  - `raw_query_for_test_minimal_prepare_test` — single-parameter `SELECT` end-to-end through `prepare`.
  - `raw_query_for_test_across_placeholder_styles_test` — same slice metadata across `DollarNumbered` / `QuestionNumbered` / `QuestionPositional`, asserting the engine-specific wire shapes.
  - `raw_query_for_test_zero_length_slice_collapses_to_null_test` — `IN (NULL)` rewrite for empty slices.
- `README.md` — new \"Writing custom adapters\" section before *License*. Walks through the contract, shows the helper, and points readers at `test/runtime_property_test.gleam` for longer examples. Cross-references `expand_slice_placeholders_checked` from #546 for the runtime-source case.
- `CHANGELOG.md` — `[Unreleased]` documents the additive helper.

## Design Decisions

- **Helper, not new type.** `RawQuery` was already exposed via its public constructor; the helper is a named alias. Going further (an opaque `TestQuery` distinct from the production type) would force consumers to convert and break the property that the test helper produces a value the runtime treats identically to codegen output. The current shape preserves that.
- **Labelled arguments.** All seven parameters share the same shape as the `RawQuery` record fields, so labels read identically at the call site. Less mental friction for users moving between hand-rolled and codegen-emitted instances.
- **Worked examples in their own file.** `test/runtime_property_test.gleam` is new (rather than appending to `runtime_test.gleam`) so the README can link to it as a single canonical recipe. It also keeps the existing `runtime_test.gleam` focused on the smaller `RawQuery(...)` constructor cases.
- **README placement.** The new section sits between *Migrating from sqlc* and *License*, matching the README's narrative arc (\"how to use sqlode the normal way\" → \"how to extend sqlode\" → end matter). It is not promoted into the Quickstart because the audience is small.

## Limitations

- The helper does not validate `RawQuery` field invariants (e.g. SQL containing references to `__sqlode_param_<N>__` for `N > param_count`). The runtime catches malformed `slices` via #546's validation; param-marker / SQL-template invariants are still the codegen's responsibility.
- `runtime_property_test.gleam` does not yet use `metamon.forall` for true property-based testing — the worked examples are explicit `prepare` calls. Wiring `metamon` into the test suite would be a follow-up.

Closes #547