### PR TITLE
feat(runtime): rename raw_query_for_test to raw_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `sqlode/runtime.raw_query/7`: the same hand-rolled `RawQuery` constructor previously named `raw_query_for_test/7`, without the suffix that made library-mode callers think the helper was test-only. Behaviour is identical; the rename is purely a discoverability fix for callers using `sqlode/runtime` as a library (no escript, no `sqlode generate` codegen). Production callers who run codegen continue to use the `RawQuery` values `sqlode generate` produces from declarative SQL fixtures. (#569)
+
+### Deprecated
+
+- `sqlode/runtime.raw_query_for_test/7`: now a `@deprecated` thin alias of `raw_query/7`. The `_for_test` suffix discouraged the only sanctioned non-constructor path from library-mode use, which was the friction reported in the issue. Callers see the deprecation warning at their own call site and migrate at their own pace. (#569)
+
 ### Documentation
 
 - `sqlode/runtime.PlaceholderStyle`: docstring expanded with an engine-mapping table that pairs each variant with the databases that accept its syntax (PostgreSQL / MySQL / SQLite). The previous docstring framed `QuestionPositional` as MySQL-only, so SQLite users landing on the variant list saw no clearly-labelled sqlite option even though bare `?` is the canonical SQLite placeholder. Per-variant doc-comments also call out which engines accept (or reject) each syntax. (#572)

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -75,12 +75,17 @@ pub type RawQuery(p) {
   )
 }
 
-/// Construct a `RawQuery` directly. **Test-only**: production callers
-/// should always go through codegen-emitted `RawQuery` values, which
-/// `sqlode generate` produces from declarative SQL fixtures.
+/// Construct a `RawQuery` directly. Behaviour is identical to
+/// invoking the `RawQuery(...)` constructor; the named helper exists
+/// so the intent ("this is a hand-rolled `RawQuery`, not codegen
+/// output") is obvious at the call site and discoverable via the
+/// docs.
 ///
 /// Use this helper when:
 ///
+/// - using `sqlode/runtime` as a library, bypassing `sqlode generate`
+///   codegen for hand-rolled queries that live next to your handler
+///   code;
 /// - writing a custom adapter (in-memory test database, SQLite WASM
 ///   shim, query-log middleware, ...) that needs to exercise
 ///   `prepare(query, params)` against a hand-rolled `RawQuery`
@@ -89,11 +94,11 @@ pub type RawQuery(p) {
 ///   (`prepare`, `expand_slice_placeholders`) without regenerating
 ///   fixtures every time.
 ///
-/// Behaviour is identical to invoking the `RawQuery(...)` constructor
-/// directly; the named helper exists so the intent (\"this is a
-/// hand-rolled RawQuery, not codegen output\") is obvious at the call
-/// site and discoverable via the docs.
-pub fn raw_query_for_test(
+/// Production callers who run codegen should keep using the
+/// `RawQuery` values `sqlode generate` produces from declarative SQL
+/// fixtures — they pin the SQL string and parameter shape next to the
+/// schema, which this helper does not.
+pub fn raw_query(
   name name: String,
   sql sql: String,
   command command: QueryCommand,
@@ -103,6 +108,32 @@ pub fn raw_query_for_test(
   slice_info slice_info: fn(p) -> List(#(Int, Int)),
 ) -> RawQuery(p) {
   RawQuery(
+    name: name,
+    sql: sql,
+    command: command,
+    param_count: param_count,
+    placeholder_style: placeholder_style,
+    encode: encode,
+    slice_info: slice_info,
+  )
+}
+
+/// Deprecated alias for `raw_query/7`. The `_for_test` suffix
+/// discouraged library-mode callers from using the only sanctioned
+/// non-constructor path even though library use is exactly what the
+/// helper was built for. `raw_query/7` carries the same behaviour
+/// without the suffix.
+@deprecated("Use `runtime.raw_query` instead. The `_for_test` suffix discouraged library-mode callers even though library use is exactly what the helper was built for.")
+pub fn raw_query_for_test(
+  name name: String,
+  sql sql: String,
+  command command: QueryCommand,
+  param_count param_count: Int,
+  placeholder_style placeholder_style: PlaceholderStyle,
+  encode encode: fn(p) -> List(Value),
+  slice_info slice_info: fn(p) -> List(#(Int, Int)),
+) -> RawQuery(p) {
+  raw_query(
     name: name,
     sql: sql,
     command: command,

--- a/test/runtime_property_test.gleam
+++ b/test/runtime_property_test.gleam
@@ -1,4 +1,4 @@
-//// Worked examples of `runtime.raw_query_for_test` in use. Custom-adapter
+//// Worked examples of `runtime.raw_query` in use. Custom-adapter
 //// authors and property-test authors can lift the patterns here directly.
 ////
 //// The helper is identical to invoking the `RawQuery(...)` constructor;
@@ -15,9 +15,9 @@ import sqlode/runtime
 // `prepare` to obtain the final SQL and value list.
 // ---------------------------------------------------------------------------
 
-pub fn raw_query_for_test_minimal_prepare_test() {
+pub fn raw_query_minimal_prepare_test() {
   let query =
-    runtime.raw_query_for_test(
+    runtime.raw_query(
       name: "GetUser",
       sql: "SELECT * FROM users WHERE id = " <> runtime.param_marker(1),
       command: runtime.QueryOne,
@@ -37,9 +37,9 @@ pub fn raw_query_for_test_minimal_prepare_test() {
 // guarantees: same slice metadata, three different on-the-wire shapes.
 // ---------------------------------------------------------------------------
 
-pub fn raw_query_for_test_across_placeholder_styles_test() {
+pub fn raw_query_across_placeholder_styles_test() {
   let make_query = fn(style) {
-    runtime.raw_query_for_test(
+    runtime.raw_query(
       name: "GetByIds",
       sql: "SELECT * FROM users WHERE id IN (" <> runtime.slice_marker(1) <> ")",
       command: runtime.QueryMany,
@@ -68,9 +68,9 @@ pub fn raw_query_for_test_across_placeholder_styles_test() {
 // `IN (NULL)` rewrite without going through the codegen pipeline.
 // ---------------------------------------------------------------------------
 
-pub fn raw_query_for_test_zero_length_slice_collapses_to_null_test() {
+pub fn raw_query_zero_length_slice_collapses_to_null_test() {
   let query =
-    runtime.raw_query_for_test(
+    runtime.raw_query(
       name: "GetByIds",
       sql: "SELECT * FROM users WHERE id IN (" <> runtime.slice_marker(1) <> ")",
       command: runtime.QueryMany,


### PR DESCRIPTION
## Summary

Renames `runtime.raw_query_for_test/7` to `runtime.raw_query/7`. The `_for_test` suffix discouraged the only sanctioned non-constructor path from library-mode use, which was the friction reported in #569. The new name carries the same behaviour and the existing function becomes a `@deprecated` thin alias.

## Changes

- `src/sqlode/runtime.gleam`: introduce `pub fn raw_query/7` carrying the existing body. The doc-comment expands the use-case list to lead with "using `sqlode/runtime` as a library" before the existing custom-adapter and property-test cases. Production codegen callers are still named — they keep using the `RawQuery` values `sqlode generate` emits, because those pin the SQL string and parameter shape next to the schema, which the hand-rolled helper does not.
- Same file: `pub fn raw_query_for_test/7` becomes a one-line delegation to `raw_query/7`, annotated with `@deprecated` and a message naming the replacement and the reason. Callers who already wrote `raw_query_for_test` continue to compile; the compiler nudges them to migrate at their own call site.
- `test/runtime_property_test.gleam`: migrated the three test cases (`raw_query_*_test`) and the module doc-comment to the new name. This keeps `gleam build --warnings-as-errors` clean for the library itself; downstream callers see the warning at their own call site, which is the whole point.
- `CHANGELOG.md`: `[Unreleased]` entries under `### Added` (the new name) and `### Deprecated` (the alias).

## Design Decisions

`raw_query_for_test` is kept rather than removed so existing callers do not get a hard break. The deprecation warning fires at the call site (the natural place to migrate), and the alias is a single-line delegation so a future implementation change cannot make the two names drift apart.

The library's internal usages were migrated in the same commit so the library itself stays warning-clean under `--warnings-as-errors`. Leaving the call sites untouched would either weaken the CI flag or push a mechanical migration into a follow-up PR — the migration is `runtime.raw_query_for_test` → `runtime.raw_query`, which is uniform and reviewable inline.

The `for_test` connotation captured a real but narrow concern when the helper was first introduced (writing fixtures by hand). The follow-up issue argues the same shape is needed for library use; both can be served by one name plus a doc-comment that enumerates the use cases.

## Test plan

- [x] `gleam build --warnings-as-errors`: clean
- [x] `gleam test` (Erlang target): 1130 passed
- [x] `gleam format --check src test`: clean

Closes #569


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `raw_query` function for library-mode query construction; `raw_query_for_test` is now deprecated with unchanged behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqlode/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->