### PR TITLE
docs(runtime): clarify PlaceholderStyle engine support for sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- `sqlode/runtime.PlaceholderStyle`: docstring expanded with an engine-mapping table that pairs each variant with the databases that accept its syntax (PostgreSQL / MySQL / SQLite). The previous docstring framed `QuestionPositional` as MySQL-only, so SQLite users landing on the variant list saw no clearly-labelled sqlite option even though bare `?` is the canonical SQLite placeholder. Per-variant doc-comments also call out which engines accept (or reject) each syntax. (#572)
+
 ## [0.28.0] - 2026-05-11
 
 ### Fixed

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -34,12 +34,24 @@ pub type QueryInfo {
 
 /// Placeholder style used by the target database driver.
 ///
-/// - `DollarNumbered` — PostgreSQL style: `$1`, `$2`, ...
-/// - `QuestionNumbered` — SQLite style: `?1`, `?2`, ...
-/// - `QuestionPositional` — MySQL style: bare `?` (matched by position)
+/// SQLite accepts both `?1`-style and bare-`?`-style placeholders, so
+/// the engine column below marks both rows ✓ for sqlite. Pick the
+/// variant whose syntax matches the query strings your codegen — or
+/// hand-rolled SQL — actually emits.
+///
+/// | Variant              | Syntax        | PostgreSQL | MySQL | SQLite |
+/// | -------------------- | ------------- | ---------- | ----- | ------ |
+/// | `DollarNumbered`     | `$1`, `$2`, … | ✓          | —     | —      |
+/// | `QuestionNumbered`   | `?1`, `?2`, … | —          | —     | ✓      |
+/// | `QuestionPositional` | bare `?`      | —          | ✓     | ✓      |
 pub type PlaceholderStyle {
+  /// PostgreSQL: `$1`, `$2`, … Indices are 1-based and explicit.
   DollarNumbered
+  /// SQLite numbered form: `?1`, `?2`, … Indices are 1-based and
+  /// explicit. PostgreSQL and MySQL do not accept this syntax.
   QuestionNumbered
+  /// Bare `?` matched by position. Used by both MySQL and SQLite.
+  /// PostgreSQL does not accept this syntax.
   QuestionPositional
 }
 


### PR DESCRIPTION
## Summary

Rewrites the `runtime.PlaceholderStyle` docstring as an engine-mapping table. The previous bulleted list framed `QuestionPositional` as "MySQL style", so a SQLite user landing on the variant list saw no clearly-labelled sqlite option even though bare `?` is the canonical SQLite placeholder syntax.

## Changes

- `src/sqlode/runtime.gleam`: replace the `///`-bulleted variant list above `pub type PlaceholderStyle` with a three-column engine table (PostgreSQL / MySQL / SQLite). The table marks `QuestionNumbered` ✓ for SQLite only, `QuestionPositional` ✓ for both MySQL and SQLite, and `DollarNumbered` ✓ for PostgreSQL only. Each variant gets a one-line per-variant docstring that names the engine(s) accepting its syntax — useful when the variant shows up in an editor's hover instead of the type-level docs.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Documentation` describing the change.

## Design Decisions

A table beats per-variant prose for this kind of orthogonal information — three variants × three engines is exactly what tables are for, and a future fourth engine adds a column rather than a paragraph rewrite. Variants keep their original names; this PR is purely documentation, so existing call sites are untouched.

The table calls out SQLite acceptance of both `QuestionNumbered` and `QuestionPositional` explicitly so neither row reads as "the SQLite option you missed". Per-variant doc-comments make the engine pairing visible at hover time (where the type-level table doesn't reach).

## Test plan

- [x] `gleam build --warnings-as-errors`: clean
- [x] `gleam format --check src test`: clean

Closes #572
