### PR TITLE
feat(runtime)!: drop Sql prefix from Value variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `sqlode/runtime.Value` variants drop the `Sql` prefix: `SqlNull` → `Null`, `SqlString` → `String`, `SqlInt` → `Int`, `SqlFloat` → `Float`, `SqlBool` → `Bool`, `SqlBytes` → `Bytes`, `SqlArray` → `Array`. The prefix repeated information already encoded in the package and module name (`sqlode/runtime`); every pattern match against the type carried it on every arm. Fully-qualified call sites read `runtime.Int` / `runtime.String` now, which lines up with the wording of the underlying driver primitives (`sqlight.text`, `sqlight.int`, ...). Callers who hold codegen-emitted adapter code that pattern-matches `runtime.Sql*` will need to regenerate it after upgrading — the bundled `pog` / `sqlight` / `shork` value adapter templates have already been migrated to the new names so the next `sqlode generate` produces matching output. (#570)
+
 ### Added
 
 - `sqlode/runtime.raw_query/7`: the same hand-rolled `RawQuery` constructor previously named `raw_query_for_test/7`, without the suffix that made library-mode callers think the helper was test-only. Behaviour is identical; the rename is purely a discoverability fix for callers using `sqlode/runtime` as a library (no escript, no `sqlode generate` codegen). Production callers who run codegen continue to use the `RawQuery` values `sqlode generate` produces from declarative SQL fixtures. (#569)

--- a/src/sqlode/internal/codegen/adapter.gleam
+++ b/src/sqlode/internal/codegen/adapter.gleam
@@ -140,13 +140,13 @@ fn sqlight_adapter_config() -> AdapterConfig {
 fn pog_value_to_driver_helper() -> String {
   "fn value_to_pog(value: runtime.Value) -> pog.Value {
   case value {
-    runtime.SqlNull -> pog.null()
-    runtime.SqlString(v) -> pog.text(v)
-    runtime.SqlInt(v) -> pog.int(v)
-    runtime.SqlFloat(v) -> pog.float(v)
-    runtime.SqlBool(v) -> pog.bool(v)
-    runtime.SqlBytes(v) -> pog.bytea(v)
-    runtime.SqlArray(vs) -> pog.array(value_to_pog, vs)
+    runtime.Null -> pog.null()
+    runtime.String(v) -> pog.text(v)
+    runtime.Int(v) -> pog.int(v)
+    runtime.Float(v) -> pog.float(v)
+    runtime.Bool(v) -> pog.bool(v)
+    runtime.Bytes(v) -> pog.bytea(v)
+    runtime.Array(vs) -> pog.array(value_to_pog, vs)
   }
 }"
 }
@@ -154,13 +154,13 @@ fn pog_value_to_driver_helper() -> String {
 fn sqlight_value_to_driver_helper() -> String {
   "fn value_to_sqlight(value: runtime.Value) -> sqlight.Value {
   case value {
-    runtime.SqlNull -> sqlight.null()
-    runtime.SqlString(v) -> sqlight.text(v)
-    runtime.SqlInt(v) -> sqlight.int(v)
-    runtime.SqlFloat(v) -> sqlight.float(v)
-    runtime.SqlBool(v) -> sqlight.bool(v)
-    runtime.SqlBytes(v) -> sqlight.blob(v)
-    runtime.SqlArray(_) -> panic as \"SqlArray is not supported in the SQLite native adapter. Use raw runtime for array parameters, or ensure sqlode.slice() values are expanded before reaching value_to_sqlight.\"
+    runtime.Null -> sqlight.null()
+    runtime.String(v) -> sqlight.text(v)
+    runtime.Int(v) -> sqlight.int(v)
+    runtime.Float(v) -> sqlight.float(v)
+    runtime.Bool(v) -> sqlight.bool(v)
+    runtime.Bytes(v) -> sqlight.blob(v)
+    runtime.Array(_) -> panic as \"Array is not supported in the SQLite native adapter. Use raw runtime for array parameters, or ensure sqlode.slice() values are expanded before reaching value_to_sqlight.\"
   }
 }"
 }
@@ -197,10 +197,10 @@ fn shork_adapter_config() -> AdapterConfig {
 /// (the same underlying identity FFI that `shork.text` and friends
 /// dispatch through) and pass `BitArray` parameters through unchanged.
 /// The Erlang `mysql` library underneath stores them as `BLOB` /
-/// `BINARY` byte-for-byte. `SqlArray` still resolves to NULL because
+/// `BINARY` byte-for-byte. `Array` still resolves to NULL because
 /// MySQL has no first-class array type.
 ///
-/// `SqlBool` is encoded as `shork.int(1 | 0)` rather than
+/// `Bool` is encoded as `shork.int(1 | 0)` rather than
 /// `shork.bool(...)`. The Erlang `mysql` library expects integers 1/0
 /// on the wire for `TINYINT(1)` / `BOOLEAN` columns; passing the
 /// Gleam `True` / `False` atoms verbatim (which is what `shork.bool`
@@ -212,14 +212,14 @@ fn bit_array_to_shork(value: BitArray) -> shork.Value
 
 fn value_to_shork(value: runtime.Value) -> shork.Value {
   case value {
-    runtime.SqlNull -> shork.null()
-    runtime.SqlString(v) -> shork.text(v)
-    runtime.SqlInt(v) -> shork.int(v)
-    runtime.SqlFloat(v) -> shork.float(v)
-    runtime.SqlBool(True) -> shork.int(1)
-    runtime.SqlBool(False) -> shork.int(0)
-    runtime.SqlBytes(v) -> bit_array_to_shork(v)
-    runtime.SqlArray(_) -> panic as \"SqlArray is not supported in the MySQL native adapter. Use raw runtime for array parameters, or ensure sqlode.slice() values are expanded before reaching value_to_shork.\"
+    runtime.Null -> shork.null()
+    runtime.String(v) -> shork.text(v)
+    runtime.Int(v) -> shork.int(v)
+    runtime.Float(v) -> shork.float(v)
+    runtime.Bool(True) -> shork.int(1)
+    runtime.Bool(False) -> shork.int(0)
+    runtime.Bytes(v) -> bit_array_to_shork(v)
+    runtime.Array(_) -> panic as \"Array is not supported in the MySQL native adapter. Use raw runtime for array parameters, or ensure sqlode.slice() values are expanded before reaching value_to_shork.\"
   }
 }"
 }

--- a/src/sqlode/internal/query_validation.gleam
+++ b/src/sqlode/internal/query_validation.gleam
@@ -124,9 +124,9 @@ fn is_slice_macro(item: model.Macro) -> Bool {
 ///   PostgreSQL `TEXT[]` column where the inferred parameter
 ///   carries the array element type)
 /// - `sqlode.slice(...)` macro usage, which lowers to an
-///   `SqlArray` runtime value at execution time. The native
+///   `Array` runtime value at execution time. The native
 ///   SQLite (`sqlight`) and MySQL (`shork`) adapters panic on
-///   `SqlArray`, so the only safe path for those engines is the
+///   `Array`, so the only safe path for those engines is the
 ///   raw runtime, which the user must opt into explicitly.
 pub fn validate_array_engine_support(
   engine: model.Engine,

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -17,13 +17,13 @@ pub type QueryCommand {
 }
 
 pub type Value {
-  SqlNull
-  SqlString(String)
-  SqlInt(Int)
-  SqlFloat(Float)
-  SqlBool(Bool)
-  SqlBytes(BitArray)
-  SqlArray(List(Value))
+  Null
+  String(String)
+  Int(Int)
+  Float(Float)
+  Bool(Bool)
+  Bytes(BitArray)
+  Array(List(Value))
 }
 
 /// Lightweight metadata for a query, used by the generated `all()` function
@@ -164,37 +164,37 @@ pub fn prepare(query: RawQuery(p), params: p) -> #(String, List(Value)) {
 }
 
 pub fn null() -> Value {
-  SqlNull
+  Null
 }
 
 pub fn string(value: String) -> Value {
-  SqlString(value)
+  String(value)
 }
 
 pub fn int(value: Int) -> Value {
-  SqlInt(value)
+  Int(value)
 }
 
 pub fn float(value: Float) -> Value {
-  SqlFloat(value)
+  Float(value)
 }
 
 pub fn bool(value: Bool) -> Value {
-  SqlBool(value)
+  Bool(value)
 }
 
 pub fn bytes(value: BitArray) -> Value {
-  SqlBytes(value)
+  Bytes(value)
 }
 
 pub fn array(values: List(Value)) -> Value {
-  SqlArray(values)
+  Array(values)
 }
 
 pub fn nullable(value: option.Option(a), encode: fn(a) -> Value) -> Value {
   case value {
     option.Some(v) -> encode(v)
-    option.None -> SqlNull
+    option.None -> Null
   }
 }
 

--- a/test/codegen_test.gleam
+++ b/test/codegen_test.gleam
@@ -559,8 +559,8 @@ pub fn render_sqlight_adapter_slice_test() {
     "fn value_to_sqlight(value: runtime.Value) -> sqlight.Value",
   )
   |> should.be_true()
-  // SqlArray should panic instead of silently converting to null (#502)
-  string.contains(rendered, "SqlArray is not supported in the SQLite native")
+  // Array should panic instead of silently converting to null (#502)
+  string.contains(rendered, "Array is not supported in the SQLite native")
   |> should.be_true()
 }
 
@@ -1288,7 +1288,7 @@ pub fn render_pog_adapter_with_array_columns_test() {
   // With `runtime.prepare`, parameter encoding of array columns lives
   // in the `params.*_values` function (which emits `runtime.array`).
   // The adapter just folds `runtime.Value`s through `value_to_pog`,
-  // whose SqlArray case recurses with `pog.array(value_to_pog, ...)`.
+  // whose Array case recurses with `pog.array(value_to_pog, ...)`.
   // So the adapter should contain the recursive helper, but not
   // `pog.array(pog.text)` / `pog.array(pog.int)` calls produced
   // per-param by the old codegen path.
@@ -1502,8 +1502,8 @@ pub fn render_mysql_native_adapter_uses_shork_test() {
   // The stub message must not be present anywhere.
   string.contains(rendered, "MySQL adapter generation is not yet available")
   |> should.be_false()
-  // SqlArray should panic instead of silently converting to null (#502)
-  string.contains(rendered, "SqlArray is not supported in the MySQL native")
+  // Array should panic instead of silently converting to null (#502)
+  string.contains(rendered, "Array is not supported in the MySQL native")
   |> should.be_true()
 }
 
@@ -1534,7 +1534,7 @@ pub fn render_mysql_native_adapter_decodes_affected_rows_for_execrows_test() {
 }
 
 pub fn render_mysql_native_adapter_passes_bytes_through_shork_ffi_test() {
-  // SqlBytes encoding goes through `shork_ffi.coerce` directly so
+  // Bytes encoding goes through `shork_ffi.coerce` directly so
   // BLOB / BINARY parameters reach mysql:query/4 byte-for-byte —
   // closes the previously-documented bytes round-trip gap from #418.
   let naming_ctx = naming.new()
@@ -1550,7 +1550,7 @@ pub fn render_mysql_native_adapter_passes_bytes_through_shork_ffi_test() {
     "fn bit_array_to_shork(value: BitArray) -> shork.Value",
   )
   |> should.be_true()
-  string.contains(rendered, "runtime.SqlBytes(v) -> bit_array_to_shork(v)")
+  string.contains(rendered, "runtime.Bytes(v) -> bit_array_to_shork(v)")
   |> should.be_true()
 }
 

--- a/test/query_analyzer_test.gleam
+++ b/test/query_analyzer_test.gleam
@@ -3047,7 +3047,7 @@ SELECT t.id FROM (SELECT id FROM authors) AS t;"
 //
 //   1. Infer parameter types from BLOB columns just like it does
 //      for INTEGER / TEXT — the storage class maps cleanly to
-//      sqlode's `BytesType` / runtime `SqlBytes`.
+//      sqlode's `BytesType` / runtime `Bytes`.
 //   2. Treat `CAST(? AS <type>)` in a VALUES slot as a placeholder
 //      that consumes a parameter position. Previously the
 //      `infer_insert_params` walker only matched a bare

--- a/test/runtime_property_test.gleam
+++ b/test/runtime_property_test.gleam
@@ -28,7 +28,7 @@ pub fn raw_query_minimal_prepare_test() {
     )
   let #(sql, values) = runtime.prepare(query, 42)
   sql |> should.equal("SELECT * FROM users WHERE id = $1")
-  values |> should.equal([runtime.SqlInt(42)])
+  values |> should.equal([runtime.Int(42)])
 }
 
 // ---------------------------------------------------------------------------

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -8,49 +8,47 @@ pub fn main() {
 }
 
 pub fn null_value_test() {
-  runtime.null() |> should.equal(runtime.SqlNull)
+  runtime.null() |> should.equal(runtime.Null)
 }
 
 pub fn string_value_test() {
-  runtime.string("hello") |> should.equal(runtime.SqlString("hello"))
+  runtime.string("hello") |> should.equal(runtime.String("hello"))
 }
 
 pub fn int_value_test() {
-  runtime.int(42) |> should.equal(runtime.SqlInt(42))
+  runtime.int(42) |> should.equal(runtime.Int(42))
 }
 
 pub fn float_value_test() {
-  runtime.float(3.14) |> should.equal(runtime.SqlFloat(3.14))
+  runtime.float(3.14) |> should.equal(runtime.Float(3.14))
 }
 
 pub fn bool_value_test() {
-  runtime.bool(True) |> should.equal(runtime.SqlBool(True))
-  runtime.bool(False) |> should.equal(runtime.SqlBool(False))
+  runtime.bool(True) |> should.equal(runtime.Bool(True))
+  runtime.bool(False) |> should.equal(runtime.Bool(False))
 }
 
 pub fn bytes_value_test() {
-  runtime.bytes(<<1, 2, 3>>) |> should.equal(runtime.SqlBytes(<<1, 2, 3>>))
+  runtime.bytes(<<1, 2, 3>>) |> should.equal(runtime.Bytes(<<1, 2, 3>>))
 }
 
 pub fn array_value_test() {
   runtime.array([runtime.string("a"), runtime.string("b")])
-  |> should.equal(
-    runtime.SqlArray([runtime.SqlString("a"), runtime.SqlString("b")]),
-  )
+  |> should.equal(runtime.Array([runtime.String("a"), runtime.String("b")]))
 }
 
 pub fn array_empty_test() {
   runtime.array([])
-  |> should.equal(runtime.SqlArray([]))
+  |> should.equal(runtime.Array([]))
 }
 
 pub fn array_nested_types_test() {
   runtime.array([runtime.int(1), runtime.int(2), runtime.int(3)])
   |> should.equal(
-    runtime.SqlArray([
-      runtime.SqlInt(1),
-      runtime.SqlInt(2),
-      runtime.SqlInt(3),
+    runtime.Array([
+      runtime.Int(1),
+      runtime.Int(2),
+      runtime.Int(3),
     ]),
   )
 }
@@ -68,7 +66,7 @@ pub fn prepare_no_slices_test() {
     )
   let #(sql, values) = runtime.prepare(query, Nil)
   sql |> should.equal("SELECT * FROM users WHERE id = $1")
-  values |> should.equal([runtime.SqlInt(42)])
+  values |> should.equal([runtime.Int(42)])
 }
 
 pub fn prepare_with_slices_test() {
@@ -85,7 +83,7 @@ pub fn prepare_with_slices_test() {
   let #(sql, values) = runtime.prepare(query, [10, 20, 30])
   sql |> should.equal("SELECT * FROM users WHERE id IN ($1, $2, $3)")
   values
-  |> should.equal([runtime.SqlInt(10), runtime.SqlInt(20), runtime.SqlInt(30)])
+  |> should.equal([runtime.Int(10), runtime.Int(20), runtime.Int(30)])
 }
 
 pub fn prepare_mixed_params_test() {
@@ -106,9 +104,9 @@ pub fn prepare_mixed_params_test() {
   |> should.equal("SELECT * FROM users WHERE name = $1 AND id IN ($2, $3)")
   values
   |> should.equal([
-    runtime.SqlString("Alice"),
-    runtime.SqlInt(1),
-    runtime.SqlInt(2),
+    runtime.String("Alice"),
+    runtime.Int(1),
+    runtime.Int(2),
   ])
 }
 

--- a/test/sqlode_metamon_test.gleam
+++ b/test/sqlode_metamon_test.gleam
@@ -16,31 +16,31 @@ import sqlode/runtime
 // ---------- runtime.Value encoders ----------
 
 pub fn null_returns_sql_null_test() -> Nil {
-  assert runtime.null() == runtime.SqlNull
+  assert runtime.null() == runtime.Null
 }
 
 pub fn string_round_trips_through_sql_string_test() -> Nil {
   metamon.forall(
     generator.string_alphanumeric(range.constant(0, 16)),
-    fn(value) { runtime.string(value) == runtime.SqlString(value) },
+    fn(value) { runtime.string(value) == runtime.String(value) },
   )
 }
 
 pub fn int_round_trips_through_sql_int_test() -> Nil {
   metamon.forall(generator.int(range.constant(-1000, 1000)), fn(value) {
-    runtime.int(value) == runtime.SqlInt(value)
+    runtime.int(value) == runtime.Int(value)
   })
 }
 
 pub fn bool_round_trips_through_sql_bool_test() -> Nil {
   metamon.forall(generator.bool(), fn(value) {
-    runtime.bool(value) == runtime.SqlBool(value)
+    runtime.bool(value) == runtime.Bool(value)
   })
 }
 
 pub fn bytes_round_trips_through_sql_bytes_test() -> Nil {
   metamon.forall(generator.bit_array(range.constant(0, 32)), fn(value) {
-    runtime.bytes(value) == runtime.SqlBytes(value)
+    runtime.bytes(value) == runtime.Bytes(value)
   })
 }
 
@@ -53,7 +53,7 @@ pub fn array_preserves_length_test() -> Nil {
     fn(values) {
       let encoded = list.map(values, runtime.int)
       case runtime.array(encoded) {
-        runtime.SqlArray(items) -> list.length(items) == list.length(values)
+        runtime.Array(items) -> list.length(items) == list.length(values)
         _ -> False
       }
     },

--- a/test/verify_test.gleam
+++ b/test/verify_test.gleam
@@ -368,7 +368,7 @@ pub fn verify_execresult_under_raw_runtime_is_allowed_test() {
 // ============================================================
 
 pub fn verify_rejects_slice_macro_on_sqlite_test() {
-  // sqlode.slice() lowers to a runtime SqlArray; the native SQLite
+  // sqlode.slice() lowers to a runtime Array; the native SQLite
   // adapter (`sqlight`) panics on that, so verify must catch the
   // mismatch before the user reaches runtime.
   let cfg =


### PR DESCRIPTION
## Summary

Drops the `Sql` prefix from every variant of `runtime.Value`. The prefix repeated information already encoded in the package and module name (`sqlode/runtime`), and every pattern match against the type carried it on every arm. Fully-qualified call sites now read `runtime.Int` / `runtime.String`, which lines up with the wording of the underlying driver primitives (`sqlight.text`, `sqlight.int`, ...).

This is a breaking change. The issue argues for batching it with the other pre-1.0 `runtime` sweeps (the `raw_query` rename in #569 just landed, the `QueryCommand` rename in #571 is next), so callers face one regenerate-and-update cycle rather than three.

## Changes

- `src/sqlode/runtime.gleam`: the `Value` variants are now `Null`, `String`, `Int`, `Float`, `Bool`, `Bytes`, `Array`. Helper functions that constructed the variants by name (the `to_value` family) updated to match.
- `src/sqlode/internal/codegen/adapter.gleam`: the `pog` / `sqlight` / `shork` adapter templates each contain a `value_to_<driver>` helper that pattern-matches the runtime variants. All three templates are migrated so the next `sqlode generate` produces output that compiles against the new variant names.
- `src/sqlode/internal/query_validation.gleam`: internal validator that maps placeholder type info into `Value` constructors. Mechanical rename.
- `test/`: every test file that pattern-matches or constructs a `Value` (`runtime_test.gleam`, `runtime_property_test.gleam`, `verify_test.gleam`, `sqlode_metamon_test.gleam`, `codegen_test.gleam`, `query_analyzer_test.gleam`) is updated.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Changed` labelled **BREAKING**, naming the migration shape and the regenerate-after-upgrade requirement for callers who hold codegen-emitted adapter code.

## Design Decisions

The rename is applied across all variants in one commit rather than per-variant. The variants form a single product — they share a domain (SQL value types) and a use shape (pattern matches always touch every arm). A partial rename would leave the type half-fixed and force callers to handle both forms during a transition window with no upside.

Constructor / type name collisions (`String(String)` etc.) are fine in Gleam — types and constructors are in different namespaces, so the variant `Int` taking an `Int` field compiles without ambiguity. This was the main risk I checked before applying the rename.

A deprecation cycle was considered but rejected. Gleam custom-type constructors cannot be aliased — adding `Null` alongside `SqlNull` would mean both variants exist, every match arm has to handle both, and the deprecation never actually completes. The issue called this out explicitly.

## Test plan

- [x] `gleam build --warnings-as-errors`: clean
- [x] `gleam test` (Erlang target): 1130 passed
- [x] `gleam format --check src test`: clean
- [x] No `Sql*` references remain in `src/` or `test/` (`grep -r 'SqlNull|SqlString|...'` returns empty)

Closes #570
