### PR TITLE
chore(ci): bump atago to v0.17.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       - name: Download dependencies
         run: gleam deps download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: nao1215/setup-atago@v0
         with:
-          version: v0.16.0
+          version: v0.17.0
 
       - name: Download dependencies
         run: gleam deps download


### PR DESCRIPTION
Pins the E2E suites to [atago v0.17.0](https://github.com/nao1215/atago/releases/tag/v0.17.0).

That release adds a Scoop bucket for Windows installs and carries two failure-message fixes: an assertion whose observed value was empty now renders `(empty)` instead of omitting the `Actual:` section, and a run step whose output capture was cut short now names the exit code the process reached instead of reporting `failed to execute`.

No spec changes are needed — neither fix alters an assertion's verdict, only how a failure reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Atago toolchain to version 0.17.0 for continuous integration and release validation.
  * No changes to application functionality or release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->