### PR TITLE
fix(analyzer): surface TableNotFound before parameter inference for missing tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- **Schema/query mismatch now surfaces as `TableNotFound` instead of
+  the misleading `ParameterTypeNotInferred` "use CAST(?) AS INTEGER"
+  hint.** When a query references a table not in `schema.sql`,
+  `oaspec generate` previously failed type inference for the
+  WHERE-clause placeholder ("could not infer type for parameter ?N")
+  with a CAST suggestion that does not actually fix the underlying
+  problem. The analyzer now checks every table the query references
+  against the catalog before parameter inference runs and reports the
+  first missing table name. Covers SELECT (FROM/JOIN), INSERT INTO,
+  UPDATE, and DELETE; UnstructuredStatement (parser-internal fallback
+  for shapes the IR does not yet model) keeps the original behavior
+  to avoid false positives. (#557)
 - **`sqlode init` stub schema now adds `DEFAULT CURRENT_TIMESTAMP` to
   `created_at`** (across SQLite / MySQL / PostgreSQL templates) so the
   documented `init → generate → gleam run` happy path actually inserts

--- a/src/sqlode/internal/query_analyzer.gleam
+++ b/src/sqlode/internal/query_analyzer.gleam
@@ -171,6 +171,20 @@ fn build_params(
   catalog: model.Catalog,
   occurrences: List(placeholder.PlaceholderOccurrence),
 ) -> Result(List(model.QueryParam), context.AnalysisError) {
+  // Issue #557: pre-flight check — every table the query references
+  // must exist in the schema catalog. Without this, a query that
+  // names a table not in `schema.sql` falls through every inferencer
+  // (column lookup returns `None`, the param is silently skipped) and
+  // surfaces only at the final pass as `ParameterTypeNotInferred` with
+  // an unhelpful CAST hint. Catching the missing table up front lets
+  // us point the user at the real cause: the table is not in the
+  // schema.
+  use _ <- result.try(check_referenced_tables_exist(
+    catalog,
+    query.name,
+    tokens,
+    statement,
+  ))
   use equality <- result.try(param_inferencer.infer_equality_params(
     ctx,
     engine,
@@ -278,6 +292,60 @@ fn build_params(
       is_list:,
     ))
   })
+}
+
+/// Issue #557: pre-flight check that every table the query references
+/// is in the schema catalog. Run before parameter inference so the
+/// user sees a `TableNotFound` diagnostic naming the missing table,
+/// not a downstream `ParameterTypeNotInferred` that points at a CAST
+/// fix that can't actually fix the underlying problem.
+///
+/// The check uses the structural IR (`SqlStatement`):
+///
+/// - `SelectStatement` walks the FROM/JOIN tokens via
+///   `extract_table_names` (the same shape `infer_equality_params`
+///   uses to set up the column-lookup scope).
+/// - `InsertStatement` / `UpdateStatement` / `DeleteStatement` use
+///   the IR-provided `table_name` only; the token extractor would
+///   pick up `display_name` from a MySQL `ON DUPLICATE KEY UPDATE
+///   display_name = …` clause as if `UPDATE` had introduced a table,
+///   surfacing as a false `TableNotFound` against perfectly
+///   well-formed upserts.
+/// - `UnstructuredStatement` skips the check entirely. The structurer
+///   gave up on this token stream, so any table-name extraction
+///   would be best-effort and risk false positives. The downstream
+///   `ParameterTypeNotInferred` path still applies for those cases;
+///   covering them too is a follow-up that needs a richer IR.
+///
+/// CTE-defined virtual tables are already merged into the catalog by
+/// `merge_virtual_tables` before `build_params` runs, so they are
+/// part of `catalog.tables` and pass this check.
+fn check_referenced_tables_exist(
+  catalog: model.Catalog,
+  query_name: String,
+  tokens: List(lexer.Token),
+  statement: query_ir.SqlStatement,
+) -> Result(Nil, context.AnalysisError) {
+  let referenced = case statement {
+    query_ir.InsertStatement(table_name:, ..) -> [table_name]
+    query_ir.UpdateStatement(table_name:, ..) -> [table_name]
+    query_ir.DeleteStatement(table_name:, ..) -> [table_name]
+    query_ir.SelectStatement(..) -> {
+      let main_tokens = token_utils.strip_leading_with(tokens)
+      token_utils.extract_table_names(main_tokens)
+    }
+    query_ir.UnstructuredStatement(..) -> []
+  }
+  case list.find(referenced, fn(name) { !table_in_catalog(catalog, name) }) {
+    Ok(missing) ->
+      Error(context.TableNotFound(query_name: query_name, table_name: missing))
+    Error(_) -> Ok(Nil)
+  }
+}
+
+fn table_in_catalog(catalog: model.Catalog, name: String) -> Bool {
+  let normalized = naming.normalize_identifier(name)
+  list.any(catalog.tables, fn(t) { t.name == normalized })
 }
 
 fn macro_index(m: model.Macro) -> Int {

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -695,6 +695,69 @@ pub fn table_not_found_error_test() {
   result |> should.be_error()
 }
 
+// Issue #557: a query that references a missing table while binding a
+// placeholder against one of its columns must surface as `TableNotFound`,
+// not as the downstream `ParameterTypeNotInferred` (whose CAST hint
+// cannot fix the underlying problem).
+pub fn table_not_found_takes_priority_over_parameter_type_test() {
+  // The fixture catalog declares only `authors`; `bookmarks` is
+  // intentionally absent so the analyzer must reach the new
+  // pre-flight check rather than column-inference.
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: GetMissing :one\nSELECT id, name FROM bookmarks WHERE id = $1;"
+  let assert Ok(queries) =
+    query_parser.parse_file("missing.sql", model.PostgreSQL, naming_ctx, sql)
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  case result {
+    Error(context.TableNotFound(
+      query_name: "GetMissing",
+      table_name: "bookmarks",
+    )) -> Nil
+    Error(other) -> {
+      let msg = query_analyzer.analysis_error_to_string(other, model.PostgreSQL)
+      panic as { "expected TableNotFound, got: " <> msg }
+    }
+    Ok(_) ->
+      panic as "expected TableNotFound, query analyzed cleanly against missing table"
+  }
+}
+
+// Issue #557: same priority for INSERT.
+pub fn table_not_found_insert_test() {
+  let naming_ctx = naming.new()
+  let catalog = test_catalog()
+  let sql =
+    "-- name: CreateMissing :exec\nINSERT INTO bookmarks (name) VALUES ($1);"
+  let assert Ok(queries) =
+    query_parser.parse_file("missing.sql", model.PostgreSQL, naming_ctx, sql)
+  let result =
+    query_analyzer.analyze_queries(
+      model.PostgreSQL,
+      catalog,
+      naming_ctx,
+      queries,
+    )
+  case result {
+    Error(context.TableNotFound(
+      query_name: "CreateMissing",
+      table_name: "bookmarks",
+    )) -> Nil
+    Error(other) -> {
+      let msg = query_analyzer.analysis_error_to_string(other, model.PostgreSQL)
+      panic as { "expected TableNotFound, got: " <> msg }
+    }
+    Ok(_) -> panic as "expected TableNotFound on INSERT INTO unknown table"
+  }
+}
+
 pub fn analysis_error_to_string_table_not_found_test() {
   let error = context.TableNotFound(query_name: "GetUsers", table_name: "users")
   let msg = query_analyzer.analysis_error_to_string(error, model.PostgreSQL)

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -556,6 +556,14 @@ pub fn table_not_found_error_test() {
   query_analyzer_test.table_not_found_error_test()
 }
 
+pub fn table_not_found_takes_priority_over_parameter_type_test() {
+  query_analyzer_test.table_not_found_takes_priority_over_parameter_type_test()
+}
+
+pub fn table_not_found_insert_test() {
+  query_analyzer_test.table_not_found_insert_test()
+}
+
 pub fn analysis_error_to_string_table_not_found_test() {
   query_analyzer_test.analysis_error_to_string_table_not_found_test()
 }


### PR DESCRIPTION
## Summary

Issue #557: when a query references a table that is not in `schema.sql`, `oaspec generate` reported `Query "X": could not infer type for parameter ?N. Use CAST(? AS INTEGER) to specify the type` instead of saying the table is missing. The CAST hint cannot fix the underlying problem — the type cannot be inferred *because* the column lookup falls off the cliff at the missing table — so the user is steered toward a workaround that doesn't apply.

This PR adds a pre-flight check at the top of `build_params` that walks the structural IR (`SqlStatement`) and verifies every referenced table exists in the catalog. If a referenced table is missing, the analyzer returns `TableNotFound(query_name, table_name)` directly, before parameter inference runs.

## Changes

- `src/sqlode/internal/query_analyzer.gleam`
  - New private `check_referenced_tables_exist/4` helper, called as the first step in `build_params`.
  - The check uses the structural IR rather than free-form token scanning to avoid false positives:
    - `InsertStatement` / `UpdateStatement` / `DeleteStatement` use the IR-provided `table_name` only. (Token scanning would otherwise pick up `display_name` from MySQL `ON DUPLICATE KEY UPDATE display_name = …` clauses as if `UPDATE` had introduced a table.)
    - `SelectStatement` walks the FROM/JOIN tokens via `extract_table_names`, the same shape `infer_equality_params` already uses to set up the column-lookup scope.
    - `UnstructuredStatement` skips the check; the structurer gave up on the token stream, so any extraction we'd do is best-effort and risks false positives. The downstream `ParameterTypeNotInferred` path stays in place for those cases.
  - CTE-defined virtual tables remain handled correctly because `merge_virtual_tables` runs before `build_params` and the catalog already contains them by the time the check fires.
- `test/query_analyzer_test.gleam`:
  - `table_not_found_takes_priority_over_parameter_type_test` — pins down that a SELECT referencing a missing table now surfaces as `TableNotFound`, not as the misleading `ParameterTypeNotInferred`.
  - `table_not_found_insert_test` — same for INSERT INTO.
- `test/sqlode_test.gleam` — wires the two new cases into the top-level test runner.
- `CHANGELOG.md` — Unreleased entry under `### Fixed`.

## Design Decisions

- **Pre-flight check, not a deeper rewrite of the inferencer.** The existing inferencer chain (column → param) silently swallows a missing table by returning `Ok(None)` for the column lookup, eventually leading to `ParameterTypeNotInferred`. Restructuring those paths to thread `TableNotFound` through is invasive; gating them with a one-pass check up front gets the right error to the user with the smallest possible surface change.
- **Structural-IR-driven, not token-driven.** The first attempt used `extract_table_names` for all statement kinds, but it triggered on MySQL upserts because `extract_table_names` treats the `UPDATE` keyword inside `ON DUPLICATE KEY UPDATE` as a fresh table introducer. Using the IR's own `table_name` for INSERT/UPDATE/DELETE eliminates that class of false positive while keeping SELECT coverage broad.
- **Skip `UnstructuredStatement`.** Falling back to token extraction here would risk false positives in queries the structurer doesn't yet model (CTE-prefixed INSERTs, RETURNING, etc.). Letting those continue to surface as `ParameterTypeNotInferred` is strictly worse than the new behavior, but no worse than today; we can extend coverage as the IR grows.

## Limitations

- The check covers FROM/JOIN/INSERT/UPDATE/DELETE on cleanly-structured queries. Queries the structurer can't classify (UnstructuredStatement) still go through the old path. Follow-up issues for those shapes would be natural.
- Column-level mismatches (table exists but the named column does not) are also potentially affected but already surfaced as `ColumnNotFound` in `column_inferencer`. This PR does not change that path.

Closes #557