### PR TITLE
fix(sqlode): try/catch FFI port_close, version constant bump, README nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `sqlode_ffi`: replaced the deprecated `catch port_close(Port)` form with `try port_close(Port) catch _:_ -> ok end`. The old expression form of `catch` is deprecated in recent OTP releases and emitted a `'catch ...' is deprecated; please use 'try ... catch ... end' instead` warning at every `gleam build` of any project that depends on `sqlode`. The new form preserves the original intent (swallow any error when closing an already-closed port). (#579)
+- `sqlode/internal/version`: bumped the `version` constant from `0.15.0` to `0.29.0` so `sqlode version` reports the package version actually shipped (it had drifted ~14 releases out of date). Added a `version_constant_matches_gleam_toml_test` that reads `gleam.toml` at test time and cross-checks the constant, so a future release bump cannot ship a stale CLI version. (#581)
+
+### Documentation
+
+- README "Quickstart (SQLite)" section now shows the full `sqlode.yaml` structure with `runtime: "native"` correctly nested under `sql[].gen.gleam.runtime`. A top-level `runtime:` (where the original prose was ambiguous) is rejected with `Unsupported config fields: sql.runtime`, so callers hand-writing the yaml from the README needed to see the actual nesting. (#580)
+
 ## [0.29.0] - 2026-05-16
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -54,7 +54,24 @@ VALUES (sqlode.arg(author_name), sqlode.narg(bio));
 ```
 
 Switch to native mode (so `sqlode` emits a ready-to-call `sqlight`
-adapter) and generate:
+adapter) and generate. `runtime` is nested under `sql[].gen.gleam` —
+not at the top of a `sql[]` entry (a top-level `runtime:` is rejected
+as `Unsupported config fields: sql.runtime`):
+
+```yaml
+# sqlode.yaml — the `init` command writes this file. Only the
+# `runtime: "native"` line below changes when you flip from `raw`.
+version: "2"
+sql:
+  - schema: "db/schema.sql"
+    queries: "db/query.sql"
+    engine: "sqlite"
+    gen:
+      gleam:
+        package: "myapp"
+        out: "src/db"
+        runtime: "native"
+```
 
 ```console
 sed -i 's/runtime: "raw"/runtime: "native"/' sqlode.yaml

--- a/src/sqlode/internal/version.gleam
+++ b/src/sqlode/internal/version.gleam
@@ -1,1 +1,1 @@
-pub const version = "0.15.0"
+pub const version = "0.29.0"

--- a/src/sqlode_ffi.erl
+++ b/src/sqlode_ffi.erl
@@ -69,6 +69,6 @@ collect_exit(Port, Acc) ->
         {Port, {exit_status, Code}} ->
             {Code, Acc}
     after 60000 ->
-        catch port_close(Port),
+        try port_close(Port) catch _:_ -> ok end,
         {1, <<Acc/binary, "(timed out after 60s)">>}
     end.

--- a/test/cli_test.gleam
+++ b/test/cli_test.gleam
@@ -1,9 +1,11 @@
+import gleam/list
 import gleam/result
 import gleam/string
 import gleeunit/should
 import glint
 import simplifile
 import sqlode/cli
+import sqlode/internal/version
 
 const base_dir = "test_output/cli_test"
 
@@ -110,6 +112,35 @@ pub fn version_command_succeeds_test() {
   |> glint.execute(["version"])
   |> result.is_ok
   |> should.be_true
+}
+
+// Issue #581: the version constant exposed via `sqlode version` is
+// the source of truth for users diagnosing which build is installed.
+// Cross-check it against `gleam.toml` at test time so the CLI cannot
+// silently drift from the Hex metadata (this guard caught a 14-
+// release gap where the constant stuck at 0.15.0 while gleam.toml
+// reached 0.29.0).
+pub fn version_constant_matches_gleam_toml_test() {
+  let assert Ok(toml) = simplifile.read("gleam.toml")
+  let assert Ok(toml_version) = extract_toml_version(toml)
+  version.version
+  |> should.equal(toml_version)
+}
+
+fn extract_toml_version(toml: String) -> Result(String, Nil) {
+  toml
+  |> string.split("\n")
+  |> list.find(fn(line) { string.starts_with(string.trim(line), "version = ") })
+  |> result.try(fn(line) {
+    case string.split_once(line, "\"") {
+      Ok(#(_, after_open)) ->
+        case string.split_once(after_open, "\"") {
+          Ok(#(value, _)) -> Ok(value)
+          Error(_) -> Error(Nil)
+        }
+      Error(_) -> Error(Nil)
+    }
+  })
 }
 
 pub fn init_sqlite_engine_generates_sqlite_schema_test() {

--- a/test/sqlode_test.gleam
+++ b/test/sqlode_test.gleam
@@ -986,6 +986,10 @@ pub fn version_command_succeeds_test() {
   cli_test.version_command_succeeds_test()
 }
 
+pub fn version_constant_matches_gleam_toml_test() {
+  cli_test.version_constant_matches_gleam_toml_test()
+}
+
 // --- Entry-point error rewriting (#466) ---
 
 pub fn rewrite_error_no_args_says_missing_subcommand_test() {


### PR DESCRIPTION
## Summary

Three small related fixes bundled into one PR: the FFI `catch port_close` deprecation warning that surfaces on every downstream `gleam build` (#579), the long-stale `sqlode/internal/version.version` constant that made `sqlode version` lie about which build was installed (#581), and the README `sqlode.yaml` snippet that omitted the `gen.gleam.runtime` nesting and led readers to write a top-level `runtime:` field that gets rejected with `Unsupported config fields: sql.runtime` (#580).

## Changes

- [src/sqlode_ffi.erl](src/sqlode_ffi.erl) `catch port_close(Port)` replaced with `try port_close(Port) catch _:_ -> ok end` inside the `after 60000` clause of `collect_exit/2`. Identical fix to the one merged in `nao1215/oaspec` for the parallel issue. (#579)
- [src/sqlode/internal/version.gleam](src/sqlode/internal/version.gleam) bumped `version` constant from `0.15.0` to `0.29.0` so `sqlode version` reports the package version that's actually shipped (#581).
- [test/cli_test.gleam](test/cli_test.gleam) and [test/sqlode_test.gleam](test/sqlode_test.gleam) new `version_constant_matches_gleam_toml_test` that reads `gleam.toml` at test time and cross-checks `version.version`. This is the guard rail — without it the constant will drift again on the next release. (`qrkit` uses the same shape via its `package_version_test`.)
- [README.md](README.md) Quickstart yaml block now shows the complete `sqlc`-style nesting:
  ```yaml
  sql:
    - schema: \"db/schema.sql\"
      queries: \"db/query.sql\"
      engine: \"sqlite\"
      gen:
        gleam:
          package: \"myapp\"
          out: \"src/db\"
          runtime: \"native\"
  ```
  plus a one-line callout that a top-level `runtime:` is rejected (#580).
- [CHANGELOG.md](CHANGELOG.md) Unreleased Fixed + Documentation entries.

## Design Decisions

Bundled into one PR because all three are tiny, all touch the same package, and the CI cost of three separate PRs (sqlode's test suite takes a few minutes per run) was disproportionate to the size of each change.

For the version constant, the simplest correct fix is the explicit bump plus a test that prevents recurrence — making the constant read from `gleam.toml` at runtime would require either an `etoml`-style FFI or a build-time generated source file, neither of which is worth the complexity when a sub-100-line cross-check test catches the drift at the same moment a release would normally happen.

Closes #579, closes #580, closes #581