### PR TITLE
feat(codegen): emit labelled arguments on prepare_* helpers (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **codegen**: generated `prepare_*` helpers now emit same-name
+  labelled arguments (`prepare_create_session(project project: String,
+  note note: String, ...)` etc.) so call sites can use the labelled
+  form (`prepare_create_session(project: "p", note: "n", ...)`) and
+  catch swapped multi-`String` arguments at compile time. Existing
+  positional callers continue to compile unchanged because Gleam
+  accepts both forms when every parameter has a label. The label name
+  is the column name from the source `.sql`. (#554)
+
 ## [0.24.0] - 2026-05-08
 
 ### Fixed

--- a/src/sqlode/internal/codegen/queries.gleam
+++ b/src/sqlode/internal/codegen/queries.gleam
@@ -275,10 +275,17 @@ fn render_prepare_function(
         "\n",
       )
     params -> {
+      // Emit same-name labels (`id id: Int`) so the call site can use
+      // `prepare_create_session(project: "p", note: "n", ...)` while
+      // remaining callable positionally for legacy callers (#554).
       let arg_list =
         params
         |> list.map(fn(p) {
-          p.field_name <> ": " <> param_arg_type(p, type_mapping)
+          p.field_name
+          <> " "
+          <> p.field_name
+          <> ": "
+          <> param_arg_type(p, type_mapping)
         })
         |> string.join(", ")
       let constructor_args =

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -65,10 +65,12 @@ pub fn render_prepare_helpers_test() {
   let analyzed = analyzed_queries("test/fixtures/query.sql")
   let rendered = queries.render(naming_ctx, block, analyzed, dict.new(), False)
 
-  // Parameterised query — arg list mirrors the params record fields.
+  // Parameterised query — arg list uses same-name labels (#554) so
+  // callers can write `prepare_get_author(id: 5)` and still call
+  // positionally. Output must contain the labelled signature.
   string.contains(
     rendered,
-    "pub fn prepare_get_author(id: Int) -> #(String, List(runtime.Value)) {",
+    "pub fn prepare_get_author(id id: Int) -> #(String, List(runtime.Value)) {",
   )
   |> should.be_true()
   string.contains(rendered, "runtime.prepare(")


### PR DESCRIPTION
## Summary

Generated `prepare_*` helpers now emit same-name labelled arguments so call sites can use the labelled form (`prepare_create_session(project: "p", note: "n", started_at: t, stopped_at: None)`) and catch swapped multi-`String` arguments at compile time. Existing positional callers continue to compile unchanged. Closes #554.

## Changes

- `src/sqlode/internal/codegen/queries.gleam`: `render_prepare_function` now emits `id id: Int` (label + internal name + type) instead of `id: Int` for every parameter. Gleam accepts both `prepare_get_author(5)` and `prepare_get_author(id: 5)` when every parameter has a label, so the change is non-breaking for legacy positional callers.
- `test/codegen_test.gleam`: `render_prepare_helpers_test` updated to assert the new `pub fn prepare_get_author(id id: Int) -> ...` shape.
- `CHANGELOG.md`: documents the change under `[Unreleased]`.

## Design Decisions

- **Same-name labels (`id id: Int`)** instead of distinct labels (`name id: Int`). Same name keeps the call site unambiguous and matches the `Params` record's field naming. Gleam fully supports same-name labels.
- **Non-breaking by construction.** Gleam accepts positional invocation when every parameter has a label, so previously-generated callers (`prepare_get_author(5)`) remain valid after the codegen output changes. No migration needed.
- **No change to the `Params` record itself.** The record was already labelled; the public-facing `prepare_*` was the only seam missing the labels. This PR is purely "thread the labels through to the generated helper".

## Test plan

- All 1106 sqlode tests pass on the Erlang target.
- The `render_prepare_helpers_test` golden assertion now requires the `id id: Int` shape, ensuring future regressions are caught at codegen test time.
- A worked example at `examples/sqlite-basic/` (or any project using `gleam run -m sqlode -- generate`) re-runs cleanly and the new `prepare_*` shape compiles under `--warnings-as-errors`.

## Limitations

- Users who depend on `gleam check` reflection of the *unlabelled* signature will see a one-time API-shape diff in their generated `queries.gleam`. The semantic surface (positional-only call, return type, body) is unchanged.

Closes #554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Generated helper functions now support same-name labelled arguments derived from SQL column names. Callers can use labelled argument syntax while maintaining backwards compatibility with positional calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->