### PR TITLE
chore(release): prepare v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-05-08
+
 ### Fixed
 - **runtime**: `runtime.param_marker/1` and `runtime.slice_marker/1`
   now panic when `index < 1` with

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.23.0"
+version = "0.24.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.23.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.24.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]


### PR DESCRIPTION
### Fixed
- **runtime**: `runtime.param_marker/1` and `runtime.slice_marker/1`
  now panic when `index < 1` with
  `"sqlode.runtime.<param_marker|slice_marker>: index must be >= 1
  (1-based) (got <n>)"`. The runtime expand step is keyed by 1-based
  positions; previously a `0` or negative index would either fail to
  round-trip through `expand_slice_placeholders` (leaving the literal
  marker in the SQL → runtime SQL syntax error) or silently match an
  unrelated marker (silent SQL-shape bug). The codegen path always
  emits 1-based indices so production users are unaffected; the new
  guard catches buggy hand-rolled `RawQuery` values and custom adapter
  authors. Symmetric front-end concern to #546
  (`expand_slice_placeholders` validation). (#551)

### Added
- **runtime**: `runtime.param_marker_checked/1` and
  `runtime.slice_marker_checked/1` return
  `Result(String, MarkerError)` instead of panicking. Use the checked
  variants when `index` comes from a custom adapter or hand-rolled
  `RawQuery` and the caller wants to surface bookkeeping mistakes
  without crashing the process. Same shape as the existing
  `expand_slice_placeholders_checked/4`. The new
  `runtime.MarkerError` type carries the offending index in its
  `MarkerIndexNonPositive(index)` variant. (#551)
