### PR TITLE
ci: bump atago to v0.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.11.0
+          version: v0.13.0
 
       - name: Download dependencies
         run: gleam deps download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.11.0
+          version: v0.13.0
 
       - name: Download dependencies
         run: gleam deps download


### PR DESCRIPTION
## Summary

Moves the atago E2E jobs to v0.13.0, the current release.

## Changes

- Bump the `nao1215/setup-atago` version input to `v0.13.0` in the workflows that run atago.

## Design Decisions

v0.13.0 changes two contracts that can turn a previously green spec red, so this is worth noting rather than treating as a routine bump. A command killed by its timeout now fails the step unless an assert reads its result, and the spec loader rejects explicit YAML tags. The specs in this repository author no YAML tags, and any step that sets a timeout is followed by an assert on the result, so neither change applies here. CI is the check that confirms it.