### PR TITLE
chore(release): prepare v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-05-09
+
 ### Fixed
 - **Schema/query mismatch now surfaces as `TableNotFound` instead of
   the misleading `ParameterTypeNotInferred` "use CAST(?) AS INTEGER"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.25.0"
+version = "0.26.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }

--- a/integration_test/warmup/manifest.toml
+++ b/integration_test/warmup/manifest.toml
@@ -27,7 +27,7 @@ packages = [
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "sqlight", version = "1.1.0", build_tools = ["gleam"], requirements = ["esqlite", "gleam_stdlib"], otp_app = "sqlight", source = "hex", outer_checksum = "ECA1A4B45C35EB9EFCEEB7FAAC7BF5D8B2C777A7C1FC8A9C12CB67D54CED42E7" },
-  { name = "sqlode", version = "0.25.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
+  { name = "sqlode", version = "0.26.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_regexp", "gleam_stdlib", "glint", "simplifile", "yay"], source = "local", path = "../.." },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
   { name = "yay", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "yamerl"], otp_app = "yay", source = "hex", outer_checksum = "B208F9A14FA2B5E306728812814B01E760BC7F3BCAC4BD6889E9CA8088ACFD48" },
 ]


### PR DESCRIPTION
### Fixed
- **Schema/query mismatch now surfaces as `TableNotFound` instead of
  the misleading `ParameterTypeNotInferred` "use CAST(?) AS INTEGER"
  hint.** When a query references a table not in `schema.sql`,
  `oaspec generate` previously failed type inference for the
  WHERE-clause placeholder ("could not infer type for parameter ?N")
  with a CAST suggestion that does not actually fix the underlying
  problem. The analyzer now checks every table the query references
  against the catalog before parameter inference runs and reports the
  first missing table name. Covers SELECT (FROM/JOIN), INSERT INTO,
  UPDATE, and DELETE; UnstructuredStatement (parser-internal fallback
  for shapes the IR does not yet model) keeps the original behavior
  to avoid false positives. (#557)
- **`sqlode init` stub schema now adds `DEFAULT CURRENT_TIMESTAMP` to
  `created_at`** (across SQLite / MySQL / PostgreSQL templates) so the
  documented `init → generate → gleam run` happy path actually inserts
  one row. Previously the stub schema declared
  `created_at TEXT NOT NULL` (or DATETIME / TIMESTAMP) without a default
  while the stub `CreateAuthor` query only set `name` and `bio` — the
  first call to the generated `create_author` failed with a
  `ConstraintNotnull` violation. Adding `DEFAULT CURRENT_TIMESTAMP`
  matches the column's intent (filled by the database, not the
  application) and is uniform across the three engines. (#558)
- **`sqlode init` log indent**: the first "Created …" line now uses the
  same two-space indent as the schema/query lines below it, so the three
  paths align in the user's terminal. (#558)
