### PR TITLE
fix(runtime): reject negative total_params in expand_slice_placeholders_checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `runtime.expand_slice_placeholders_checked` no longer panics for
+  `total_params < 0`. Pre-fix the `_checked` variant validated `slices`
+  but forwarded a negative `total_params` to
+  `expand_slice_placeholders`, where the `int.range` loop reached
+  `param_marker(0)` and crashed the process (the post-#551 hardening
+  rejects index 0 on the marker constructor). The validator now
+  rejects negative `total_params` upstream with a new
+  `TotalParamsNegative` variant on `ExpandError`, restoring the
+  `_checked` naming contract that no user input ever panics. The
+  non-checked `expand_slice_placeholders` still panics on the same
+  input but with a clearer message that names the offending value
+  and points callers at the `_checked` variant. (#565)
+
 ## [0.27.0] - 2026-05-10
 
 ### Added

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -277,6 +277,12 @@ pub fn expand_slice_placeholders(
         <> int.to_string(total)
         <> ")"
       }
+    Error(TotalParamsNegative(total)) ->
+      panic as {
+        "sqlode.expand_slice_placeholders: total_params must be >= 0 (got "
+        <> int.to_string(total)
+        <> "). Use expand_slice_placeholders_checked for a Result-returning variant. (#565)"
+      }
   }
   let #(_, mapping) =
     int.range(
@@ -343,9 +349,14 @@ fn render_placeholder(style: PlaceholderStyle, index: Int) -> String {
 ///   index falls outside `[1, total_params]`. Indices outside that
 ///   window can never match the loop's `orig_idx` and are silently
 ///   ignored otherwise.
+/// - `TotalParamsNegative` covers a `total_params` that is below 0.
+///   Parameter counts cannot be negative; without this check the
+///   `int.range` loop in `expand_slice_placeholders` would call
+///   `param_marker(0)`, which panics post-#551. (#565)
 pub type ExpandError {
   SliceLengthNegative(index: Int, length: Int)
   SliceIndexOutOfRange(index: Int, total_params: Int)
+  TotalParamsNegative(total_params: Int)
 }
 
 /// Like `expand_slice_placeholders`, but returns the validation
@@ -362,13 +373,27 @@ pub fn expand_slice_placeholders_checked(
   total_params: Int,
   style: PlaceholderStyle,
 ) -> Result(String, ExpandError) {
-  case validate_slices(slices, total_params) {
-    Error(e) -> Error(e)
-    Ok(_) -> Ok(expand_slice_placeholders(sql, slices, total_params, style))
+  case total_params < 0 {
+    True -> Error(TotalParamsNegative(total_params: total_params))
+    False ->
+      case validate_slices(slices, total_params) {
+        Error(e) -> Error(e)
+        Ok(_) -> Ok(expand_slice_placeholders(sql, slices, total_params, style))
+      }
   }
 }
 
 fn validate_slices(
+  slices: List(#(Int, Int)),
+  total_params: Int,
+) -> Result(Nil, ExpandError) {
+  case total_params < 0 {
+    True -> Error(TotalParamsNegative(total_params: total_params))
+    False -> validate_slice_entries(slices, total_params)
+  }
+}
+
+fn validate_slice_entries(
   slices: List(#(Int, Int)),
   total_params: Int,
 ) -> Result(Nil, ExpandError) {
@@ -381,7 +406,7 @@ fn validate_slices(
           case idx < 1 || idx > total_params {
             True ->
               Error(SliceIndexOutOfRange(index: idx, total_params: total_params))
-            False -> validate_slices(rest, total_params)
+            False -> validate_slice_entries(rest, total_params)
           }
       }
   }

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -260,6 +260,24 @@ pub fn expand_slice_placeholders_checked_index_zero_returns_error_test() {
   )
 }
 
+pub fn expand_slice_placeholders_checked_negative_total_params_returns_error_test() {
+  // Issue #565: total_params < 0 must surface as Error rather than
+  // panicking through the int.range loop inside
+  // expand_slice_placeholders (which calls param_marker(0), banned
+  // post-#551). The `_checked` variant's promise is "no panic on
+  // user input"; this pins the boundary at total_params = -2 from
+  // the reproduction.
+  let result =
+    runtime.expand_slice_placeholders_checked(
+      "",
+      [],
+      -2,
+      runtime.QuestionNumbered,
+    )
+  result
+  |> should.equal(Error(runtime.TotalParamsNegative(total_params: -2)))
+}
+
 pub fn expand_slice_placeholders_checked_zero_length_collapses_to_null_test() {
   // Length 0 is a legitimate degenerate case: expands to NULL so that
   // `WHERE x IN (NULL)` evaluates to NULL (always-false). Validate this


### PR DESCRIPTION
## Summary

`runtime.expand_slice_placeholders_checked` promised a `Result` return type but panicked when `total_params < 0`: the `int.range(from: 1, to: total_params + 1)` loop yielded `0` as `orig_idx`, and `param_marker(0)` panics post-#551.

## Changes

- New `TotalParamsNegative` variant on `ExpandError`.
- `validate_slices` now checks `total_params >= 0` upstream of the per-entry checks; `expand_slice_placeholders_checked` surfaces the new variant as `Error(TotalParamsNegative(...))`.
- The non-checked `expand_slice_placeholders` still panics on `total_params < 0`, but with a message that names the offending value and points callers at the checked variant.
- New test `expand_slice_placeholders_checked_negative_total_params_returns_error_test` pins the boundary from the issue.

Closes #565