### PR TITLE
chore(ci): bump atago to v0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.15.0
+          version: v0.16.0
 
       - name: Download dependencies
         run: gleam deps download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.15.0
+          version: v0.16.0
 
       - name: Download dependencies
         run: gleam deps download


### PR DESCRIPTION
Move the pinned atago used by this repo's workflows from v0.15.0 to v0.16.0.

v0.16.0 adds `changes: ignore:` and fixes failure messages that pointed at the
wrong step. Two entries could matter to a suite:

- A `pty` step killed with its program still running reports a new step name and
  message, and a failure block names the command the failing check asserts on
  rather than the scenario's last command. Only a spec that pins atago's own
  console text is affected; the specs here assert on this repo's own output.
- `--repeat` / `--retry-failed` write attempts after the first into an
  `attempt-<N>` subdirectory of `--artifacts-dir`.

Verified first on career, whose atago E2E is green on Linux and macOS with this
version.