### PR TITLE
docs(readme): show --runtime=native at sqlode init, not via post-edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README quick-start now passes `--runtime=native` to `sqlode init` and explains the choice next to the `--engine` flag. The flag was already wired in the CLI but the README still showed the bare `--engine=sqlite` form, so first-time users had to either accept the default `runtime: "raw"` or edit `sqlode.yaml` post-init to opt into the typed adapter output. Surfacing the flag at the moment of engine selection removes the post-edit step. The CLI usage block further down also lists `[--engine=...] [--runtime=...]` so the discoverability story is consistent. (#568)
+
 ### Changed
 
 - **BREAKING**: `sqlode/runtime.QueryCommand` variants drop the `Query` prefix: `QueryOne` → `One`, `QueryMany` → `Many`, `QueryExec` → `Exec`, `QueryExecResult` → `ExecResult`, `QueryExecRows` → `ExecRows`, `QueryExecLastId` → `ExecLastId`, `QueryBatchOne` → `BatchOne`, `QueryBatchMany` → `BatchMany`, `QueryBatchExec` → `BatchExec`, `QueryCopyFrom` → `CopyFrom`. The prefix repeated information already encoded in the type name and module path (`sqlode/runtime.QueryCommand`); every pattern match against the type carried it on every arm. Fully-qualified call sites read `runtime.Many` / `runtime.BatchExec` now. Companion to the `runtime.Value` rename in #570 — both pre-1.0 sweeps land together so callers face one regenerate-and-update cycle. (#571)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ escript install — just `gleam` and `sqlode` as a dependency.
 gleam new myapp
 cd myapp
 gleam add sqlode sqlight
-gleam run -m sqlode -- init --engine=sqlite
+gleam run -m sqlode -- init --engine=sqlite --runtime=native
 ```
+
+`--runtime=native` (default: `raw`) opts into the strongly-typed adapter
+output — the recommended choice for new projects on any engine. Drop
+the flag, or pass `--runtime=raw`, to keep the runtime-tagged
+`runtime.Value` shape (useful when you want to hand-roll your adapter
+or interleave queries from multiple drivers). Either way, the choice
+is baked into the `sqlode.yaml` that `init` writes; you no longer have
+to edit the file before the first `generate`.
 
 Edit the generated `db/schema.sql` and `db/query.sql` (the `init` stubs
 already compile, so it is fine to leave them as-is for the first run):
@@ -858,12 +866,12 @@ gen:
 # Standalone escript
 sqlode generate [--config=./sqlode.yaml]
 sqlode verify   [--config=./sqlode.yaml]
-sqlode init     [--output=./sqlode.yaml]
+sqlode init     [--output=./sqlode.yaml] [--engine=postgresql|sqlite|mysql] [--runtime=raw|native]
 
 # Via Gleam
 gleam run -m sqlode -- generate [--config=./sqlode.yaml]
 gleam run -m sqlode -- verify   [--config=./sqlode.yaml]
-gleam run -m sqlode -- init     [--output=./sqlode.yaml]
+gleam run -m sqlode -- init     [--output=./sqlode.yaml] [--engine=postgresql|sqlite|mysql] [--runtime=raw|native]
 ```
 
 ### `sqlode verify`


### PR DESCRIPTION
## Summary

The `--runtime=raw|native` flag has already been wired into `sqlode init` (cli.gleam lines 136-140) — its absence at the quick-start was the friction reported in #568. Surface the flag in the README so first-time users see the choice at engine-selection time instead of editing `sqlode.yaml` post-init.

## Changes

- `README.md`: update the quick-start to call `sqlode init --engine=sqlite --runtime=native`. A short paragraph below the command explains the choice: `native` produces the strongly-typed adapter output, `raw` keeps the runtime-tagged `runtime.Value` shape for callers who want to hand-roll their adapter or interleave multiple drivers.
- Same file: the CLI usage block further down (the "command catalog" section) gains `[--engine=postgresql|sqlite|mysql] [--runtime=raw|native]` on both the standalone-escript and `gleam run -m sqlode --` forms, so the help-style reference matches the quick-start.
- `CHANGELOG.md`: `[Unreleased]` entry under `### Documentation` describing the change.

## Design Decisions

The flag itself is left as-is. It already exists, has tests (`init_sqlite_native_runtime_test` / `init_mysql_native_runtime_test` in `test/cli_test.gleam`), and behaves the way the issue asked for. The remaining gap was discoverability: the quick-start didn't show it, so users following the README never knew the post-edit step was avoidable.

The quick-start passes `--runtime=native` rather than leaving it implicit. The issue's design note suggested that `native` could become the default when the engine supports it; surfacing it explicitly at the call site is the lighter-touch precursor (no behaviour change for existing users who already commit a `runtime: "raw"` config). If a future PR flips the default, the quick-start does not need to change.

The CLI usage block already followed a `command [--flag=...]` documentation pattern, so adding two more bracketed flags doesn't change its shape — readers scanning it for syntax see the new options inline.

## Test plan

- [x] Read-only changes — no source code edits, no test additions needed beyond the existing `cli_test.gleam` coverage that already exercises `--runtime=native`
- [x] `gleam test`: unchanged, 1130 passed (no source under test was touched)

Closes #568
