### PR TITLE
chore(ci): bump atago to v0.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       - name: Download dependencies
         run: gleam deps download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.13.0
+          version: v0.15.0
 
       - name: Download dependencies
         run: gleam deps download


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.13.0 to v0.15.0.

Two changes in that range can turn a passing spec red:

- `changes:` now tracks symlinks, so a step that plants or retargets a link is a
  creation or a modification instead of being invisible.
- `file: exists` / `file: executable` no longer accept a directory.

Neither affects the specs in this repo (checked: no `changes:` assertion here
covers a symlink-creating step, and no `file:` assertion targets a directory).
Everything else in v0.14.0 and v0.15.0 is additive or improves failure messages.