### PR TITLE
fix(runtime): reject non-1-based index in param_marker / slice_marker (#551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **runtime**: `runtime.param_marker/1` and `runtime.slice_marker/1`
+  now panic when `index < 1` with
+  `"sqlode.runtime.<param_marker|slice_marker>: index must be >= 1
+  (1-based) (got <n>)"`. The runtime expand step is keyed by 1-based
+  positions; previously a `0` or negative index would either fail to
+  round-trip through `expand_slice_placeholders` (leaving the literal
+  marker in the SQL → runtime SQL syntax error) or silently match an
+  unrelated marker (silent SQL-shape bug). The codegen path always
+  emits 1-based indices so production users are unaffected; the new
+  guard catches buggy hand-rolled `RawQuery` values and custom adapter
+  authors. Symmetric front-end concern to #546
+  (`expand_slice_placeholders` validation). (#551)
+
+### Added
+- **runtime**: `runtime.param_marker_checked/1` and
+  `runtime.slice_marker_checked/1` return
+  `Result(String, MarkerError)` instead of panicking. Use the checked
+  variants when `index` comes from a custom adapter or hand-rolled
+  `RawQuery` and the caller wants to surface bookkeeping mistakes
+  without crashing the process. Same shape as the existing
+  `expand_slice_placeholders_checked/4`. The new
+  `runtime.MarkerError` type carries the offending index in its
+  `MarkerIndexNonPositive(index)` variant. (#551)
+
 ## [0.23.0] - 2026-05-07
 
 ### Added

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -156,17 +156,85 @@ pub fn nullable(value: option.Option(a), encode: fn(a) -> Value) -> Value {
 }
 
 /// Marker prefix emitted by the generator for a regular `sqlode.arg` /
-/// `sqlode.narg` / `@name` parameter at the given 1-based index.
-/// Rendered into the final placeholder at runtime by `expand_slice_placeholders`.
+/// `sqlode.narg` / `@name` parameter at the given **1-based** index.
+/// Rendered into the final placeholder at runtime by
+/// `expand_slice_placeholders`.
+///
+/// Panics with
+/// `"sqlode.runtime.param_marker: index must be >= 1 (1-based) (got <n>)"`
+/// when `index < 1`. The runtime expand step is keyed by 1-based positions,
+/// so a `0` or negative index would either round-trip to a syntactically
+/// broken SQL string or silently match an unrelated marker — both
+/// constitute SQL-shape bugs. Use `param_marker_checked/1` instead when
+/// the caller wants to surface the precondition as a `Result` (for
+/// example, in a custom adapter that accepts user-supplied indices).
 pub fn param_marker(index: Int) -> String {
-  "__sqlode_param_" <> int.to_string(index) <> "__"
+  case index < 1 {
+    True ->
+      panic as {
+        "sqlode.runtime.param_marker: index must be >= 1 (1-based) (got "
+        <> int.to_string(index)
+        <> ")"
+      }
+    False -> "__sqlode_param_" <> int.to_string(index) <> "__"
+  }
 }
 
 /// Marker prefix emitted by the generator for a `sqlode.slice` parameter at
-/// the given 1-based index. Rendered into the expanded placeholder list at
-/// runtime by `expand_slice_placeholders`.
+/// the given **1-based** index. Rendered into the expanded placeholder list
+/// at runtime by `expand_slice_placeholders`.
+///
+/// Panics with
+/// `"sqlode.runtime.slice_marker: index must be >= 1 (1-based) (got <n>)"`
+/// when `index < 1`. Same reasoning as `param_marker/1`. Use
+/// `slice_marker_checked/1` instead when the caller wants to surface the
+/// precondition as a `Result`.
 pub fn slice_marker(index: Int) -> String {
-  "__sqlode_slice_" <> int.to_string(index) <> "__"
+  case index < 1 {
+    True ->
+      panic as {
+        "sqlode.runtime.slice_marker: index must be >= 1 (1-based) (got "
+        <> int.to_string(index)
+        <> ")"
+      }
+    False -> "__sqlode_slice_" <> int.to_string(index) <> "__"
+  }
+}
+
+/// Why `param_marker_checked` / `slice_marker_checked` rejected its input.
+///
+/// - `MarkerIndexNonPositive` — the supplied `index` is `<= 0`. Marker
+///   indices are 1-based; values below `1` would either fail to round-trip
+///   through `expand_slice_placeholders` (leaving the literal marker in
+///   the SQL → runtime SQL syntax error) or silently match an unrelated
+///   marker (silent SQL-shape bug). Same precondition as the panicking
+///   `param_marker/1` / `slice_marker/1` constructors.
+pub type MarkerError {
+  MarkerIndexNonPositive(index: Int)
+}
+
+/// Like `param_marker/1`, but returns the precondition failure as a
+/// `Result` instead of panicking. Use this when `index` comes from a
+/// custom adapter or hand-rolled `RawQuery` and the caller wants to
+/// surface bookkeeping mistakes without crashing the process. Same
+/// reasoning as `expand_slice_placeholders_checked` (#546).
+///
+/// On success the returned string is identical to `param_marker(index)`.
+pub fn param_marker_checked(index: Int) -> Result(String, MarkerError) {
+  case index < 1 {
+    True -> Error(MarkerIndexNonPositive(index: index))
+    False -> Ok("__sqlode_param_" <> int.to_string(index) <> "__")
+  }
+}
+
+/// Like `slice_marker/1`, but returns the precondition failure as a
+/// `Result` instead of panicking. Same shape and reasoning as
+/// `param_marker_checked/1`.
+pub fn slice_marker_checked(index: Int) -> Result(String, MarkerError) {
+  case index < 1 {
+    True -> Error(MarkerIndexNonPositive(index: index))
+    False -> Ok("__sqlode_slice_" <> int.to_string(index) <> "__")
+  }
 }
 
 /// Render a parameter marker into the final engine-specific placeholder.

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -241,8 +241,12 @@ pub fn expand_slice_placeholders_checked_index_out_of_range_returns_error_test()
 }
 
 pub fn expand_slice_placeholders_checked_index_zero_returns_error_test() {
-  // 1-based indices: zero is out of range too.
-  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(0) <> ")"
+  // 1-based indices: zero is out of range too. The marker constructor
+  // now panics on index < 1 (#551), so we hand-roll the marker literal
+  // here to exercise the validator surface — that is what would happen
+  // if a buggy adapter put `0` in the slices list while still emitting
+  // a valid 1-based marker in the SQL.
+  let sql = "SELECT * FROM t WHERE id IN (__sqlode_slice_0__)"
   let result =
     runtime.expand_slice_placeholders_checked(
       sql,
@@ -291,4 +295,88 @@ pub fn expand_slice_placeholders_checked_valid_slices_match_panicking_variant_te
       runtime.QuestionPositional,
     )
   checked |> should.equal(Ok(panicking))
+}
+
+// ---------------------------------------------------------------------------
+// param_marker / slice_marker reject non-1-based indices (#551).
+// The runtime expand step is keyed by 1-based positions; a `0` or
+// negative index would either round-trip to a syntactically broken SQL
+// string (the literal marker stays in place) or silently match an
+// unrelated marker (silent SQL-shape bug). The checked variants surface
+// the precondition as a `Result`; the panicking variants are exercised
+// indirectly through the codegen path which always emits 1-based
+// indices.
+// ---------------------------------------------------------------------------
+
+pub fn param_marker_accepts_one_test() {
+  // Boundary: index 1 is the smallest valid value.
+  runtime.param_marker(1) |> should.equal("__sqlode_param_1__")
+}
+
+pub fn slice_marker_accepts_one_test() {
+  runtime.slice_marker(1) |> should.equal("__sqlode_slice_1__")
+}
+
+pub fn param_marker_accepts_large_index_test() {
+  runtime.param_marker(99_999) |> should.equal("__sqlode_param_99999__")
+}
+
+pub fn slice_marker_accepts_large_index_test() {
+  runtime.slice_marker(99_999) |> should.equal("__sqlode_slice_99999__")
+}
+
+// --- _checked variants ---
+
+pub fn param_marker_checked_returns_error_for_zero_test() {
+  runtime.param_marker_checked(0)
+  |> should.equal(Error(runtime.MarkerIndexNonPositive(index: 0)))
+}
+
+pub fn param_marker_checked_returns_error_for_negative_test() {
+  runtime.param_marker_checked(-7)
+  |> should.equal(Error(runtime.MarkerIndexNonPositive(index: -7)))
+}
+
+pub fn slice_marker_checked_returns_error_for_zero_test() {
+  runtime.slice_marker_checked(0)
+  |> should.equal(Error(runtime.MarkerIndexNonPositive(index: 0)))
+}
+
+pub fn slice_marker_checked_returns_error_for_negative_test() {
+  runtime.slice_marker_checked(-42)
+  |> should.equal(Error(runtime.MarkerIndexNonPositive(index: -42)))
+}
+
+pub fn param_marker_checked_matches_panicking_variant_for_valid_indices_test() {
+  // For valid input the checked variant must produce byte-identical
+  // output to the panicking variant. Same invariant the equivalent
+  // expand_slice_placeholders_checked test pins.
+  runtime.param_marker_checked(1) |> should.equal(Ok(runtime.param_marker(1)))
+  runtime.param_marker_checked(5) |> should.equal(Ok(runtime.param_marker(5)))
+}
+
+pub fn slice_marker_checked_matches_panicking_variant_for_valid_indices_test() {
+  runtime.slice_marker_checked(1) |> should.equal(Ok(runtime.slice_marker(1)))
+  runtime.slice_marker_checked(9) |> should.equal(Ok(runtime.slice_marker(9)))
+}
+
+// --- Marker round-trips through expand_slice_placeholders for valid indices ---
+
+pub fn param_marker_round_trips_for_index_one_test() {
+  let sql = "SELECT * FROM t WHERE id = " <> runtime.param_marker(1)
+  let expanded =
+    runtime.expand_slice_placeholders(sql, [], 1, runtime.QuestionNumbered)
+  expanded |> should.equal("SELECT * FROM t WHERE id = ?1")
+}
+
+pub fn slice_marker_round_trips_for_index_one_test() {
+  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
+  let expanded =
+    runtime.expand_slice_placeholders(
+      sql,
+      [#(1, 3)],
+      1,
+      runtime.QuestionNumbered,
+    )
+  expanded |> should.equal("SELECT * FROM t WHERE id IN (?1, ?2, ?3)")
 }


### PR DESCRIPTION
## Summary

`runtime.param_marker/1` and `runtime.slice_marker/1` previously accepted any `Int`, including `0` and negative values. The runtime expand step is keyed by 1-based positions, so an out-of-range marker would either fail to round-trip (leaving the literal marker in the SQL → runtime SQL syntax error) or silently match an unrelated marker (silent SQL-shape bug). This change makes the constructors panic on `index < 1` and adds `_checked` variants for callers that prefer `Result`. Closes #551. Symmetric front-end concern to #546 (`expand_slice_placeholders` validation).

## Changes

- `src/sqlode/runtime.gleam`
  - `param_marker/1` panics with `"sqlode.runtime.param_marker: index must be >= 1 (1-based) (got <n>)"` when `index < 1`. Same shape and reasoning as the existing panic in `expand_slice_placeholders`.
  - `slice_marker/1` panics analogously.
  - Doc strings now state "**1-based** index" explicitly and cross-reference the `_checked` variants.
  - New `MarkerError` type with one variant: `MarkerIndexNonPositive(index)`.
  - New `param_marker_checked/1` and `slice_marker_checked/1` returning `Result(String, MarkerError)`. Mirrors `expand_slice_placeholders_checked/4` (#546).
- `test/runtime_test.gleam`
  - New tests for the panic-side accept boundary (`index == 1`, large indices).
  - New tests for `_checked` rejection at `0` and negative values.
  - New tests asserting `_checked` matches the panicking variant for valid input (round-trip invariant).
  - New tests pinning that markers round-trip through `expand_slice_placeholders` for `index == 1`.
  - Existing test `expand_slice_placeholders_checked_index_zero_returns_error_test` reworked to use a hand-rolled marker literal (`__sqlode_slice_0__`) instead of calling `slice_marker(0)` directly — that call now panics. The test still exercises the validator surface.
- `CHANGELOG.md`: documents the fix and the new public API under `[Unreleased]`.

## Design Decisions

- **Panic primary, `_checked` secondary**: matches the existing precedent set by `expand_slice_placeholders` / `expand_slice_placeholders_checked` (#546). The codegen path always emits 1-based indices, so production users hit the cheap total path; the `_checked` variant is for hand-rolled `RawQuery` values and custom adapter authors who want to surface bookkeeping mistakes without crashing.
- **One `MarkerError` variant for now**: only one precondition exists (`index < 1`). Keeping the type as a single-variant sum (`MarkerIndexNonPositive(index)`) leaves room to grow without another breaking change if more constructor preconditions are added later.
- **Test the rejection via `_checked`, not panic-catching**: gleeunit doesn't expose a built-in `should.panic`. The `_checked` variants share the exact same predicate, so testing those is sufficient — the panicking and checked surfaces agree by construction.

## Limitations

- The metamon property test suggested in the issue is not added: `metamon` is not a dev-dep of sqlode. The deterministic boundary tests (0, -1, -7, -42, 1, 99_999) cover the same ground.
- `param_marker(0)` previously returned `"__sqlode_param_0__"` and `param_marker(-1)` returned `"__sqlode_param_-1__"`. Callers who relied on that behaviour (none expected from the codegen path) will now panic. The `_checked` variants provide a non-panicking migration path.

Closes #551