### PR TITLE
chore(release): prepare v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-05-07
+
 ### Added
 
 - **runtime**: `runtime.raw_query_for_test/7` — labelled-argument

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.22.0"
+version = "0.23.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.22.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.23.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]


### PR DESCRIPTION
### Added

- **runtime**: `runtime.raw_query_for_test/7` — labelled-argument
  helper for constructing a `RawQuery(p)` directly without going
  through the codegen pipeline. Intended for custom-adapter authors
  (in-memory test database, SQLite WASM, query-log middleware, ...)
  and for property / regression tests against `prepare` /
  `expand_slice_placeholders`. The README's new "Writing custom
  adapters" section walks through the full pattern, and
  `test/runtime_property_test.gleam` carries three worked examples
  (single-param `SELECT`, three-style slice expansion, and the empty-
  slice `IN (NULL)` rewrite). (#547)
- **runtime**: `expand_slice_placeholders_checked` and the
  `ExpandError` type (`SliceLengthNegative` / `SliceIndexOutOfRange`)
  expose validation failures as a `Result` instead of panicking. Use
  this from custom adapters or hand-rolled `RawQuery` consumers that
  want to surface bookkeeping mistakes without crashing the process;
  the codegen-driven path keeps using the panicking
  `expand_slice_placeholders`. (#546)

### Changed

- **Breaking (runtime)**: `expand_slice_placeholders` now panics at
  the start of the call when `slices` is malformed: a negative slice
  length, or a slice index outside `[1, total_params]`. The previous
  behaviour silently produced broken output — a negative length was
  rounded to its absolute value and emitted that many placeholders,
  while an out-of-range index left the corresponding
  `__sqlode_slice_<idx>__` marker in the SQL for the engine to
  reject. Failing visibly catches codegen / adapter bookkeeping
  mistakes near their cause. The panic message names the offending
  index and the bound that was violated. (#546)
