### PR TITLE
feat(runtime): add raw_query_simple/6 to drop empty slice_info noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `sqlode/runtime.raw_query_simple/6`: thin wrapper around `raw_query/7` that supplies `slice_info: fn(_) { [] }` so hand-rolled queries without slice-expanded `IN ($N)` placeholders no longer need to repeat the always-empty lambda at every call site. `sqlode generate` codegen continues to emit `raw_query/7` (or the bare constructor) so slice-bearing queries are unaffected. (#584)
+
 ## [0.30.0] - 2026-05-18
 
 ### Fixed

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -118,6 +118,44 @@ pub fn raw_query(
   )
 }
 
+/// Thin wrapper around `raw_query/7` for hand-rolled queries that do
+/// not use slice-expanded `IN ($1)` placeholders. Forwards every
+/// labelled argument to `raw_query` and supplies
+/// `slice_info: fn(_) { [] }` so ad-hoc callers do not have to repeat
+/// the always-empty lambda at every call site.
+///
+/// Reach for `raw_query_simple` when:
+///
+/// - writing a hand-rolled `INSERT` / `UPDATE` / `DELETE` or a fixed-
+///   shape `SELECT` whose SQL has zero slice markers; or
+/// - prototyping a query against `sqlode/runtime` as a library, before
+///   moving the SQL into a declarative fixture and regenerating
+///   through `sqlode generate`.
+///
+/// Keep using `raw_query/7` when the SQL contains slice-expanded
+/// `IN ($N)` placeholders — those queries need the real `slice_info`
+/// callback to expand at `prepare/2` time. `sqlode generate` codegen
+/// continues to emit `raw_query/7` (or the bare `RawQuery(...)`
+/// constructor) so this wrapper only affects ad-hoc callers.
+pub fn raw_query_simple(
+  name name: String,
+  sql sql: String,
+  command command: QueryCommand,
+  param_count param_count: Int,
+  placeholder_style placeholder_style: PlaceholderStyle,
+  encode encode: fn(p) -> List(Value),
+) -> RawQuery(p) {
+  raw_query(
+    name: name,
+    sql: sql,
+    command: command,
+    param_count: param_count,
+    placeholder_style: placeholder_style,
+    encode: encode,
+    slice_info: fn(_) { [] },
+  )
+}
+
 /// Deprecated alias for `raw_query/7`. The `_for_test` suffix
 /// discouraged library-mode callers from using the only sanctioned
 /// non-constructor path even though library use is exactly what the

--- a/test/regression_raw_query_simple_test.gleam
+++ b/test/regression_raw_query_simple_test.gleam
@@ -1,0 +1,113 @@
+//// Regression tests for Issue #584 — `runtime.raw_query_simple/6`.
+////
+//// `raw_query_simple` is a thin wrapper around `raw_query/7` that
+//// supplies `slice_info: fn(_) { [] }` so hand-rolled queries without
+//// slice-expanded `IN ($N)` placeholders do not have to repeat the
+//// always-empty lambda. These tests pin the wrapper-equivalence
+//// contract: a value constructed via `raw_query_simple` must be
+//// indistinguishable from one constructed via `raw_query` with the
+//// empty `slice_info`.
+
+import gleeunit
+import gleeunit/should
+import sqlode/runtime
+
+pub fn main() {
+  gleeunit.main()
+}
+
+// Encode helpers used by multiple cases — kept top-level so the
+// equivalence test below can pass the *same* function reference to
+// both `raw_query` and `raw_query_simple`.
+fn encode_audit(p: #(String, String, String, Int)) -> List(runtime.Value) {
+  [
+    runtime.string(p.0),
+    runtime.string(p.1),
+    runtime.string(p.2),
+    runtime.int(p.3),
+  ]
+}
+
+fn encode_id(id: Int) -> List(runtime.Value) {
+  [runtime.int(id)]
+}
+
+pub fn raw_query_simple_matches_raw_query_with_empty_slice_info_test() {
+  let audit_sql =
+    "INSERT INTO audit (id, actor, action, amount_minor) VALUES (__sqlode_param_1__, __sqlode_param_2__, __sqlode_param_3__, __sqlode_param_4__)"
+  let simple =
+    runtime.raw_query_simple(
+      name: "insert_audit_row",
+      sql: audit_sql,
+      command: runtime.Exec,
+      param_count: 4,
+      placeholder_style: runtime.DollarNumbered,
+      encode: encode_audit,
+    )
+  let full =
+    runtime.raw_query(
+      name: "insert_audit_row",
+      sql: audit_sql,
+      command: runtime.Exec,
+      param_count: 4,
+      placeholder_style: runtime.DollarNumbered,
+      encode: encode_audit,
+      slice_info: fn(_) { [] },
+    )
+
+  // Field-by-field equivalence — function-typed fields (`encode`,
+  // `slice_info`) are compared by identity / behaviour rather than by
+  // structural equality.
+  simple.name |> should.equal(full.name)
+  simple.sql |> should.equal(full.sql)
+  simple.command |> should.equal(full.command)
+  simple.param_count |> should.equal(full.param_count)
+  simple.placeholder_style |> should.equal(full.placeholder_style)
+
+  let params = #("a-id", "alice", "create", 100)
+  simple.encode(params) |> should.equal(full.encode(params))
+  simple.slice_info(params) |> should.equal(full.slice_info(params))
+}
+
+pub fn raw_query_simple_prepare_renders_dollar_numbered_test() {
+  let query =
+    runtime.raw_query_simple(
+      name: "GetUser",
+      sql: "SELECT * FROM users WHERE id = __sqlode_param_1__",
+      command: runtime.One,
+      param_count: 1,
+      placeholder_style: runtime.DollarNumbered,
+      encode: encode_id,
+    )
+  let #(sql, values) = runtime.prepare(query, 42)
+  sql |> should.equal("SELECT * FROM users WHERE id = $1")
+  values |> should.equal([runtime.Int(42)])
+}
+
+pub fn raw_query_simple_prepare_respects_question_positional_test() {
+  let query =
+    runtime.raw_query_simple(
+      name: "GetUser",
+      sql: "SELECT * FROM users WHERE id = __sqlode_param_1__",
+      command: runtime.One,
+      param_count: 1,
+      placeholder_style: runtime.QuestionPositional,
+      encode: encode_id,
+    )
+  let #(sql, _values) = runtime.prepare(query, 7)
+  sql |> should.equal("SELECT * FROM users WHERE id = ?")
+}
+
+pub fn raw_query_simple_slice_info_always_empty_test() {
+  let query =
+    runtime.raw_query_simple(
+      name: "GetUser",
+      sql: "SELECT * FROM users WHERE id = __sqlode_param_1__",
+      command: runtime.One,
+      param_count: 1,
+      placeholder_style: runtime.DollarNumbered,
+      encode: encode_id,
+    )
+  query.slice_info(1) |> should.equal([])
+  query.slice_info(99) |> should.equal([])
+}


### PR DESCRIPTION
## Summary

`sqlode/runtime.raw_query/7` requires a `slice_info` callback even when the SQL has zero slice-expanded `IN ($N)` placeholders. Ad-hoc hand-rolled callers (i.e. anyone reaching for `raw_query` outside the `sqlode generate` codegen path) have to repeat `slice_info: fn(_) { [] }` at every call site just to satisfy the type. The lambda is mechanical noise that adds nothing to the description of the query.

This PR adds `raw_query_simple/6`, a thin wrapper that forwards every other labelled argument to `raw_query/7` and supplies the always-empty `slice_info` itself. The 7-arg form is left untouched, so:

- codegen output is unchanged (`sqlode generate` continues to emit `raw_query/7` or the bare `RawQuery(...)` constructor for slice-bearing queries);
- slice-bearing queries still go through `raw_query/7` with a real `slice_info`;
- only the ad-hoc / library-mode call sites change shape.

Doc-comment on the new function calls out the slice-vs-no-slice picking rule so the discoverability story is explicit.

## Changes

- `src/sqlode/runtime.gleam` — add `raw_query_simple/6` with full doc-comment, placed next to `raw_query/7`.
- `test/regression_raw_query_simple_test.gleam` — new regression test file pinning the wrapper-equivalence contract:
  - same `name` / `sql` / `command` / `param_count` / `placeholder_style` as `raw_query/7`;
  - same `encode` output for a representative tuple;
  - `slice_info` returns `[]` for arbitrary input;
  - `prepare/2` renders correctly for both `DollarNumbered` and `QuestionPositional`.
- `CHANGELOG.md` — `[Unreleased]` / `Added` entry referencing #584.

## Test plan

- [x] `just all` green on the branch (1136 gleam tests, 18 JS runtime laws, 30 shellspec examples)
- [x] glinter clean
- [x] `gleam format --check` clean

Closes #584