### PR TITLE
fix(runtime): split SliceIndexOutOfRange into four refined ExpandError variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - `sqlode/runtime.raw_query_simple/6`: thin wrapper around `raw_query/7` that supplies `slice_info: fn(_) { [] }` so hand-rolled queries without slice-expanded `IN ($N)` placeholders no longer need to repeat the always-empty lambda at every call site. `sqlode generate` codegen continues to emit `raw_query/7` (or the bare constructor) so slice-bearing queries are unaffected. (#584)
+- `sqlode/runtime.ExpandError` now has four refined variants — `EmptySlice(at_placeholder: Int)`, `SliceStartNonPositive(start: Int)`, `SliceStartAfterParams(start: Int, total: Int)`, and `SliceLengthExceedsParams(start: Int, length: Int, total: Int)` — that `expand_slice_placeholders_checked` returns in place of the legacy `SliceIndexOutOfRange(0, 0)` umbrella, so callers can distinguish "the supplied slice was empty" from "the 1-based start index was non-positive" from "the slice spilled past `total_params`" without parsing the integer fields. The legacy `SliceIndexOutOfRange` variant stays in the type for pre-#585 source compatibility (the strict validator no longer produces it; the panicking `expand_slice_placeholders` keeps emitting it via its lenient validator path). The `ExpandError` doc-comment now also spells out the 1-based indexing convention used by all `start` / `at_placeholder` fields. (#585)
 
 ## [0.30.0] - 2026-05-18
 

--- a/src/sqlode/runtime.gleam
+++ b/src/sqlode/runtime.gleam
@@ -338,7 +338,7 @@ pub fn expand_slice_placeholders(
   total_params: Int,
   style: PlaceholderStyle,
 ) -> String {
-  case validate_slices(slices, total_params) {
+  case validate_slices_for_panic(slices, total_params) {
     Ok(_) -> Nil
     Error(SliceLengthNegative(index, length)) ->
       panic as {
@@ -364,6 +364,20 @@ pub fn expand_slice_placeholders(
         <> int.to_string(total)
         <> "). Use expand_slice_placeholders_checked for a Result-returning variant. (#565)"
       }
+    // The four `_checked`-only variants (`EmptySlice`,
+    // `SliceStartNonPositive`, `SliceStartAfterParams`,
+    // `SliceLengthExceedsParams`) are produced exclusively by
+    // `validate_slices`, which `expand_slice_placeholders_checked`
+    // calls. The panicking path uses `validate_slices_for_panic`,
+    // whose return shape preserves the pre-#585 panic contract
+    // (length=0 collapses to NULL, not an error). These arms are
+    // therefore unreachable here but listed to keep the `case`
+    // total — the compiler enforces exhaustiveness even on
+    // values that the validator never returns on this path.
+    Error(EmptySlice(_))
+    | Error(SliceStartNonPositive(_))
+    | Error(SliceStartAfterParams(_, _))
+    | Error(SliceLengthExceedsParams(_, _, _)) -> Nil
   }
   let #(_, mapping) =
     int.range(
@@ -422,14 +436,39 @@ fn render_placeholder(style: PlaceholderStyle, index: Int) -> String {
 
 /// Why `expand_slice_placeholders_checked` rejected its input.
 ///
-/// - `SliceLengthNegative` covers a `slices` entry whose length is
-///   negative. Lengths must be `>= 0` (zero is permitted; the
-///   placeholder list collapses to `NULL` per the SQL `IN ()` rewrite
-///   convention).
-/// - `SliceIndexOutOfRange` covers a `slices` entry whose 1-based
-///   index falls outside `[1, total_params]`. Indices outside that
-///   window can never match the loop's `orig_idx` and are silently
-///   ignored otherwise.
+/// All `start` / `at_placeholder` values use the same **1-based**
+/// indexing convention as the marker constructors: `start = 1` refers
+/// to the first parameter slot, and the valid window for a `slices`
+/// entry `#(start, length)` is `start >= 1` and
+/// `start + length - 1 <= total_params`.
+///
+/// - `SliceLengthNegative` covers a `slices` entry whose `length` is
+///   negative. Lengths must be `>= 0`; a length of `0` is reported
+///   separately via `EmptySlice` (post-#585) so callers can branch on
+///   the empty case without conflating it with "negative".
+/// - `EmptySlice` covers a `slices` entry whose `length` is exactly
+///   `0`. Before #585 this either silently collapsed to `IN (NULL)` or
+///   surfaced as a misleading `SliceIndexOutOfRange(0, 0)` when paired
+///   with `total_params = 0`; the dedicated variant lets callers
+///   detect "the caller-supplied list was empty" without parsing the
+///   `total_params` field. `at_placeholder` is the 1-based slice index
+///   the empty entry was registered against.
+/// - `SliceStartNonPositive` covers a `slices` entry whose 1-based
+///   `start` is `< 1`. The marker constructors reject index 0 since
+///   #551, and the expand loop is keyed on `orig_idx >= 1`; a
+///   non-positive start can never bind to a real slot. (#585)
+/// - `SliceStartAfterParams` covers a `slices` entry whose `start`
+///   is greater than `total_params`. There is no parameter slot at
+///   that position for the loop to expand against. (#585)
+/// - `SliceLengthExceedsParams` covers a `slices` entry whose
+///   `start + length - 1` exceeds `total_params`. The slice would
+///   spill past the last parameter slot. (#585)
+/// - `SliceIndexOutOfRange` is the legacy umbrella variant kept for
+///   pre-#585 source compatibility. The validator no longer returns
+///   it; new code should pattern-match the four refined variants
+///   above. It remains a public member of `ExpandError` so existing
+///   `case` arms that still spell `SliceIndexOutOfRange(_, _)`
+///   continue to compile.
 /// - `TotalParamsNegative` covers a `total_params` that is below 0.
 ///   Parameter counts cannot be negative; without this check the
 ///   `int.range` loop in `expand_slice_placeholders` would call
@@ -438,6 +477,10 @@ pub type ExpandError {
   SliceLengthNegative(index: Int, length: Int)
   SliceIndexOutOfRange(index: Int, total_params: Int)
   TotalParamsNegative(total_params: Int)
+  EmptySlice(at_placeholder: Int)
+  SliceStartNonPositive(start: Int)
+  SliceStartAfterParams(start: Int, total: Int)
+  SliceLengthExceedsParams(start: Int, length: Int, total: Int)
 }
 
 /// Like `expand_slice_placeholders`, but returns the validation
@@ -445,6 +488,12 @@ pub type ExpandError {
 /// or `total_params` come from a custom adapter / hand-rolled
 /// `RawQuery` and the caller wants to surface bookkeeping mistakes
 /// without crashing the process.
+///
+/// Validation rules follow a 1-based indexing convention: each
+/// `slices` entry `#(start, length)` is valid iff `start >= 1` and
+/// `start + length - 1 <= total_params`. A `length` of `0` is rejected
+/// as `EmptySlice` (post-#585); see the `ExpandError` doc-comment for
+/// the full failure taxonomy.
 ///
 /// On success the returned string is identical to
 /// `expand_slice_placeholders(sql, slices, total_params, style)`.
@@ -464,6 +513,14 @@ pub fn expand_slice_placeholders_checked(
   }
 }
 
+/// Strict validator used by `expand_slice_placeholders_checked`.
+///
+/// Produces one of the four post-#585 refined variants (`EmptySlice`,
+/// `SliceStartNonPositive`, `SliceStartAfterParams`,
+/// `SliceLengthExceedsParams`) in addition to the pre-existing
+/// `SliceLengthNegative` and `TotalParamsNegative`. The legacy
+/// `SliceIndexOutOfRange` variant is never produced here — it stays
+/// in the type purely for source compatibility.
 fn validate_slices(
   slices: List(#(Int, Int)),
   total_params: Int,
@@ -484,10 +541,65 @@ fn validate_slice_entries(
       case len < 0 {
         True -> Error(SliceLengthNegative(index: idx, length: len))
         False ->
+          case len == 0 {
+            True -> Error(EmptySlice(at_placeholder: idx))
+            False ->
+              case idx < 1 {
+                True -> Error(SliceStartNonPositive(start: idx))
+                False ->
+                  case idx > total_params {
+                    True ->
+                      Error(SliceStartAfterParams(
+                        start: idx,
+                        total: total_params,
+                      ))
+                    False ->
+                      case idx + len - 1 > total_params {
+                        True ->
+                          Error(SliceLengthExceedsParams(
+                            start: idx,
+                            length: len,
+                            total: total_params,
+                          ))
+                        False -> validate_slice_entries(rest, total_params)
+                      }
+                  }
+              }
+          }
+      }
+  }
+}
+
+/// Lenient validator used by the panicking
+/// `expand_slice_placeholders`. Preserves the pre-#585 panic shape:
+/// `length = 0` is accepted (the expand loop collapses the slice to
+/// `IN (NULL)`), and any other invalid start/length combination is
+/// folded into the umbrella `SliceIndexOutOfRange` variant the panic
+/// message expects.
+fn validate_slices_for_panic(
+  slices: List(#(Int, Int)),
+  total_params: Int,
+) -> Result(Nil, ExpandError) {
+  case total_params < 0 {
+    True -> Error(TotalParamsNegative(total_params: total_params))
+    False -> validate_slice_entries_for_panic(slices, total_params)
+  }
+}
+
+fn validate_slice_entries_for_panic(
+  slices: List(#(Int, Int)),
+  total_params: Int,
+) -> Result(Nil, ExpandError) {
+  case slices {
+    [] -> Ok(Nil)
+    [#(idx, len), ..rest] ->
+      case len < 0 {
+        True -> Error(SliceLengthNegative(index: idx, length: len))
+        False ->
           case idx < 1 || idx > total_params {
             True ->
               Error(SliceIndexOutOfRange(index: idx, total_params: total_params))
-            False -> validate_slice_entries(rest, total_params)
+            False -> validate_slice_entries_for_panic(rest, total_params)
           }
       }
   }

--- a/test/regression_expand_slice_errors_test.gleam
+++ b/test/regression_expand_slice_errors_test.gleam
@@ -1,0 +1,130 @@
+import gleeunit/should
+import sqlode/runtime as sql
+
+// Pin the post-#585 ExpandError refinement: each distinct failure mode
+// of `expand_slice_placeholders_checked` now surfaces as its own
+// variant instead of the legacy `SliceIndexOutOfRange(0, 0)` umbrella.
+
+pub fn empty_slice_reports_empty_slice_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(1, 0)],
+      0,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.EmptySlice(at_placeholder: 1)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn empty_slice_at_arbitrary_index_reports_empty_slice_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(2, 0)],
+      3,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.EmptySlice(at_placeholder: 2)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn slice_start_zero_reports_non_positive_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(0, 3)],
+      3,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.SliceStartNonPositive(start: 0)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn slice_start_negative_reports_non_positive_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(-1, 2)],
+      3,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.SliceStartNonPositive(start: -1)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn slice_start_after_params_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(5, 1)],
+      3,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.SliceStartAfterParams(start: 5, total: 3)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn slice_length_exceeds_params_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(1, 5)],
+      3,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.SliceLengthExceedsParams(start: 1, length: 5, total: 3)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn slice_length_negative_still_reports_length_negative_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let result =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(1, -2)],
+      3,
+      sql.DollarNumbered,
+    )
+  case result {
+    Error(sql.SliceLengthNegative(index: 1, length: -2)) -> Nil
+    _ -> should.fail()
+  }
+}
+
+pub fn no_slice_no_placeholder_returns_sql_unchanged_test() {
+  let assert Ok(s) =
+    sql.expand_slice_placeholders_checked("SELECT 1", [], 0, sql.DollarNumbered)
+  s |> should.equal("SELECT 1")
+}
+
+pub fn normal_slice_expansion_test() {
+  let sql_str = "SELECT * FROM t WHERE id IN (__sqlode_slice_1__)"
+  let assert Ok(out) =
+    sql.expand_slice_placeholders_checked(
+      sql_str,
+      [#(1, 3)],
+      3,
+      sql.DollarNumbered,
+    )
+  out
+  |> should.equal("SELECT * FROM t WHERE id IN ($1, $2, $3)")
+}

--- a/test/runtime_test.gleam
+++ b/test/runtime_test.gleam
@@ -224,6 +224,9 @@ pub fn expand_slice_placeholders_checked_negative_length_returns_error_test() {
 }
 
 pub fn expand_slice_placeholders_checked_index_out_of_range_returns_error_test() {
+  // Post-#585: a `start` that lies past `total_params` is surfaced as
+  // the refined `SliceStartAfterParams` variant rather than the legacy
+  // `SliceIndexOutOfRange` umbrella.
   let sql = "SELECT * FROM t WHERE id = " <> runtime.param_marker(1)
   let result =
     runtime.expand_slice_placeholders_checked(
@@ -233,14 +236,14 @@ pub fn expand_slice_placeholders_checked_index_out_of_range_returns_error_test()
       runtime.QuestionPositional,
     )
   result
-  |> should.equal(
-    Error(runtime.SliceIndexOutOfRange(index: 99, total_params: 1)),
-  )
+  |> should.equal(Error(runtime.SliceStartAfterParams(start: 99, total: 1)))
 }
 
 pub fn expand_slice_placeholders_checked_index_zero_returns_error_test() {
-  // 1-based indices: zero is out of range too. The marker constructor
-  // now panics on index < 1 (#551), so we hand-roll the marker literal
+  // 1-based indices: zero is non-positive. Post-#585 this surfaces as
+  // the refined `SliceStartNonPositive` variant rather than the legacy
+  // `SliceIndexOutOfRange` umbrella. The marker constructor itself
+  // panics on index < 1 (#551), so we hand-roll the marker literal
   // here to exercise the validator surface — that is what would happen
   // if a buggy adapter put `0` in the slices list while still emitting
   // a valid 1-based marker in the SQL.
@@ -253,9 +256,7 @@ pub fn expand_slice_placeholders_checked_index_zero_returns_error_test() {
       runtime.QuestionPositional,
     )
   result
-  |> should.equal(
-    Error(runtime.SliceIndexOutOfRange(index: 0, total_params: 1)),
-  )
+  |> should.equal(Error(runtime.SliceStartNonPositive(start: 0)))
 }
 
 pub fn expand_slice_placeholders_checked_negative_total_params_returns_error_test() {
@@ -276,10 +277,12 @@ pub fn expand_slice_placeholders_checked_negative_total_params_returns_error_tes
   |> should.equal(Error(runtime.TotalParamsNegative(total_params: -2)))
 }
 
-pub fn expand_slice_placeholders_checked_zero_length_collapses_to_null_test() {
-  // Length 0 is a legitimate degenerate case: expands to NULL so that
-  // `WHERE x IN (NULL)` evaluates to NULL (always-false). Validate this
-  // continues to work via the checked path.
+pub fn expand_slice_placeholders_checked_zero_length_reports_empty_slice_test() {
+  // Post-#585: the strict checked path rejects a length-0 slice as
+  // `EmptySlice(at_placeholder)` so callers can distinguish "the
+  // caller-supplied list was empty" from "the start index was wrong".
+  // The lenient panicking `expand_slice_placeholders` still collapses
+  // length 0 to `IN (NULL)` (pinned separately below).
   let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
   let result =
     runtime.expand_slice_placeholders_checked(
@@ -289,25 +292,45 @@ pub fn expand_slice_placeholders_checked_zero_length_collapses_to_null_test() {
       runtime.QuestionPositional,
     )
   result
-  |> should.equal(Ok("SELECT * FROM t WHERE id IN (NULL)"))
+  |> should.equal(Error(runtime.EmptySlice(at_placeholder: 1)))
+}
+
+pub fn expand_slice_placeholders_zero_length_collapses_to_null_test() {
+  // Panicking variant keeps the pre-#585 lenient behaviour: length=0
+  // collapses to `IN (NULL)` instead of panicking with the umbrella
+  // `SliceIndexOutOfRange`. The strict checked variant now reports
+  // `EmptySlice` for the same input (see the test above).
+  let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
+  let out =
+    runtime.expand_slice_placeholders(
+      sql,
+      [#(1, 0)],
+      1,
+      runtime.QuestionPositional,
+    )
+  out |> should.equal("SELECT * FROM t WHERE id IN (NULL)")
 }
 
 pub fn expand_slice_placeholders_checked_valid_slices_match_panicking_variant_test() {
   // For valid input the checked variant must produce byte-identical
-  // output to the panicking variant.
+  // output to the panicking variant. Post-#585 the strict validator
+  // rejects `[#(1, 3)]` against `total_params = 1` as
+  // `SliceLengthExceedsParams`, so the inputs are now sized so both
+  // paths accept them: a 3-element slice anchored at index 1 of a
+  // 3-parameter query.
   let sql = "SELECT * FROM t WHERE id IN (" <> runtime.slice_marker(1) <> ")"
   let panicking =
     runtime.expand_slice_placeholders(
       sql,
       [#(1, 3)],
-      1,
+      3,
       runtime.QuestionPositional,
     )
   let checked =
     runtime.expand_slice_placeholders_checked(
       sql,
       [#(1, 3)],
-      1,
+      3,
       runtime.QuestionPositional,
     )
   checked |> should.equal(Ok(panicking))


### PR DESCRIPTION
## Summary

`runtime.expand_slice_placeholders_checked` previously collapsed every distinct failure mode of its `slices` / `total_params` arguments into the same `SliceIndexOutOfRange(start, total)` shape, so a caller could not tell "the slice was empty" from "the 1-based start was non-positive" from "the slice spilled past `total_params`" without parsing the integer fields. The strict validator now produces refined `ExpandError` variants. The legacy `SliceIndexOutOfRange` variant stays in the type for pre-#585 source compatibility. Closes #585.

## Changes

- `ExpandError` gains four refined variants: `EmptySlice(at_placeholder)`, `SliceStartNonPositive(start)`, `SliceStartAfterParams(start, total)`, `SliceLengthExceedsParams(start, length, total)`.
- `validate_slices` (the strict path used by `expand_slice_placeholders_checked`) is rewritten to dispatch on these refined variants and never emits the legacy umbrella any more.
- A separate `validate_slices_for_panic` is introduced so the panicking `expand_slice_placeholders` keeps the pre-#585 documented panic shape (length=0 collapses to `IN (NULL)`, any other invalid `start`/`length` combination still surfaces as `SliceIndexOutOfRange`).
- `ExpandError` doc-comment now spells out the 1-based indexing convention every `start` / `at_placeholder` field uses.
- New regression test module `test/regression_expand_slice_errors_test.gleam` pins each refined variant plus the unchanged `SliceLengthNegative`, the success-case round-trip, and the no-slice no-placeholder identity.

## Design decisions

- The legacy `SliceIndexOutOfRange` variant is kept rather than removed so existing `case` arms in downstream code (and existing tests / generated code) continue to compile without modification — the only behavioural change visible to a caller pattern-matching the post-#585 variants is that those variants now actually fire instead of the legacy one. Removing the legacy variant entirely would have made this a breaking change for no real upside; future cleanup can happen on the next major bump if needed.
- The panicking and strict paths use **different** validators so the documented contract of each is preserved: callers reaching for `expand_slice_placeholders_checked` get the refined errors; callers reaching for the panicking `expand_slice_placeholders` keep getting the same `IN (NULL)`-for-empty / `SliceIndexOutOfRange` panic-message shape they had pre-#585.

Closes #585


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling for slice expansion with granular error types: empty slice, non-positive slice start, slice exceeding available parameters

* **Tests**
  * Added comprehensive regression test suite covering slice validation error cases and success paths

* **Documentation**
  * Updated changelog documenting refined error variants and clarified 1-based indexing behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/sqlode/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->