### PR TITLE
fix(cli): add DEFAULT CURRENT_TIMESTAMP to init stub created_at across all engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`sqlode init` stub schema now adds `DEFAULT CURRENT_TIMESTAMP` to
+  `created_at`** (across SQLite / MySQL / PostgreSQL templates) so the
+  documented `init → generate → gleam run` happy path actually inserts
+  one row. Previously the stub schema declared
+  `created_at TEXT NOT NULL` (or DATETIME / TIMESTAMP) without a default
+  while the stub `CreateAuthor` query only set `name` and `bio` — the
+  first call to the generated `create_author` failed with a
+  `ConstraintNotnull` violation. Adding `DEFAULT CURRENT_TIMESTAMP`
+  matches the column's intent (filled by the database, not the
+  application) and is uniform across the three engines. (#558)
+- **`sqlode init` log indent**: the first "Created …" line now uses the
+  same two-space indent as the schema/query lines below it, so the three
+  paths align in the user's terminal. (#558)
+
 ## [0.25.0] - 2026-05-08
 
 ### Changed

--- a/spec/cli_spec.sh
+++ b/spec/cli_spec.sh
@@ -38,6 +38,30 @@ Describe 'sqlode CLI'
       The contents of file "$TEST_OUTPUT_DIR/sqlode.yaml" should include 'runtime: "native"'
       The contents of file "$TEST_OUTPUT_DIR/db/schema.sql" should include 'BIGINT AUTO_INCREMENT PRIMARY KEY'
     End
+
+    It 'sqlite stub schema gives created_at a DEFAULT CURRENT_TIMESTAMP (issue #558)'
+      # The stub CreateAuthor query only inserts name + bio; the created_at
+      # column must therefore have a DEFAULT so the generated insert does not
+      # hit a NOT NULL constraint violation on the first run.
+      When run init_cmd --output="$TEST_OUTPUT_DIR/sqlode.yaml" --engine=sqlite
+      The status should be success
+      The output should include 'Created'
+      The contents of file "$TEST_OUTPUT_DIR/db/schema.sql" should include 'created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP'
+    End
+
+    It 'mysql stub schema gives created_at a DEFAULT CURRENT_TIMESTAMP (issue #558)'
+      When run init_cmd --output="$TEST_OUTPUT_DIR/sqlode.yaml" --engine=mysql
+      The status should be success
+      The output should include 'Created'
+      The contents of file "$TEST_OUTPUT_DIR/db/schema.sql" should include 'created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP'
+    End
+
+    It 'postgresql stub schema gives created_at a DEFAULT CURRENT_TIMESTAMP (issue #558)'
+      When run init_cmd --output="$TEST_OUTPUT_DIR/sqlode.yaml" --engine=postgresql
+      The status should be success
+      The output should include 'Created'
+      The contents of file "$TEST_OUTPUT_DIR/db/schema.sql" should include 'created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'
+    End
   End
 
   Describe 'generate command'

--- a/src/sqlode/cli.gleam
+++ b/src/sqlode/cli.gleam
@@ -325,7 +325,10 @@ fn run_init(path: String, engine: String, runtime: String) -> Nil {
             Ok(Nil) ->
               case simplifile.write(path, template) {
                 Ok(_) -> {
-                  io.println("Created " <> path)
+                  // Issue #558: indent matches `create_stub_files`'s
+                  // "  Created ..." lines so the three creation lines
+                  // align in the user's terminal.
+                  io.println("  Created " <> path)
                   create_stub_files(parent_dir, engine)
                 }
                 Error(err) -> {
@@ -421,13 +424,20 @@ fn create_stub_files(base_dir: String, engine: String) -> Nil {
 }
 
 fn starter_schema(engine: String) -> String {
+  // Issue #558: every column NOT NULL in the schema must either accept
+  // a value from the stub query (`name`, `bio`) or supply a DEFAULT —
+  // otherwise `sqlode init` produces stubs whose first `gleam run`
+  // hits a NOT NULL constraint violation. `created_at` is filled in by
+  // the database, not by the application, so a `DEFAULT
+  // CURRENT_TIMESTAMP` makes the happy path work without forcing
+  // every caller of `CreateAuthor` to compute a timestamp.
   case engine {
     "sqlite" ->
       "CREATE TABLE authors (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT NOT NULL,
   bio TEXT,
-  created_at TEXT NOT NULL
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 "
     "mysql" ->
@@ -435,7 +445,7 @@ fn starter_schema(engine: String) -> String {
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   name TEXT NOT NULL,
   bio TEXT,
-  created_at DATETIME NOT NULL
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 "
     _ ->
@@ -443,7 +453,7 @@ fn starter_schema(engine: String) -> String {
   id BIGSERIAL PRIMARY KEY,
   name TEXT NOT NULL,
   bio TEXT,
-  created_at TIMESTAMP NOT NULL
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 "
   }


### PR DESCRIPTION
## Summary

Issue #558: `sqlode init --engine=sqlite` (and `mysql` / `postgresql`) produced a stub `db/schema.sql` with `created_at NOT NULL` but no default, while the stub `db/query.sql`'s `CreateAuthor` only set `name + bio`. Following the documented `init → generate → gleam run` flow with the stubs unmodified made the first `create_author` call fail with a `ConstraintNotnull` violation.

This PR adds `DEFAULT CURRENT_TIMESTAMP` to the `created_at` column in every engine's stub schema. `created_at` is a "filled by the database, not the application" column, which is exactly what the default expresses; the stub now compiles, generates, and runs through one happy-path insert without forcing every caller to compute a timestamp themselves.

The `sqlode init` log indent is also fixed in the same change: the first "Created …" line now uses the same two-space indent as the schema/query lines below it.

## Changes

- `src/sqlode/cli.gleam`
  - `starter_schema/1`: every engine's stub schema now declares `created_at … NOT NULL DEFAULT CURRENT_TIMESTAMP` (TEXT for SQLite, DATETIME for MySQL, TIMESTAMP for PostgreSQL).
  - The first "Created …" line in the init flow now indents to match the schema/query "Created …" lines.
- `spec/cli_spec.sh` — three new shellspec tests pin down the schema string per engine, plus the existing tests still pass.
- `CHANGELOG.md` — Unreleased entry under `### Fixed`.

## Design Decisions

- **`DEFAULT CURRENT_TIMESTAMP` over dropping `created_at` or extending the query.** The README's Quickstart shows a 3-column schema (no `created_at`) so dropping the column would also work — but `created_at` is a useful column for an authors table, and `DEFAULT CURRENT_TIMESTAMP` is the idiomatic SQL story for "the database fills this in." It also means the stub accurately demonstrates a non-trivial schema feature, which is exactly what `init` is for.
- **Same fix across SQLite / MySQL / PostgreSQL.** All three accept the same `DEFAULT CURRENT_TIMESTAMP` syntax, so the fix is uniform. This keeps the three stub schemas comparable.
- **Stub query unchanged.** The `CreateAuthor` query keeps its current shape (`INSERT INTO authors (name, bio) VALUES (...)`) — adding `created_at` to the query would have been louder and would have forced every caller to compute a timestamp, which defeats the point of the default.
- **Indent fix bundled.** The cosmetic indent fix is a one-character change in the same code path; bundling avoids a noise-only follow-up PR.

## Limitations

- Existing projects that ran `sqlode init` before this fix and committed the broken stubs are not auto-fixed. The change only affects new `init` runs.

Closes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `sqlode init` to generate database schemas with `DEFAULT CURRENT_TIMESTAMP` for the `created_at` column across SQLite, MySQL, and PostgreSQL
* Standardized output formatting in `sqlode init` with consistent indentation for all status messages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqlode/pull/559)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->