### PR TITLE
chore(release): prepare v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-05-16
+
 ### Documentation
 
 - README quick-start now passes `--runtime=native` to `sqlode init` and explains the choice next to the `--engine` flag. The flag was already wired in the CLI but the README still showed the bare `--engine=sqlite` form, so first-time users had to either accept the default `runtime: "raw"` or edit `sqlode.yaml` post-init to opt into the typed adapter output. Surfacing the flag at the moment of engine selection removes the post-edit step. The CLI usage block further down also lists `[--engine=...] [--runtime=...]` so the discoverability story is consistent. (#568)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "sqlode"
-version = "0.28.0"
+version = "0.29.0"
 description = "Generate type-safe Gleam code from SQL schemas and queries"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "sqlode" }


### PR DESCRIPTION
### Changed

- **BREAKING**: `sqlode/runtime.QueryCommand` variants drop the `Query` prefix: `QueryOne` → `One`, `QueryMany` → `Many`, `QueryExec` → `Exec`, `QueryExecResult` → `ExecResult`, `QueryExecRows` → `ExecRows`, `QueryExecLastId` → `ExecLastId`, `QueryBatchOne` → `BatchOne`, `QueryBatchMany` → `BatchMany`, `QueryBatchExec` → `BatchExec`, `QueryCopyFrom` → `CopyFrom`. The prefix repeated information already encoded in the type name and module path (`sqlode/runtime.QueryCommand`); every pattern match against the type carried it on every arm. Fully-qualified call sites read `runtime.Many` / `runtime.BatchExec` now. Companion to the `runtime.Value` rename in #570 — both pre-1.0 sweeps land together so callers face one regenerate-and-update cycle. (#571)
- **BREAKING**: `sqlode/runtime.Value` variants drop the `Sql` prefix: `SqlNull` → `Null`, `SqlString` → `String`, `SqlInt` → `Int`, `SqlFloat` → `Float`, `SqlBool` → `Bool`, `SqlBytes` → `Bytes`, `SqlArray` → `Array`. The prefix repeated information already encoded in the package and module name (`sqlode/runtime`); every pattern match against the type carried it on every arm. Fully-qualified call sites read `runtime.Int` / `runtime.String` now, which lines up with the wording of the underlying driver primitives (`sqlight.text`, `sqlight.int`, ...). Callers who hold codegen-emitted adapter code that pattern-matches `runtime.Sql*` will need to regenerate it after upgrading — the bundled `pog` / `sqlight` / `shork` value adapter templates have already been migrated to the new names so the next `sqlode generate` produces matching output. (#570)

### Added

- `sqlode/runtime.raw_query/7`: the same hand-rolled `RawQuery` constructor previously named `raw_query_for_test/7`, without the suffix that made library-mode callers think the helper was test-only. Behaviour is identical; the rename is purely a discoverability fix for callers using `sqlode/runtime` as a library (no escript, no `sqlode generate` codegen). Production callers who run codegen continue to use the `RawQuery` values `sqlode generate` produces from declarative SQL fixtures. (#569)

### Deprecated

- `sqlode/runtime.raw_query_for_test/7`: now a `@deprecated` thin alias of `raw_query/7`. The `_for_test` suffix discouraged the only sanctioned non-constructor path from library-mode use, which was the friction reported in the issue. Callers see the deprecation warning at their own call site and migrate at their own pace. (#569)

### Documentation

- README quick-start now passes `--runtime=native` to `sqlode init` and explains the choice next to the `--engine` flag. The flag was already wired in the CLI but the README still showed the bare `--engine=sqlite` form, so first-time users had to either accept the default `runtime: "raw"` or edit `sqlode.yaml` post-init to opt into the typed adapter output. Surfacing the flag at the moment of engine selection removes the post-edit step. The CLI usage block further down also lists `[--engine=...] [--runtime=...]` so the discoverability story is consistent. (#568)
- `sqlode/runtime.PlaceholderStyle`: docstring expanded with an engine-mapping table that pairs each variant with the databases that accept its syntax (PostgreSQL / MySQL / SQLite). The previous docstring framed `QuestionPositional` as MySQL-only, so SQLite users landing on the variant list saw no clearly-labelled sqlite option even though bare `?` is the canonical SQLite placeholder. Per-variant doc-comments also call out which engines accept (or reject) each syntax. (#572)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.29.0 released. Package version incremented from 0.28.0 to 0.29.0. Changelog documentation updated with new release entry dated May 16, 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqlode/pull/578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->